### PR TITLE
Fix link to chapter introduction

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/beans/context-introduction.adoc
+++ b/framework-docs/modules/ROOT/pages/core/beans/context-introduction.adoc
@@ -1,7 +1,7 @@
 [[context-introduction]]
 = Additional Capabilities of the `ApplicationContext`
 
-As discussed in the xref:web/webmvc-view/mvc-xslt.adoc#mvc-view-xslt-beandefs[chapter introduction], the `org.springframework.beans.factory`
+As discussed in the xref:core/beans/basics.adoc#mvc-view-xslt-beandefs[chapter introduction], the `org.springframework.beans.factory`
 package provides basic functionality for managing and manipulating beans, including in a
 programmatic way. The `org.springframework.context` package adds the
 {spring-framework-api}/context/ApplicationContext.html[`ApplicationContext`]

--- a/framework-docs/modules/ROOT/pages/core/beans/context-introduction.adoc
+++ b/framework-docs/modules/ROOT/pages/core/beans/context-introduction.adoc
@@ -1,7 +1,7 @@
 [[context-introduction]]
 = Additional Capabilities of the `ApplicationContext`
 
-As discussed in the xref:core/beans/basics.adoc#mvc-view-xslt-beandefs[chapter introduction], the `org.springframework.beans.factory`
+As discussed in the xref:core/beans/basics.adoc[chapter introduction], the `org.springframework.beans.factory`
 package provides basic functionality for managing and manipulating beans, including in a
 programmatic way. The `org.springframework.context` package adds the
 {spring-framework-api}/context/ApplicationContext.html[`ApplicationContext`]


### PR DESCRIPTION
## Context
In https://docs.spring.io/spring-framework/reference/core/beans/context-introduction.html, you can read as first statement

> As discussed in the [chapter introduction](https://docs.spring.io/spring-framework/reference/web/webmvc-view/mvc-xslt.html#mvc-view-xslt-beandefs), the org.springframework.beans.factory package provides basic functionality for managing and manipulating beans, including in a programmatic way

which redirects to https://docs.spring.io/spring-framework/reference/web/webmvc-view/mvc-xslt.html#mvc-view-xslt-beandefs, that
* it's not a chapter introduction section
* there is NO reference about "beans.factory" package

## Description
* Switch linked page to the more accurated one (IMHO), https://docs.spring.io/spring-framework/reference/core/beans/basics.html

## How to review?
* Check that the suggested refered page makes more sense than previous one