### PR TITLE
Fix incorrect access to field `beanName` in `RuntimeBeanNameReference#equals()`

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/RuntimeBeanNameReference.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/RuntimeBeanNameReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ public class RuntimeBeanNameReference implements BeanReference {
 	@Override
 	public boolean equals(@Nullable Object other) {
 		return (this == other || (other instanceof RuntimeBeanNameReference that &&
-				this.beanName.equals(that.beanName)));
+				getBeanName().equals(that.getBeanName())));
 	}
 
 	@Override


### PR DESCRIPTION
The original code used `that.beanName` to access the private field `beanName`, which is not allowed. Changed to use getter method.