### PR TITLE
Fix Javadoc `@since` tags in `JettyCoreRequestUpgradeStrategy`

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/socket/server/upgrade/JettyCoreRequestUpgradeStrategy.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/socket/server/upgrade/JettyCoreRequestUpgradeStrategy.java
@@ -49,7 +49,7 @@ import org.springframework.web.server.ServerWebExchange;
  *
  * @author Rossen Stoyanchev
  * @author Greg Wilkins
- * @since 5.3.4
+ * @since 6.2
  */
 public class JettyCoreRequestUpgradeStrategy implements RequestUpgradeStrategy {
 
@@ -62,7 +62,6 @@ public class JettyCoreRequestUpgradeStrategy implements RequestUpgradeStrategy {
 	/**
 	 * Add a callback to configure WebSocket server parameters on
 	 * {@link JettyWebSocketServerContainer}.
-	 * @since 6.1
 	 */
 	public void addWebSocketConfigurer(Consumer<Configurable> webSocketConfigurer) {
 		this.webSocketConfigurer = (this.webSocketConfigurer != null ?


### PR DESCRIPTION
This PR fixes Javadoc `@since` tags in the `JettyCoreRequestUpgradeStrategy`.

See gh-32097