### PR TITLE
Add Javadoc since for ReflectionHints.registerForInterfaces()

### DIFF
--- a/spring-core/src/main/java/org/springframework/aot/hint/ReflectionHints.java
+++ b/spring-core/src/main/java/org/springframework/aot/hint/ReflectionHints.java
@@ -182,6 +182,7 @@ public class ReflectionHints {
 	 * @param type the type to consider
 	 * @param typeHint a builder to further customize hints for each type
 	 * @return {@code this}, to facilitate method chaining
+	 * @since 6.2
 	 */
 	public ReflectionHints registerForInterfaces(Class<?> type, Consumer<TypeHint.Builder> typeHint) {
 		Class<?> currentClass = type;


### PR DESCRIPTION
This PR adds a Javadoc `@since` tag for the `ReflectionHints.registerForInterfaces()`.

See gh-32824