### PR TITLE
Upgrade to Awaitility 4.2.2

### DIFF
--- a/framework-platform/framework-platform.gradle
+++ b/framework-platform/framework-platform.gradle
@@ -110,7 +110,7 @@ dependencies {
 		api("org.aspectj:aspectjrt:1.9.22.1")
 		api("org.aspectj:aspectjtools:1.9.22.1")
 		api("org.aspectj:aspectjweaver:1.9.22.1")
-		api("org.awaitility:awaitility:4.2.0")
+		api("org.awaitility:awaitility:4.2.2")
 		api("org.bouncycastle:bcpkix-jdk18on:1.72")
 		api("org.codehaus.jettison:jettison:1.5.4")
 		api("org.crac:crac:1.4.0")


### PR DESCRIPTION
https://github.com/awaitility/awaitility/issues/275 has been fixed in [4.2.2](https://github.com/awaitility/awaitility/blob/master/changelog.txt#L1-L3), and [the JDK 23 CI build is also against GA](https://github.com/spring-projects/spring-framework/blob/main/.github/workflows/ci.yml#L25), so it's okay to upgrade to Awaitility 4.2.2 either way now.

See gh-33143