### PR TITLE
Refine naming consistency for HttpRequestFactories and update RestOperations interface

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClientBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClientBuilder.java
@@ -28,7 +28,7 @@ import org.springframework.http.client.reactive.ClientHttpConnector;
 import org.springframework.http.client.reactive.HttpComponentsClientHttpConnector;
 import org.springframework.http.client.reactive.JdkClientHttpConnector;
 import org.springframework.http.client.reactive.JettyClientHttpConnector;
-import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.http.client.reactive.ReactorNettyClientHttpConnector;
 import org.springframework.http.client.reactive.ReactorNetty2ClientHttpConnector;
 import org.springframework.http.codec.ClientCodecConfigurer;
 import org.springframework.lang.Nullable;
@@ -314,7 +314,7 @@ class DefaultWebTestClientBuilder implements WebTestClient.Builder {
 
 	private static ClientHttpConnector initConnector() {
 		if (reactorNettyClientPresent) {
-			return new ReactorClientHttpConnector();
+			return new ReactorNettyClientHttpConnector();
 		}
 		else if (reactorNetty2ClientPresent) {
 			return new ReactorNetty2ClientHttpConnector();

--- a/spring-web/src/main/java/org/springframework/http/client/HttpComponentsClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/HttpComponentsClientHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,13 +43,13 @@ import org.springframework.util.StringUtils;
  * {@link ClientHttpRequest} implementation based on
  * Apache HttpComponents HttpClient.
  *
- * <p>Created via the {@link HttpComponentsClientHttpRequestFactory}.
+ * <p>Created via the {@link HttpComponentsClientRequestFactory}.
  *
  * @author Oleg Kalnichevski
  * @author Arjen Poutsma
  * @author Juergen Hoeller
  * @since 3.1
- * @see HttpComponentsClientHttpRequestFactory#createRequest(URI, HttpMethod)
+ * @see HttpComponentsClientRequestFactory#createRequest(URI, HttpMethod)
  */
 final class HttpComponentsClientHttpRequest extends AbstractStreamingClientHttpRequest {
 

--- a/spring-web/src/main/java/org/springframework/http/client/HttpComponentsClientRequestFactory.java
+++ b/spring-web/src/main/java/org/springframework/http/client/HttpComponentsClientRequestFactory.java
@@ -62,7 +62,7 @@ import org.springframework.util.Assert;
  * @author Juergen Hoeller
  * @since 3.1
  */
-public class HttpComponentsClientHttpRequestFactory implements ClientHttpRequestFactory, DisposableBean {
+public class HttpComponentsClientRequestFactory implements ClientHttpRequestFactory, DisposableBean {
 
 	private HttpClient httpClient;
 
@@ -78,7 +78,7 @@ public class HttpComponentsClientHttpRequestFactory implements ClientHttpRequest
 	 * Create a new instance of the {@code HttpComponentsClientHttpRequestFactory}
 	 * with a default {@link HttpClient} based on system properties.
 	 */
-	public HttpComponentsClientHttpRequestFactory() {
+	public HttpComponentsClientRequestFactory() {
 		this.httpClient = HttpClients.createSystem();
 	}
 
@@ -87,7 +87,7 @@ public class HttpComponentsClientHttpRequestFactory implements ClientHttpRequest
 	 * with the given {@link HttpClient} instance.
 	 * @param httpClient the HttpClient instance to use for this request factory
 	 */
-	public HttpComponentsClientHttpRequestFactory(HttpClient httpClient) {
+	public HttpComponentsClientRequestFactory(HttpClient httpClient) {
 		this.httpClient = httpClient;
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/client/ReactorClientHttpRequestFactory.java
+++ b/spring-web/src/main/java/org/springframework/http/client/ReactorClientHttpRequestFactory.java
@@ -43,9 +43,9 @@ import org.springframework.util.Assert;
  * @author Sebastien Deleuze
  * @since 6.1
  */
-public class ReactorNettyClientRequestFactory implements ClientHttpRequestFactory, SmartLifecycle {
+public class ReactorClientHttpRequestFactory implements ClientHttpRequestFactory, SmartLifecycle {
 
-	private static final Log logger = LogFactory.getLog(ReactorNettyClientRequestFactory.class);
+	private static final Log logger = LogFactory.getLog(ReactorClientHttpRequestFactory.class);
 
 	private static final Function<HttpClient, HttpClient> defaultInitializer = client -> client.compress(true);
 
@@ -73,7 +73,7 @@ public class ReactorNettyClientRequestFactory implements ClientHttpRequestFactor
 	 * Create a new instance of the {@code ReactorNettyClientRequestFactory}
 	 * with a default {@link HttpClient} that has compression enabled.
 	 */
-	public ReactorNettyClientRequestFactory() {
+	public ReactorClientHttpRequestFactory() {
 		this.httpClient = defaultInitializer.apply(HttpClient.create());
 		this.resourceFactory = null;
 		this.mapper = null;
@@ -84,7 +84,7 @@ public class ReactorNettyClientRequestFactory implements ClientHttpRequestFactor
 	 * based on the given {@link HttpClient}.
 	 * @param httpClient the client to base on
 	 */
-	public ReactorNettyClientRequestFactory(HttpClient httpClient) {
+	public ReactorClientHttpRequestFactory(HttpClient httpClient) {
 		Assert.notNull(httpClient, "HttpClient must not be null");
 		this.httpClient = httpClient;
 		this.resourceFactory = null;
@@ -108,7 +108,7 @@ public class ReactorNettyClientRequestFactory implements ClientHttpRequestFactor
 	 * @param resourceFactory the resource factory to obtain the resources from
 	 * @param mapper a mapper for further initialization of the created client
 	 */
-	public ReactorNettyClientRequestFactory(ReactorResourceFactory resourceFactory, Function<HttpClient, HttpClient> mapper) {
+	public ReactorClientHttpRequestFactory(ReactorResourceFactory resourceFactory, Function<HttpClient, HttpClient> mapper) {
 		this.resourceFactory = resourceFactory;
 		this.mapper = mapper;
 		if (resourceFactory.isRunning()) {

--- a/spring-web/src/main/java/org/springframework/http/client/SimpleClientHttpRequestFactory.java
+++ b/spring-web/src/main/java/org/springframework/http/client/SimpleClientHttpRequestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ import org.springframework.util.Assert;
  * @author Juergen Hoeller
  * @since 3.0
  * @see java.net.HttpURLConnection
- * @see HttpComponentsClientHttpRequestFactory
+ * @see HttpComponentsClientRequestFactory
  */
 public class SimpleClientHttpRequestFactory implements ClientHttpRequestFactory {
 

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpRequest.java
@@ -139,13 +139,13 @@ class ReactorClientHttpRequest extends AbstractClientHttpRequest implements Zero
 	/**
 	 * Saves the {@link #getAttributes() request attributes} to the
 	 * {@link reactor.netty.channel.ChannelOperations#channel() channel} as a single map
-	 * attribute under the key {@link ReactorClientHttpConnector#ATTRIBUTES_KEY}.
+	 * attribute under the key {@link ReactorNettyClientHttpConnector#ATTRIBUTES_KEY}.
 	 */
 	@Override
 	protected void applyAttributes() {
 		if (!getAttributes().isEmpty()) {
 			((ChannelOperations<?, ?>) this.request).channel()
-					.attr(ReactorClientHttpConnector.ATTRIBUTES_KEY).set(getAttributes());
+					.attr(ReactorNettyClientHttpConnector.ATTRIBUTES_KEY).set(getAttributes());
 		}
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -161,7 +161,7 @@ class ReactorClientHttpResponse implements ClientHttpResponse {
 	}
 
 	/**
-	 * Called by {@link ReactorClientHttpConnector} when a cancellation is detected
+	 * Called by {@link ReactorNettyClientHttpConnector} when a cancellation is detected
 	 * but the content has not been subscribed to. If the subscription never
 	 * materializes then the content will remain not drained. Or it could still
 	 * materialize if the cancellation happened very early, or the response

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorNetty2ClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorNetty2ClientHttpConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ import org.springframework.util.Assert;
 /**
  * Reactor Netty 2 (Netty 5) implementation of {@link ClientHttpConnector}.
  *
- * <p>This class is based on {@link ReactorClientHttpConnector}.
+ * <p>This class is based on {@link ReactorNettyClientHttpConnector}.
  *
  * @author Violeta Georgieva
  * @since 6.0

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorNettyClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorNettyClientHttpConnector.java
@@ -50,7 +50,7 @@ import org.springframework.util.Assert;
  * @since 5.0
  * @see reactor.netty.http.client.HttpClient
  */
-public class ReactorClientHttpConnector implements ClientHttpConnector, SmartLifecycle {
+public class ReactorNettyClientHttpConnector implements ClientHttpConnector, SmartLifecycle {
 
 	/**
 	 * Channel attribute key under which {@code WebClient} request attributes are stored as a Map.
@@ -59,7 +59,7 @@ public class ReactorClientHttpConnector implements ClientHttpConnector, SmartLif
 	public static final AttributeKey<Map<String, Object>> ATTRIBUTES_KEY =
 			AttributeKey.valueOf(ReactorClientHttpRequest.class.getName() + ".ATTRIBUTES");
 
-	private static final Log logger = LogFactory.getLog(ReactorClientHttpConnector.class);
+	private static final Log logger = LogFactory.getLog(ReactorNettyClientHttpConnector.class);
 
 	private static final Function<HttpClient, HttpClient> defaultInitializer = client -> client.compress(true);
 
@@ -82,7 +82,7 @@ public class ReactorClientHttpConnector implements ClientHttpConnector, SmartLif
 	 * Default constructor. Initializes {@link HttpClient} via:
 	 * <pre class="code">HttpClient.create().compress(true)</pre>
 	 */
-	public ReactorClientHttpConnector() {
+	public ReactorNettyClientHttpConnector() {
 		this.httpClient = defaultInitializer.apply(HttpClient.create());
 		this.resourceFactory = null;
 		this.mapper = null;
@@ -93,7 +93,7 @@ public class ReactorClientHttpConnector implements ClientHttpConnector, SmartLif
 	 * @param httpClient the client to use
 	 * @since 5.1
 	 */
-	public ReactorClientHttpConnector(HttpClient httpClient) {
+	public ReactorNettyClientHttpConnector(HttpClient httpClient) {
 		Assert.notNull(httpClient, "HttpClient is required");
 		this.httpClient = httpClient;
 		this.resourceFactory = null;
@@ -118,7 +118,7 @@ public class ReactorClientHttpConnector implements ClientHttpConnector, SmartLif
 	 * @param mapper a mapper for further initialization of the created client
 	 * @since 5.1
 	 */
-	public ReactorClientHttpConnector(ReactorResourceFactory resourceFactory, Function<HttpClient, HttpClient> mapper) {
+	public ReactorNettyClientHttpConnector(ReactorResourceFactory resourceFactory, Function<HttpClient, HttpClient> mapper) {
 		this.resourceFactory = resourceFactory;
 		this.mapper = mapper;
 		if (resourceFactory.isRunning()) {

--- a/spring-web/src/main/java/org/springframework/http/client/support/HttpAccessor.java
+++ b/spring-web/src/main/java/org/springframework/http/client/support/HttpAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpRequestInitializer;
+import org.springframework.http.client.HttpComponentsClientRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.util.Assert;
 
@@ -66,7 +67,7 @@ public abstract class HttpAccessor {
 	 * Configure the Apache HttpComponents or OkHttp request factory to enable PATCH.</b>
 	 * @see #createRequest(URI, HttpMethod)
 	 * @see SimpleClientHttpRequestFactory
-	 * @see org.springframework.http.client.HttpComponentsClientHttpRequestFactory
+	 * @see HttpComponentsClientRequestFactory
 	 * @see org.springframework.http.client.OkHttp3ClientHttpRequestFactory
 	 */
 	public void setRequestFactory(ClientHttpRequestFactory requestFactory) {

--- a/spring-web/src/main/java/org/springframework/web/client/DefaultRestClientBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/client/DefaultRestClientBuilder.java
@@ -32,7 +32,7 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpRequestInitializer;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientRequestFactory;
 import org.springframework.http.client.InterceptingClientHttpRequestFactory;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.http.client.JettyClientHttpRequestFactory;
@@ -443,7 +443,7 @@ final class DefaultRestClientBuilder implements RestClient.Builder {
 			return this.requestFactory;
 		}
 		else if (httpComponentsClientPresent) {
-			return new HttpComponentsClientHttpRequestFactory();
+			return new HttpComponentsClientRequestFactory();
 		}
 		else if (jettyClientPresent) {
 			return new JettyClientHttpRequestFactory();

--- a/spring-web/src/main/java/org/springframework/web/client/RestClient.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestClient.java
@@ -42,6 +42,7 @@ import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpRequestInitializer;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.HttpComponentsClientRequestFactory;
 import org.springframework.http.client.observation.ClientRequestObservationConvention;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.lang.Nullable;
@@ -385,7 +386,7 @@ public interface RestClient {
 		 * for plugging in and/or customizing options of the underlying HTTP
 		 * client library (e.g. SSL).
 		 * <p>If no request factory is specified, {@code RestClient} uses
-		 * {@linkplain org.springframework.http.client.HttpComponentsClientHttpRequestFactory Apache Http Client},
+		 * {@linkplain HttpComponentsClientRequestFactory Apache Http Client},
 		 * {@linkplain org.springframework.http.client.JettyClientHttpRequestFactory Jetty Http Client}
 		 * if available on the classpath, and defaults to the
 		 * {@linkplain org.springframework.http.client.JdkClientHttpRequestFactory JDK HttpClient}

--- a/spring-web/src/main/java/org/springframework/web/client/RestOperations.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestOperations.java
@@ -383,7 +383,7 @@ public interface RestOperations {
 	 * @since 4.3.5
 	 * @see HttpEntity
 	 * @see RestTemplate#setRequestFactory
-	 * @see org.springframework.http.client.HttpComponentsClientHttpRequestFactory
+	 * @see org.springframework.http.client.HttpComponentsClientRequestFactory
 	 */
 	@Nullable
 	<T> T patchForObject(String url, @Nullable Object request, Class<T> responseType, Object... uriVariables)
@@ -405,7 +405,7 @@ public interface RestOperations {
 	 * @since 4.3.5
 	 * @see HttpEntity
 	 * @see RestTemplate#setRequestFactory
-	 * @see org.springframework.http.client.HttpComponentsClientHttpRequestFactory
+	 * @see org.springframework.http.client.HttpComponentsClientRequestFactory
 	 */
 	@Nullable
 	<T> T patchForObject(String url, @Nullable Object request, Class<T> responseType,
@@ -425,7 +425,7 @@ public interface RestOperations {
 	 * @since 4.3.5
 	 * @see HttpEntity
 	 * @see RestTemplate#setRequestFactory
-	 * @see org.springframework.http.client.HttpComponentsClientHttpRequestFactory
+	 * @see org.springframework.http.client.HttpComponentsClientRequestFactory
 	 */
 	@Nullable
 	<T> T patchForObject(URI url, @Nullable Object request, Class<T> responseType)

--- a/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
@@ -44,6 +44,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.HttpComponentsClientRequestFactory;
 import org.springframework.http.client.observation.ClientHttpObservationDocumentation;
 import org.springframework.http.client.observation.ClientRequestObservationContext;
 import org.springframework.http.client.observation.ClientRequestObservationConvention;
@@ -241,7 +242,7 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 	 * Create a new instance of the {@link RestTemplate} based on the given {@link ClientHttpRequestFactory}.
 	 * @param requestFactory the HTTP request factory to use
 	 * @see org.springframework.http.client.SimpleClientHttpRequestFactory
-	 * @see org.springframework.http.client.HttpComponentsClientHttpRequestFactory
+	 * @see HttpComponentsClientRequestFactory
 	 */
 	public RestTemplate(ClientHttpRequestFactory requestFactory) {
 		this();

--- a/spring-web/src/test/java/org/springframework/http/client/BufferingClientHttpRequestFactoryTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/BufferingClientHttpRequestFactoryTests.java
@@ -32,7 +32,7 @@ class BufferingClientHttpRequestFactoryTests extends AbstractHttpRequestFactoryT
 
 	@Override
 	protected ClientHttpRequestFactory createRequestFactory() {
-		return new BufferingClientHttpRequestFactory(new HttpComponentsClientHttpRequestFactory());
+		return new BufferingClientHttpRequestFactory(new HttpComponentsClientRequestFactory());
 	}
 
 	@Test

--- a/spring-web/src/test/java/org/springframework/http/client/HttpComponentsClientRequestFactoryTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/HttpComponentsClientRequestFactoryTests.java
@@ -45,11 +45,11 @@ import static org.mockito.Mockito.withSettings;
  * @author Stephane Nicoll
  * @author Brian Clozel
  */
-class HttpComponentsClientHttpRequestFactoryTests extends AbstractHttpRequestFactoryTests {
+class HttpComponentsClientRequestFactoryTests extends AbstractHttpRequestFactoryTests {
 
 	@Override
 	protected ClientHttpRequestFactory createRequestFactory() {
-		return new HttpComponentsClientHttpRequestFactory();
+		return new HttpComponentsClientRequestFactory();
 	}
 
 	@Override
@@ -63,7 +63,7 @@ class HttpComponentsClientHttpRequestFactoryTests extends AbstractHttpRequestFac
 	@SuppressWarnings("deprecation")
 	void assertCustomConfig() throws Exception {
 		HttpClient httpClient = HttpClientBuilder.create().build();
-		HttpComponentsClientHttpRequestFactory hrf = new HttpComponentsClientHttpRequestFactory(httpClient);
+		HttpComponentsClientRequestFactory hrf = new HttpComponentsClientRequestFactory(httpClient);
 		hrf.setConnectTimeout(1234);
 		hrf.setConnectionRequestTimeout(4321);
 
@@ -88,7 +88,7 @@ class HttpComponentsClientHttpRequestFactoryTests extends AbstractHttpRequestFac
 		Configurable configurable = (Configurable) client;
 		given(configurable.getConfig()).willReturn(defaultConfig);
 
-		HttpComponentsClientHttpRequestFactory hrf = new HttpComponentsClientHttpRequestFactory(client);
+		HttpComponentsClientRequestFactory hrf = new HttpComponentsClientRequestFactory(client);
 		assertThat(retrieveRequestConfig(hrf)).as("Default client configuration is expected").isSameAs(defaultConfig);
 
 		hrf.setConnectionRequestTimeout(4567);
@@ -111,7 +111,7 @@ class HttpComponentsClientHttpRequestFactoryTests extends AbstractHttpRequestFac
 		Configurable configurable = (Configurable) client;
 		given(configurable.getConfig()).willReturn(defaultConfig);
 
-		HttpComponentsClientHttpRequestFactory hrf = new HttpComponentsClientHttpRequestFactory(client);
+		HttpComponentsClientRequestFactory hrf = new HttpComponentsClientRequestFactory(client);
 		hrf.setConnectTimeout(5000);
 
 		RequestConfig requestConfig = retrieveRequestConfig(hrf);
@@ -130,7 +130,7 @@ class HttpComponentsClientHttpRequestFactoryTests extends AbstractHttpRequestFac
 		Configurable configurable = (Configurable) client;
 		given(configurable.getConfig()).willReturn(defaultConfig);
 
-		HttpComponentsClientHttpRequestFactory hrf = new HttpComponentsClientHttpRequestFactory() {
+		HttpComponentsClientRequestFactory hrf = new HttpComponentsClientRequestFactory() {
 			@Override
 			public HttpClient getHttpClient() {
 				return client;
@@ -182,7 +182,7 @@ class HttpComponentsClientHttpRequestFactoryTests extends AbstractHttpRequestFac
 		return Stream.of(HttpMethod.GET, HttpMethod.OPTIONS, HttpMethod.TRACE);
 	}
 
-	private RequestConfig retrieveRequestConfig(HttpComponentsClientHttpRequestFactory factory) throws Exception {
+	private RequestConfig retrieveRequestConfig(HttpComponentsClientRequestFactory factory) throws Exception {
 		URI uri = URI.create(baseUrl + "/status/ok");
 		HttpComponentsClientHttpRequest request = (HttpComponentsClientHttpRequest)
 				factory.createRequest(uri, HttpMethod.GET);

--- a/spring-web/src/test/java/org/springframework/http/client/InterceptingStreamingHttpComponentsTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/InterceptingStreamingHttpComponentsTests.java
@@ -27,7 +27,7 @@ class InterceptingStreamingHttpComponentsTests extends AbstractHttpRequestFactor
 
 	@Override
 	protected ClientHttpRequestFactory createRequestFactory() {
-		HttpComponentsClientHttpRequestFactory requestFactory = new HttpComponentsClientHttpRequestFactory();
+		HttpComponentsClientRequestFactory requestFactory = new HttpComponentsClientRequestFactory();
 		return new InterceptingClientHttpRequestFactory(requestFactory, null);
 	}
 

--- a/spring-web/src/test/java/org/springframework/http/client/ReactorClientHttpRequestFactoryTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/ReactorClientHttpRequestFactoryTests.java
@@ -30,11 +30,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Sebastien Deleuze
  * @since 6.1
  */
-class ReactorNettyClientRequestFactoryTests extends AbstractHttpRequestFactoryTests {
+class ReactorClientHttpRequestFactoryTests extends AbstractHttpRequestFactoryTests {
 
 	@Override
 	protected ClientHttpRequestFactory createRequestFactory() {
-		return new ReactorNettyClientRequestFactory();
+		return new ReactorClientHttpRequestFactory();
 	}
 
 	@Override
@@ -46,7 +46,7 @@ class ReactorNettyClientRequestFactoryTests extends AbstractHttpRequestFactoryTe
 
 	@Test
 	void restartWithDefaultConstructor() {
-		ReactorNettyClientRequestFactory requestFactory = new ReactorNettyClientRequestFactory();
+		ReactorClientHttpRequestFactory requestFactory = new ReactorClientHttpRequestFactory();
 		assertThat(requestFactory.isRunning()).isTrue();
 		requestFactory.start();
 		assertThat(requestFactory.isRunning()).isTrue();
@@ -59,7 +59,7 @@ class ReactorNettyClientRequestFactoryTests extends AbstractHttpRequestFactoryTe
 	@Test
 	void restartWithHttpClient() {
 		HttpClient httpClient = HttpClient.create();
-		ReactorNettyClientRequestFactory requestFactory = new ReactorNettyClientRequestFactory(httpClient);
+		ReactorClientHttpRequestFactory requestFactory = new ReactorClientHttpRequestFactory(httpClient);
 		assertThat(requestFactory.isRunning()).isTrue();
 		requestFactory.start();
 		assertThat(requestFactory.isRunning()).isTrue();
@@ -74,7 +74,7 @@ class ReactorNettyClientRequestFactoryTests extends AbstractHttpRequestFactoryTe
 		ReactorResourceFactory resourceFactory = new ReactorResourceFactory();
 		resourceFactory.afterPropertiesSet();
 		Function<HttpClient, HttpClient> mapper = Function.identity();
-		ReactorNettyClientRequestFactory requestFactory = new ReactorNettyClientRequestFactory(resourceFactory, mapper);
+		ReactorClientHttpRequestFactory requestFactory = new ReactorClientHttpRequestFactory(resourceFactory, mapper);
 		assertThat(requestFactory.isRunning()).isTrue();
 		requestFactory.start();
 		assertThat(requestFactory.isRunning()).isTrue();
@@ -88,7 +88,7 @@ class ReactorNettyClientRequestFactoryTests extends AbstractHttpRequestFactoryTe
 	void lateStartWithExternalResourceFactory() {
 		ReactorResourceFactory resourceFactory = new ReactorResourceFactory();
 		Function<HttpClient, HttpClient> mapper = Function.identity();
-		ReactorNettyClientRequestFactory requestFactory = new ReactorNettyClientRequestFactory(resourceFactory, mapper);
+		ReactorClientHttpRequestFactory requestFactory = new ReactorClientHttpRequestFactory(resourceFactory, mapper);
 		assertThat(requestFactory.isRunning()).isFalse();
 		resourceFactory.start();
 		requestFactory.start();

--- a/spring-web/src/test/java/org/springframework/http/client/reactive/ClientHttpConnectorTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/reactive/ClientHttpConnectorTests.java
@@ -209,7 +209,7 @@ class ClientHttpConnectorTests {
 
 	static List<Named<ClientHttpConnector>> connectors() {
 		return Arrays.asList(
-				named("Reactor Netty", new ReactorClientHttpConnector()),
+				named("Reactor Netty", new ReactorNettyClientHttpConnector()),
 				named("Jetty", new JettyClientHttpConnector()),
 				named("HttpComponents", new HttpComponentsClientHttpConnector())
 		);

--- a/spring-web/src/test/java/org/springframework/http/client/reactive/ReactorNettyClientHttpConnectorTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/reactive/ReactorNettyClientHttpConnectorTests.java
@@ -33,11 +33,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Juergen Hoeller
  * @since 6.1
  */
-class ReactorClientHttpConnectorTests {
+class ReactorNettyClientHttpConnectorTests {
 
 	@Test
 	void restartWithDefaultConstructor() {
-		ReactorClientHttpConnector connector = new ReactorClientHttpConnector();
+		ReactorNettyClientHttpConnector connector = new ReactorNettyClientHttpConnector();
 		assertThat(connector.isRunning()).isTrue();
 		connector.start();
 		assertThat(connector.isRunning()).isTrue();
@@ -52,7 +52,7 @@ class ReactorClientHttpConnectorTests {
 	@Test
 	void restartWithHttpClient() {
 		HttpClient httpClient = HttpClient.create();
-		ReactorClientHttpConnector connector = new ReactorClientHttpConnector(httpClient);
+		ReactorNettyClientHttpConnector connector = new ReactorNettyClientHttpConnector(httpClient);
 		assertThat(connector.isRunning()).isTrue();
 		connector.start();
 		assertThat(connector.isRunning()).isTrue();
@@ -69,7 +69,7 @@ class ReactorClientHttpConnectorTests {
 		ReactorResourceFactory resourceFactory = new ReactorResourceFactory();
 		resourceFactory.afterPropertiesSet();
 		Function<HttpClient, HttpClient> mapper = Function.identity();
-		ReactorClientHttpConnector connector = new ReactorClientHttpConnector(resourceFactory, mapper);
+		ReactorNettyClientHttpConnector connector = new ReactorNettyClientHttpConnector(resourceFactory, mapper);
 		assertThat(connector.isRunning()).isTrue();
 		connector.start();
 		assertThat(connector.isRunning()).isTrue();
@@ -85,7 +85,7 @@ class ReactorClientHttpConnectorTests {
 	void lateStartWithExternalResourceFactory() {
 		ReactorResourceFactory resourceFactory = new ReactorResourceFactory();
 		Function<HttpClient, HttpClient> mapper = Function.identity();
-		ReactorClientHttpConnector connector = new ReactorClientHttpConnector(resourceFactory, mapper);
+		ReactorNettyClientHttpConnector connector = new ReactorNettyClientHttpConnector(resourceFactory, mapper);
 		assertThat(connector.isRunning()).isFalse();
 		resourceFactory.start();
 		connector.start();
@@ -102,7 +102,7 @@ class ReactorClientHttpConnectorTests {
 	void lazyStartWithExternalResourceFactory() throws Exception {
 		ReactorResourceFactory resourceFactory = new ReactorResourceFactory();
 		Function<HttpClient, HttpClient> mapper = Function.identity();
-		ReactorClientHttpConnector connector = new ReactorClientHttpConnector(resourceFactory, mapper);
+		ReactorNettyClientHttpConnector connector = new ReactorNettyClientHttpConnector(resourceFactory, mapper);
 		assertThat(connector.isRunning()).isFalse();
 		resourceFactory.start();
 		connector.connect(HttpMethod.GET, new URI(""), request -> Mono.empty());

--- a/spring-web/src/test/java/org/springframework/http/server/reactive/ServerHttpsRequestIntegrationTests.java
+++ b/spring-web/src/test/java/org/springframework/http/server/reactive/ServerHttpsRequestIntegrationTests.java
@@ -34,7 +34,7 @@ import reactor.core.publisher.Mono;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientRequestFactory;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.testfixture.http.server.reactive.bootstrap.HttpServer;
 import org.springframework.web.testfixture.http.server.reactive.bootstrap.ReactorHttpsServer;
@@ -75,8 +75,8 @@ class ServerHttpsRequestIntegrationTests {
 				.build();
 		CloseableHttpClient httpclient = HttpClients.custom().
 				setConnectionManager(connectionManager).build();
-		HttpComponentsClientHttpRequestFactory requestFactory =
-				new HttpComponentsClientHttpRequestFactory(httpclient);
+		HttpComponentsClientRequestFactory requestFactory =
+				new HttpComponentsClientRequestFactory(httpclient);
 		this.restTemplate = new RestTemplate(requestFactory);
 	}
 

--- a/spring-web/src/test/java/org/springframework/web/bind/support/WebRequestDataBinderIntegrationTests.java
+++ b/spring-web/src/test/java/org/springframework/web/bind/support/WebRequestDataBinderIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import org.junit.jupiter.api.TestInstance.Lifecycle;
 
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientRequestFactory;
 import org.springframework.util.FileSystemUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -58,7 +58,7 @@ class WebRequestDataBinderIntegrationTests {
 
 	private final PartListServlet partListServlet = new PartListServlet();
 
-	private final RestTemplate template = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+	private final RestTemplate template = new RestTemplate(new HttpComponentsClientRequestFactory());
 
 	private Server jettyServer;
 

--- a/spring-web/src/test/java/org/springframework/web/client/RestClientIntegrationTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/RestClientIntegrationTests.java
@@ -46,10 +46,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientRequestFactory;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.http.client.JettyClientHttpRequestFactory;
-import org.springframework.http.client.ReactorNettyClientRequestFactory;
+import org.springframework.http.client.ReactorClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
@@ -80,11 +80,11 @@ class RestClientIntegrationTests {
 	static Stream<Arguments> clientHttpRequestFactories() {
 		return Stream.of(
 			argumentSet("JDK HttpURLConnection", new SimpleClientHttpRequestFactory()),
-			argumentSet("HttpComponents", new HttpComponentsClientHttpRequestFactory()),
+			argumentSet("HttpComponents", new HttpComponentsClientRequestFactory()),
 			argumentSet("OkHttp", new org.springframework.http.client.OkHttp3ClientHttpRequestFactory()),
 			argumentSet("Jetty", new JettyClientHttpRequestFactory()),
 			argumentSet("JDK HttpClient", new JdkClientHttpRequestFactory()),
-			argumentSet("Reactor Netty", new ReactorNettyClientRequestFactory())
+			argumentSet("Reactor Netty", new ReactorClientHttpRequestFactory())
 		);
 	}
 

--- a/spring-web/src/test/java/org/springframework/web/client/RestTemplateIntegrationTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/RestTemplateIntegrationTests.java
@@ -47,10 +47,10 @@ import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpRequestFactory;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientRequestFactory;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.http.client.JettyClientHttpRequestFactory;
-import org.springframework.http.client.ReactorNettyClientRequestFactory;
+import org.springframework.http.client.ReactorClientHttpRequestFactory;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.converter.FormHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJacksonValue;
@@ -94,11 +94,11 @@ class RestTemplateIntegrationTests extends AbstractMockWebServerTests {
 	static Stream<Arguments> clientHttpRequestFactories() {
 		return Stream.of(
 			argumentSet("JDK HttpURLConnection", new SimpleClientHttpRequestFactory()),
-			argumentSet("HttpComponents", new HttpComponentsClientHttpRequestFactory()),
+			argumentSet("HttpComponents", new HttpComponentsClientRequestFactory()),
 			argumentSet("OkHttp", new org.springframework.http.client.OkHttp3ClientHttpRequestFactory()),
 			argumentSet("Jetty", new JettyClientHttpRequestFactory()),
 			argumentSet("JDK HttpClient", new JdkClientHttpRequestFactory()),
-			argumentSet("Reactor Netty", new ReactorNettyClientRequestFactory())
+			argumentSet("Reactor Netty", new ReactorClientHttpRequestFactory())
 		);
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClientBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClientBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ import org.springframework.http.client.reactive.ClientHttpConnector;
 import org.springframework.http.client.reactive.HttpComponentsClientHttpConnector;
 import org.springframework.http.client.reactive.JdkClientHttpConnector;
 import org.springframework.http.client.reactive.JettyClientHttpConnector;
-import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.http.client.reactive.ReactorNettyClientHttpConnector;
 import org.springframework.http.client.reactive.ReactorNetty2ClientHttpConnector;
 import org.springframework.http.codec.ClientCodecConfigurer;
 import org.springframework.lang.Nullable;
@@ -336,7 +336,7 @@ final class DefaultWebClientBuilder implements WebClient.Builder {
 
 	private ClientHttpConnector initConnector() {
 		if (reactorNettyClientPresent) {
-			return new ReactorClientHttpConnector();
+			return new ReactorNettyClientHttpConnector();
 		}
 		else if (reactorNetty2ClientPresent) {
 			return new ReactorNetty2ClientHttpConnector();

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.reactive.ClientHttpConnector;
 import org.springframework.http.client.reactive.ClientHttpRequest;
 import org.springframework.http.client.reactive.ClientHttpResponse;
+import org.springframework.http.client.reactive.ReactorNettyClientHttpConnector;
 import org.springframework.http.codec.ClientCodecConfigurer;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.BodyExtractor;
@@ -293,7 +294,7 @@ public interface WebClient {
 		 * plugging in and/or customizing options of the underlying HTTP client
 		 * library (e.g. SSL).
 		 * <p>By default this is set to
-		 * {@link org.springframework.http.client.reactive.ReactorClientHttpConnector
+		 * {@link ReactorNettyClientHttpConnector
 		 * ReactorClientHttpConnector}.
 		 * @param connector the connector to use
 		 */

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientDataBufferAllocatingTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientDataBufferAllocatingTests.java
@@ -39,7 +39,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ReactorResourceFactory;
-import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.http.client.reactive.ReactorNettyClientHttpConnector;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
@@ -81,16 +81,16 @@ class WebClientDataBufferAllocatingTests extends AbstractDataBufferAllocatingTes
 				.build();
 	}
 
-	private ReactorClientHttpConnector initConnector() {
+	private ReactorNettyClientHttpConnector initConnector() {
 		assertThat(super.bufferFactory).isNotNull();
 
 		if (super.bufferFactory instanceof NettyDataBufferFactory nettyDataBufferFactory) {
 			ByteBufAllocator allocator = nettyDataBufferFactory.getByteBufAllocator();
-			return new ReactorClientHttpConnector(this.factory,
+			return new ReactorNettyClientHttpConnector(this.factory,
 					client -> client.option(ChannelOption.ALLOCATOR, allocator));
 		}
 		else {
-			return new ReactorClientHttpConnector();
+			return new ReactorNettyClientHttpConnector();
 		}
 	}
 

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientIntegrationTests.java
@@ -76,7 +76,7 @@ import org.springframework.http.client.reactive.ClientHttpConnector;
 import org.springframework.http.client.reactive.HttpComponentsClientHttpConnector;
 import org.springframework.http.client.reactive.JdkClientHttpConnector;
 import org.springframework.http.client.reactive.JettyClientHttpConnector;
-import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.http.client.reactive.ReactorNettyClientHttpConnector;
 import org.springframework.http.client.reactive.ReactorNetty2ClientHttpConnector;
 import org.springframework.web.reactive.function.BodyExtractors;
 import org.springframework.web.reactive.function.client.WebClient.ResponseSpec;
@@ -106,7 +106,7 @@ class WebClientIntegrationTests {
 
 	static Stream<Arguments> arguments() {
 		return Stream.of(
-				argumentSet("Reactor Netty", new ReactorClientHttpConnector()),
+				argumentSet("Reactor Netty", new ReactorNettyClientHttpConnector()),
 				argumentSet("JDK", new JdkClientHttpConnector()),
 				argumentSet("Jetty", new JettyClientHttpConnector()),
 				argumentSet("HttpComponents", new HttpComponentsClientHttpConnector())
@@ -206,7 +206,7 @@ class WebClientIntegrationTests {
 		StepVerifier.create(result).expectComplete().verify();
 
 		if (nativeRequest.get() instanceof ChannelOperations<?,?> nativeReq) {
-			Attribute<Map<String, Object>> attributes = nativeReq.channel().attr(ReactorClientHttpConnector.ATTRIBUTES_KEY);
+			Attribute<Map<String, Object>> attributes = nativeReq.channel().attr(ReactorNettyClientHttpConnector.ATTRIBUTES_KEY);
 			assertThat(attributes.get()).isNotNull();
 			assertThat(attributes.get()).containsEntry("foo", "bar");
 		}
@@ -441,7 +441,7 @@ class WebClientIntegrationTests {
 		this.server = new MockWebServer();
 		WebClient webClient = WebClient
 				.builder()
-				.clientConnector(new ReactorClientHttpConnector(HttpClient.create(connectionProvider)))
+				.clientConnector(new ReactorNettyClientHttpConnector(HttpClient.create(connectionProvider)))
 				.baseUrl(this.server.url("/").toString())
 				.build();
 

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/CrossOriginAnnotationIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/CrossOriginAnnotationIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2021 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientRequestFactory;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -78,7 +78,7 @@ class CrossOriginAnnotationIntegrationTests extends AbstractRequestMappingIntegr
 	@Override
 	protected RestTemplate initRestTemplate() {
 		// JDK default HTTP client disallowed headers like Origin
-		return new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+		return new RestTemplate(new HttpComponentsClientRequestFactory());
 	}
 
 

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/GlobalCorsConfigIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/GlobalCorsConfigIntegrationTests.java
@@ -25,7 +25,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientRequestFactory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.HttpClientErrorException;
@@ -65,7 +65,7 @@ class GlobalCorsConfigIntegrationTests extends AbstractRequestMappingIntegration
 	@Override
 	protected RestTemplate initRestTemplate() {
 		// JDK default HTTP client disallowed headers like Origin
-		return new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+		return new RestTemplate(new HttpComponentsClientRequestFactory());
 	}
 
 

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/SseIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/SseIntegrationTests.java
@@ -40,7 +40,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.client.reactive.ClientHttpConnector;
 import org.springframework.http.client.reactive.HttpComponentsClientHttpConnector;
 import org.springframework.http.client.reactive.JettyClientHttpConnector;
-import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.http.client.reactive.ReactorNettyClientHttpConnector;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.http.server.reactive.HttpHandler;
 import org.springframework.lang.Nullable;
@@ -303,19 +303,19 @@ class SseIntegrationTests extends AbstractHttpHandlerIntegrationTests {
 
 	static Stream<Arguments> arguments() {
 		return Stream.of(
-				args(new JettyHttpServer(), new ReactorClientHttpConnector()),
+				args(new JettyHttpServer(), new ReactorNettyClientHttpConnector()),
 				args(new JettyHttpServer(), new JettyClientHttpConnector()),
 				args(new JettyHttpServer(), new HttpComponentsClientHttpConnector()),
-				args(new JettyCoreHttpServer(), new ReactorClientHttpConnector()),
+				args(new JettyCoreHttpServer(), new ReactorNettyClientHttpConnector()),
 				args(new JettyCoreHttpServer(), new JettyClientHttpConnector()),
 				args(new JettyCoreHttpServer(), new HttpComponentsClientHttpConnector()),
-				args(new ReactorHttpServer(), new ReactorClientHttpConnector()),
+				args(new ReactorHttpServer(), new ReactorNettyClientHttpConnector()),
 				args(new ReactorHttpServer(), new JettyClientHttpConnector()),
 				args(new ReactorHttpServer(), new HttpComponentsClientHttpConnector()),
-				args(new TomcatHttpServer(), new ReactorClientHttpConnector()),
+				args(new TomcatHttpServer(), new ReactorNettyClientHttpConnector()),
 				args(new TomcatHttpServer(), new JettyClientHttpConnector()),
 				args(new TomcatHttpServer(), new HttpComponentsClientHttpConnector()),
-				args(new UndertowHttpServer(), new ReactorClientHttpConnector()),
+				args(new UndertowHttpServer(), new ReactorNettyClientHttpConnector()),
 				args(new UndertowHttpServer(), new JettyClientHttpConnector()),
 				args(new UndertowHttpServer(), new HttpComponentsClientHttpConnector())
 		);

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestPartIntegrationTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestPartIntegrationTests.java
@@ -46,7 +46,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.client.HttpComponentsClientRequestFactory;
 import org.springframework.http.converter.ByteArrayHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.ResourceHttpMessageConverter;
@@ -138,7 +138,7 @@ class RequestPartIntegrationTests {
 		AllEncompassingFormHttpMessageConverter converter = new AllEncompassingFormHttpMessageConverter();
 		converter.setPartConverters(converters);
 
-		restTemplate = new RestTemplate(new HttpComponentsClientHttpRequestFactory());
+		restTemplate = new RestTemplate(new HttpComponentsClientRequestFactory());
 		restTemplate.setMessageConverters(Collections.singletonList(converter));
 	}
 


### PR DESCRIPTION
This PR addresses issue #33382 by refining the naming consistency within the Spring Framework.

Class Renaming
`ReactorNettyClientRequestFactory` -> `ReactorClientHttpRequestFactory`
`ReactorClientHttpConnector` -> `ReactorNettyClientHttpConnector`
`HttpComponentsClientHttpRequestFactory` -> `HttpComponentsClientRequestFactory`

`RestOperations` Interface Update
Updated the `RestOperations` interface to reflect the new class names, specifically changing references from `HttpComponentsClientHttpRequestFactory` to `HttpComponentsClientRequestFactory`.

This update affects 32 files.

Testing
All relevant tests were executed locally using `./gradlew test`, and all tests passed successfully. No regressions were introduced by the changes in this PR.

Issue: #33382