### PR TITLE
Expand acronyms `FQN` and `FQCN`

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/ConstructorResolver.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/ConstructorResolver.java
@@ -1242,7 +1242,7 @@ class ConstructorResolver {
 	 * Return a {@link Predicate} for a parameter type that checks if its target
 	 * value is a {@link Class} and the value type is a {@link String}. This is
 	 * a regular use cases where a {@link Class} is defined in the bean
-	 * definition as an FQN.
+	 * definition as fully-qualified class name.
 	 * @param valueType the type of the value
 	 * @return a predicate to indicate a fallback match for a String to Class
 	 * parameter

--- a/spring-beans/src/main/resources/org/springframework/beans/factory/xml/spring-beans.dtd
+++ b/spring-beans/src/main/resources/org/springframework/beans/factory/xml/spring-beans.dtd
@@ -451,8 +451,8 @@
 
 <!--
 	Specification of the type of an overloaded method argument as a String.
-	For convenience, this may be a substring of the FQN. E.g. all the
-	following would match "java.lang.String":
+	For convenience, this may be a substring of the fully-qualified class name.
+	E.g. all the following would match "java.lang.String":
 	- java.lang.String
 	- String
 	- Str

--- a/spring-beans/src/main/resources/org/springframework/beans/factory/xml/spring-beans.xsd
+++ b/spring-beans/src/main/resources/org/springframework/beans/factory/xml/spring-beans.xsd
@@ -765,8 +765,8 @@
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
 	Specification of the type of an overloaded method argument as a String.
-	For convenience, this may be a substring of the FQN. E.g. all the
-	following would match "java.lang.String":
+	For convenience, this may be a substring of the fully-qualified class name.
+	E.g. all the following would match "java.lang.String":
 	- java.lang.String
 	- String
 	- Str

--- a/spring-core/src/main/java/org/springframework/aot/hint/RuntimeHintsRegistrar.java
+++ b/spring-core/src/main/java/org/springframework/aot/hint/RuntimeHintsRegistrar.java
@@ -25,7 +25,7 @@ import org.springframework.lang.Nullable;
  *
  * <p>Implementations of this interface can be registered dynamically by using
  * {@link org.springframework.context.annotation.ImportRuntimeHints @ImportRuntimeHints}
- * or statically in {@code META-INF/spring/aot.factories} by using the FQN of this
+ * or statically in {@code META-INF/spring/aot.factories} by using the fully-qualified class name of this
  * interface as the key. A standard no-arg constructor is required for implementations.
  *
  * @author Brian Clozel

--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/MethodMapTransactionAttributeSource.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/MethodMapTransactionAttributeSource.java
@@ -73,8 +73,8 @@ public class MethodMapTransactionAttributeSource
 
 
 	/**
-	 * Set a name/attribute map, consisting of "FQCN.method" method names
-	 * (e.g. "com.mycompany.mycode.MyClass.myMethod") and
+	 * Set a name/attribute map, consisting of "{@code <fully-qualified class name>.<method-name>}"
+	 * method names (e.g. "com.mycompany.mycode.MyClass.myMethod") and
 	 * {@link TransactionAttribute} instances (or Strings to be converted
 	 * to {@code TransactionAttribute} instances).
 	 * <p>Intended for configuration via setter injection, typically within
@@ -134,7 +134,7 @@ public class MethodMapTransactionAttributeSource
 		Assert.notNull(name, "Name must not be null");
 		int lastDotIndex = name.lastIndexOf('.');
 		if (lastDotIndex == -1) {
-			throw new IllegalArgumentException("'" + name + "' is not a valid method name: format is FQN.methodName");
+			throw new IllegalArgumentException("'" + name + "' is not a valid method name: format is <fully-qualified class name>.<method-name>");
 		}
 		String className = name.substring(0, lastDotIndex);
 		String methodName = name.substring(lastDotIndex + 1);

--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/TransactionAttributeSourceEditor.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/TransactionAttributeSourceEditor.java
@@ -29,7 +29,7 @@ import org.springframework.util.StringUtils;
  * {@link TransactionAttributeEditor} in this package.
  *
  * <p>Strings are in property syntax, with the form:<br>
- * {@code FQCN.methodName=<transaction attribute string>}
+ * {@code <fully-qualified class name>.<method-name>=<transaction attribute string>}
  *
  * <p>For example:<br>
  * {@code com.mycompany.mycode.MyClass.myMethod=PROPAGATION_MANDATORY,ISOLATION_DEFAULT}

--- a/spring-tx/src/test/java/org/springframework/transaction/interceptor/RuleBasedTransactionAttributeTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/interceptor/RuleBasedTransactionAttributeTests.java
@@ -108,7 +108,7 @@ class RuleBasedTransactionAttributeTests {
 	void ruleForCommitOnSubclassOfChecked() {
 		List<RollbackRuleAttribute> list = new ArrayList<>();
 		// Note that it's important to ensure that we have this as
-		// a FQN: otherwise it will match everything!
+		// fully-qualified class name: otherwise it will match everything!
 		list.add(new RollbackRuleAttribute("java.lang.Exception"));
 		list.add(new NoRollbackRuleAttribute("IOException"));
 		RuleBasedTransactionAttribute rta = new RuleBasedTransactionAttribute(TransactionDefinition.PROPAGATION_REQUIRED, list);

--- a/spring-tx/src/test/java/org/springframework/transaction/interceptor/TransactionAttributeSourceEditorTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/interceptor/TransactionAttributeSourceEditorTests.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 /**
  * Tests for {@link TransactionAttributeSourceEditor}.
  *
- * <p>Format is: {@code FQN.Method=tx attribute representation}
+ * <p>Format is: {@code <fully-qualified class name>.<method-name>=tx attribute representation}
  *
  * @author Rod Johnson
  * @author Sam Brannen

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/SimpleMappingExceptionResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/SimpleMappingExceptionResolver.java
@@ -77,7 +77,7 @@ public class SimpleMappingExceptionResolver extends AbstractHandlerExceptionReso
 	 * For example, "Exception" will match nearly anything, and will probably hide other rules.
 	 * "java.lang.Exception" would be correct if "Exception" was meant to define a rule for all
 	 * checked exceptions. With more unusual exception names such as "BaseBusinessException"
-	 * there's no need to use a FQN.
+	 * there's no need to use fully-qualified class name.
 	 * @param mappings exception patterns (can also be fully qualified class names) as keys,
 	 * and error view names as values
 	 */


### PR DESCRIPTION
We should insist on using either one to keep consistency, `FQCN` is more common in the Java ecosystem.