### PR TITLE
Add heartbeat functionality to SseEmitter

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/SseEmitter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/SseEmitter.java
@@ -67,6 +67,10 @@ public class SseEmitter extends ResponseBodyEmitter {
 	@Nullable
 	private ScheduledFuture<?> heartbeatFuture;
 
+	/**
+	 * The scheduler used to execute the heartbeat task at fixed intervals.
+	 * Used to schedule and manage the periodic heartbeat messages.
+	 */
 	@Nullable
 	private ScheduledExecutorService scheduler;
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/SseEmitterTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/SseEmitterTests.java
@@ -137,6 +137,45 @@ class SseEmitterTests {
 		this.handler.assertWriteCount(1);
 	}
 
+	@Test
+	void heartbeatIsSent() throws Exception {
+		this.emitter = new SseEmitter(0L, 100L);
+		this.emitter.initialize(this.handler);
+		Thread.sleep(250);
+		int heartbeatCount = 0;
+		for (int i = 0; i < this.handler.objects.size(); i++) {
+			Object data = this.handler.objects.get(i);
+			if (data.equals(":heartbeat\n\n")) {
+				heartbeatCount++;
+			}
+		}
+		assertThat(heartbeatCount).isGreaterThanOrEqualTo(2);
+	}
+
+	@Test
+	void heartbeatStopsAfterCompletion() throws Exception {
+		this.emitter = new SseEmitter(0L, 100L);
+		this.emitter.initialize(this.handler);
+
+		Thread.sleep(150);
+		this.emitter.complete();
+
+		int heartbeatCountBeforeCompletion = 0;
+		for (Object data : this.handler.objects) {
+			if (data.equals(":heartbeat\n\n")) {
+				heartbeatCountBeforeCompletion++;
+			}
+		}
+		Thread.sleep(150);
+		int totalHeartbeatCount = 0;
+		for (Object data : this.handler.objects) {
+			if (data.equals(":heartbeat\n\n")) {
+				totalHeartbeatCount++;
+			}
+		}
+		assertThat(totalHeartbeatCount).isEqualTo(heartbeatCountBeforeCompletion);
+	}
+
 
 	private static class TestHandler implements ResponseBodyEmitter.Handler {
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/SseEmitterTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/SseEmitterTests.java
@@ -142,13 +142,11 @@ class SseEmitterTests {
 		this.emitter = new SseEmitter(0L, 100L);
 		this.emitter.initialize(this.handler);
 		Thread.sleep(250);
-		int heartbeatCount = 0;
-		for (int i = 0; i < this.handler.objects.size(); i++) {
-			Object data = this.handler.objects.get(i);
-			if (data.equals(":heartbeat\n\n")) {
-				heartbeatCount++;
-			}
-		}
+
+		long heartbeatCount = this.handler.objects.stream()
+				.filter(data -> data.equals(":heartbeat\n\n"))
+				.count();
+
 		assertThat(heartbeatCount).isGreaterThanOrEqualTo(2);
 	}
 
@@ -156,23 +154,18 @@ class SseEmitterTests {
 	void heartbeatStopsAfterCompletion() throws Exception {
 		this.emitter = new SseEmitter(0L, 100L);
 		this.emitter.initialize(this.handler);
-
 		Thread.sleep(150);
 		this.emitter.complete();
 
-		int heartbeatCountBeforeCompletion = 0;
-		for (Object data : this.handler.objects) {
-			if (data.equals(":heartbeat\n\n")) {
-				heartbeatCountBeforeCompletion++;
-			}
-		}
+		long heartbeatCountBeforeCompletion = this.handler.objects.stream()
+				.filter(data -> data.equals(":heartbeat\n\n"))
+				.count();
+
 		Thread.sleep(150);
-		int totalHeartbeatCount = 0;
-		for (Object data : this.handler.objects) {
-			if (data.equals(":heartbeat\n\n")) {
-				totalHeartbeatCount++;
-			}
-		}
+		long totalHeartbeatCount = this.handler.objects.stream()
+				.filter(data -> data.equals(":heartbeat\n\n"))
+				.count();
+
 		assertThat(totalHeartbeatCount).isEqualTo(heartbeatCountBeforeCompletion);
 	}
 


### PR DESCRIPTION
This PR addresses issue #33355 by adding heartbeat (ping) functionality to the SseEmitter class.

Heartbeat Functionality
Added a new constructor to SseEmitter that accepts a heartbeatInterval parameter:

Heartbeat messages are sent as SSE comments (:heartbeat) at the specified interval.

Heartbeat messages automatically stop when the emitter is completed, times out, or encounters an error.

Testing
Added test cases to verify that heartbeat messages are sent at the correct intervals.

All tests have passed successfully.

Issue: #33355