### PR TITLE
Replace deprecated references in WebSocketMessageBrokerStats.toString()

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/WebSocketMessageBrokerStats.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/WebSocketMessageBrokerStats.java
@@ -281,11 +281,10 @@ public class WebSocketMessageBrokerStats implements SmartInitializingSingleton {
 	}
 
 	@Override
-	@SuppressWarnings("removal")
 	public String toString() {
-		return "WebSocketSession[" + getWebSocketSessionStatsInfo() + "]" +
-				", stompSubProtocol[" + getStompSubProtocolStatsInfo() + "]" +
-				", stompBrokerRelay[" + getStompBrokerRelayStatsInfo() + "]" +
+		return "WebSocketSession[" + getWebSocketSessionStats() + "]" +
+				", stompSubProtocol[" + getStompSubProtocolStats() + "]" +
+				", stompBrokerRelay[" + getStompBrokerRelayStats() + "]" +
 				", inboundChannel[" + getClientInboundExecutorStatsInfo() + "]" +
 				", outboundChannel[" + getClientOutboundExecutorStatsInfo() + "]" +
 				", sockJsScheduler[" + getSockJsTaskSchedulerStatsInfo() + "]";


### PR DESCRIPTION
This PR replaces deprecated references in the `WebSocketMessageBrokerStats.toString()`.

- See gh-31604