### PR TITLE
Add Javadoc `@since` for `CodeWarnings.detectDeprecation(ResolvableType)`

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/aot/CodeWarnings.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/aot/CodeWarnings.java
@@ -82,6 +82,7 @@ public class CodeWarnings {
 	 * specified {@link ResolvableType}.
 	 * @param resolvableType a type signature
 	 * @return {@code this} instance
+	 * @since 6.1.8
 	 */
 	public CodeWarnings detectDeprecation(ResolvableType resolvableType) {
 		if (ResolvableType.NONE.equals(resolvableType)) {


### PR DESCRIPTION
This PR adds a Javadoc `@since` tag for the `CodeWarnings.detectDeprecation(ResolvableType)`.

See gh-32850