### PR TITLE
Store non-empty bean names in `ConcurrentMapCacheFactoryBean`

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/concurrent/ConcurrentMapCacheFactoryBean.java
+++ b/spring-context/src/main/java/org/springframework/cache/concurrent/ConcurrentMapCacheFactoryBean.java
@@ -79,7 +79,7 @@ public class ConcurrentMapCacheFactoryBean
 
 	@Override
 	public void setBeanName(String beanName) {
-		if (!StringUtils.hasLength(this.name)) {
+		if (!StringUtils.hasText(this.name)) {
 			setName(beanName);
 		}
 	}


### PR DESCRIPTION
Typically, there are no bean names composed solely of whitespace, so the parameter for this method should be a meaningful value. To ensure the accuracy of that value, it seems more appropriate to use hasText rather than hasLength.