### PR TITLE
Reference the spring-framework-petclinic repository wich uses AspectJ

### DIFF
--- a/framework-docs/antora.yml
+++ b/framework-docs/antora.yml
@@ -74,6 +74,7 @@ asciidoc:
     kotlin-issues: 'https://youtrack.jetbrains.com/issue'
     micrometer-docs: 'https://docs.micrometer.io/micrometer/reference'
     micrometer-context-propagation-docs: 'https://docs.micrometer.io/context-propagation/reference'
+    petclinic-github-org: 'https://github.com/spring-petclinic'
     reactive-streams-site: 'https://www.reactive-streams.org'
     reactive-streams-spec: 'https://github.com/reactive-streams/reactive-streams-jvm/blob/master/README.md#specification'
     reactor-github-org: 'https://github.com/reactor'

--- a/framework-docs/modules/ROOT/pages/core/aop/using-aspectj.adoc
+++ b/framework-docs/modules/ROOT/pages/core/aop/using-aspectj.adoc
@@ -389,7 +389,7 @@ who typically are in charge of the deployment configuration, such as the launch 
 Now that the sales pitch is over, let us first walk through a quick example of AspectJ
 LTW that uses Spring, followed by detailed specifics about elements introduced in the
 example. For a complete example, see the
-{spring-github-org}/spring-petclinic[Petclinic sample application].
+{petclinic-github-org}/spring-framework-petclinic[Petclinic sample application based on Spring Framework].
 
 
 [[aop-aj-ltw-first-example]]


### PR DESCRIPTION
The canonical version of Spring Petclinic based on Spring Boot has removed the AspectJ support.
The original fork version is still based on Spring Framework. It shows the use of `AspectJ` via the [CallMonitoringAspect](https://github.com/spring-petclinic/spring-framework-petclinic/blob/0780a0f0d435f0904a453ccd817451800edf1708/src/main/java/org/springframework/samples/petclinic/util/CallMonitoringAspect.java) class and the `<aop:aspectj-autoproxy>` (main branch) and the `@EnableAspectJAutoProxy`  (javaconfig branch).
I let you check: https://github.com/search?q=repo%3Aspring-petclinic%2Fspring-framework-petclinic%20aspectj&type=code 

In this Pull Request, I propose to reference the spring framework fork to keep in the documentation an example of AspectJ implementation without Spring Boot.

