### PR TITLE
Avoid empty array allocations in AnnotationTypeMapping

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationTypeMapping.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationTypeMapping.java
@@ -69,6 +69,8 @@ final class AnnotationTypeMapping {
 
 	private static final MirrorSet[] EMPTY_MIRROR_SETS = new MirrorSet[0];
 
+	private static final int[] EMPTY_INT_ARRAY = new int[0];
+
 
 	@Nullable
 	private final AnnotationTypeMapping source;
@@ -606,6 +608,9 @@ final class AnnotationTypeMapping {
 
 
 	private static int[] filledIntArray(int size) {
+		if (size == 0) {
+			return EMPTY_INT_ARRAY;
+		}
 		int[] array = new int[size];
 		Arrays.fill(array, -1);
 		return array;
@@ -684,7 +689,7 @@ final class AnnotationTypeMapping {
 		private final MirrorSet[] assigned;
 
 		MirrorSets() {
-			this.assigned = new MirrorSet[attributes.size()];
+			this.assigned = attributes.size() > 0 ? new MirrorSet[attributes.size()] : EMPTY_MIRROR_SETS;
 			this.mirrorSets = EMPTY_MIRROR_SETS;
 		}
 
@@ -728,6 +733,9 @@ final class AnnotationTypeMapping {
 		}
 
 		int[] resolve(@Nullable Object source, @Nullable Object annotation, ValueExtractor valueExtractor) {
+			if (attributes.size() == 0) {
+				return EMPTY_INT_ARRAY;
+			}
 			int[] result = new int[attributes.size()];
 			for (int i = 0; i < result.length; i++) {
 				result[i] = i;


### PR DESCRIPTION
Avoid empty array allocations in a few places in AnnotationTypeMapping.

In a heap dump for a production app, there were a couple hundred empty int arrays referenced from AnnotationTypeMapping instances (~3kb of waste); there were also about ~60 empty MirrorSet arrays (~1kb of waste).