### PR TITLE
Remove a unnecessary else in DefaultSingletonBeanRegistry

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultSingletonBeanRegistry.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultSingletonBeanRegistry.java
@@ -264,15 +264,13 @@ public class DefaultSingletonBeanRegistry extends SimpleAliasRegistry implements
 										"\" holds singleton lock for other beans " + this.singletonsCurrentlyInCreation);
 							}
 						}
-						else {
-							// Singleton lock currently held by some other registration method -> wait.
-							this.singletonLock.lock();
-							locked = true;
-							// Singleton object might have possibly appeared in the meantime.
-							singletonObject = this.singletonObjects.get(beanName);
-							if (singletonObject != null) {
-								return singletonObject;
-							}
+						// Singleton lock currently held by some other registration method -> wait.
+						this.singletonLock.lock();
+						locked = true;
+						// Singleton object might have possibly appeared in the meantime.
+						singletonObject = this.singletonObjects.get(beanName);
+						if (singletonObject != null) {
+							return singletonObject;
 						}
 					}
 				}


### PR DESCRIPTION
The method `getSingleton(String, ObjectFactory<?>)` may throw a `BeanCurrentlyInCreationException` in multiple threads.

If Thread-A acquires the `singletonLock`, but before it assigns itself to `singletonCreationThread`,
Thread-B gets a null value at `singletonCreationThread`, then Thread-A and Thread-B will both invoke `beforeSingletonCreation`.

In this commit, I remove the else,
so the thread which does not acquire `singletonLock` will be blocked at the code `this.singletonLock.lock()`.

Closes gh-33463