### PR TITLE
Use encoded resource path  instead of input path validation in spring-webflux

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/PathResourceLookupFunction.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/PathResourceLookupFunction.java
@@ -212,7 +212,7 @@ class PathResourceLookupFunction implements Function<ServerRequest, Mono<Resourc
 			return true;
 		}
 		locationPath = (locationPath.endsWith("/") || locationPath.isEmpty() ? locationPath : locationPath + "/");
-		return (resourcePath.startsWith(locationPath) && !isInvalidEncodedInputPath(resourcePath));
+		return (resourcePath.startsWith(locationPath) && !isInvalidEncodedResourcePath(resourcePath));
 	}
 
 	private boolean isInvalidEncodedResourcePath(String resourcePath) {


### PR DESCRIPTION
This pull request adds minor fix, to the validation introduced here: https://github.com/spring-projects/spring-framework/commit/d86bf8b2056429edf5494456cffcb2b243331c49 when resolving issue https://github.com/spring-projects/spring-framework/issues/33434
It seems that in the initial fix for spring-webmvc was created correctly, but for spring-webflux validation method was used incorrectly