### PR TITLE
Add Hibernate NonUniqueException ResultSize Processing

### DIFF
--- a/spring-orm/src/main/java/org/springframework/orm/jpa/vendor/HibernateJpaDialect.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/vendor/HibernateJpaDialect.java
@@ -301,8 +301,8 @@ public class HibernateJpaDialect extends DefaultJpaDialect {
 		if (ex instanceof QueryException) {
 			return new InvalidDataAccessResourceUsageException(ex.getMessage(), ex);
 		}
-		if (ex instanceof NonUniqueResultException hibEx) {
-			return new IncorrectResultSizeDataAccessException(ex.getMessage(), 1, getActualSize(hibEx));
+		if (ex instanceof NonUniqueResultException nonUniqueEx) {
+			return new IncorrectResultSizeDataAccessException(ex.getMessage(), 1, getActualSize(nonUniqueEx));
 		}
 		if (ex instanceof NonUniqueObjectException) {
 			return new DuplicateKeyException(ex.getMessage(), ex);


### PR DESCRIPTION
```java
    private void validateAlreadyIssued(Long memberId, Long couponId) {
        try {
            // return multiple result when transaction confilcted
            memberCouponRepository.findByMemberIdAndCouponId(memberId, couponId);
        } catch (IncorrectResultSizeDataAccessException e) {
            log.info("expected size = {}, actualSize = {}", e.getExpectedSize(), e.getActualSize());
            log.info("mesage = {}", e.getMessage());

            throw new IllegalStateException("transaction conflict");
        }
    }
```

```
2024-09-28T14:18:12.153+09:00  INFO 6651 --- [ool-2-thread-28] coupon.application.MemberCouponService   : expected size = 1, actualSize = -1
2024-09-28T14:18:12.153+09:00  INFO 6651 --- [ool-2-thread-28] coupon.application.MemberCouponService   : mesage = Query did not return a unique result: 8 results were returned
```

when I checking the logs, actualSize is -1. It seems strange for me. because the message generated by hibernate (`hibernate.NonUniqueResultException`) contains the actual result size.

Since `hibernate.NonUniqueResultException` does not provide the result count, I changed `HibernateJpaDialect`
that actualSize extracted from message generated by hibernate.

If there's anything I've overlooked, I'd appreciate your feedback. 🙇🏻‍♂️