### PR TITLE
Ensure that SseEmitter outputs UTF-8 encoded text

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/SseEmitter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/SseEmitter.java
@@ -46,6 +46,8 @@ public class SseEmitter extends ResponseBodyEmitter {
 
 	private static final MediaType TEXT_PLAIN = new MediaType("text", "plain", StandardCharsets.UTF_8);
 
+	private static final MediaType TEXT_EVENT_STREAM = new MediaType("text", "event-stream", StandardCharsets.UTF_8);
+
 	/**
 	 * Guards access to write operations on the response.
 	 */
@@ -76,7 +78,7 @@ public class SseEmitter extends ResponseBodyEmitter {
 
 		HttpHeaders headers = outputMessage.getHeaders();
 		if (headers.getContentType() == null) {
-			headers.setContentType(MediaType.TEXT_EVENT_STREAM);
+			headers.setContentType(TEXT_EVENT_STREAM);
 		}
 	}
 


### PR DESCRIPTION
The character encoding is not specified in the `extendResponse` method of `SseEmitter`, so the character encoding actually received by the browser is `ISO_8859_1`. 

This PR modifies the response header in the `extendResponse` method to encode it in `UTF-8`.

Should we add a constructor that accepts other character encodings?