### PR TITLE
Update Content-Length when body changed by Interceptor

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/InterceptingClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/InterceptingClientHttpRequest.java
@@ -93,7 +93,10 @@ class InterceptingClientHttpRequest extends AbstractBufferingClientHttpRequest {
 				 * After intercepted by the interceptors, the length of the body may change.
 				 * Set the latest body.length to "Content-Length"
 				 */
-				request.getHeaders().setContentLength(body.length);
+				long contentLength = request.getHeaders().getContentLength();
+				if (contentLength >-1 & contentLength != body.length) {
+					request.getHeaders().setContentLength(body.length);
+				}
 
 				HttpMethod method = request.getMethod();
 				ClientHttpRequest delegate = requestFactory.createRequest(request.getURI(), method);

--- a/spring-web/src/main/java/org/springframework/http/client/InterceptingClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/InterceptingClientHttpRequest.java
@@ -88,6 +88,13 @@ class InterceptingClientHttpRequest extends AbstractBufferingClientHttpRequest {
 				return nextInterceptor.intercept(request, body, this);
 			}
 			else {
+
+				/*
+				 * After intercepted by the interceptors, the length of the body may change.
+				 * Set the latest body.length to "Content-Length"
+				 */
+				request.getHeaders().setContentLength(body.length);
+
 				HttpMethod method = request.getMethod();
 				ClientHttpRequest delegate = requestFactory.createRequest(request.getURI(), method);
 				request.getHeaders().forEach((key, value) -> delegate.getHeaders().addAll(key, value));

--- a/spring-web/src/main/java/org/springframework/http/client/InterceptingClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/InterceptingClientHttpRequest.java
@@ -94,7 +94,7 @@ class InterceptingClientHttpRequest extends AbstractBufferingClientHttpRequest {
 				 * Set the latest body.length to "Content-Length"
 				 */
 				long contentLength = request.getHeaders().getContentLength();
-				if (contentLength >-1 & contentLength != body.length) {
+				if (contentLength > -1 && contentLength != body.length) {
 					request.getHeaders().setContentLength(body.length);
 				}
 

--- a/spring-web/src/test/java/org/springframework/http/client/InterceptingClientHttpRequestFactoryTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/InterceptingClientHttpRequestFactoryTests.java
@@ -204,6 +204,9 @@ class InterceptingClientHttpRequestFactoryTests {
 		ClientHttpRequest request = requestFactory.createRequest(URI.create("https://example.com"), HttpMethod.GET);
 		request.execute();
 		assertThat(Arrays.equals(changedBody, requestMock.getBodyAsBytes())).isTrue();
+
+		// When the request body is changed, the "Content-Length" in the request header also needs to be changed.
+		assertThat(requestMock.getHeaders().getContentLength()).isEqualTo(changedBody.length);
 	}
 
 


### PR DESCRIPTION
Hi maintainers, while working with the framework, I discovered a bug that I believe warrants attention.

In the `org.springframework.http.client.InterceptingClientHttpRequest` , the request body may be changed by `interceptors`, but `Content-Length` in the request headers didn't. This may cause the server receive the incorrect request body. 
I created a simple demo to show this bug . [DEMO](https://github.com/imzhoukunqiang/spring-http-request-bug-demo)

The fix for this is to reset the `Content-Length` before sending the request at `org.springframework.http.client.InterceptingClientHttpRequest.InterceptingRequestExecution#execute`