### PR TITLE
Parse host from authority in UriComponentsBuilder.uri when unsuccessful

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -482,6 +482,11 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 			}
 			if (uri.getHost() != null) {
 				this.host = uri.getHost();
+			} else if (uri.getRawAuthority() != null) {
+				Matcher matcher = URI_PATTERN.matcher(uri.getRawAuthority());
+				if (matcher.matches()) {
+					this.host = matcher.group(6);
+				}
 			}
 			if (uri.getPort() != -1) {
 				this.port = String.valueOf(uri.getPort());


### PR DESCRIPTION
According to [rain.drop](https://tech.kakaopay.com/post/url-is-strange/#%EC%82%AC%EB%9D%BC%EC%A7%84-%EC%A0%95%EB%B3%B4%EB%8A%94-%EC%97%AC%EA%B8%B0%EC%97%90) in kakaopay, it appears that `UriComponentsBuilder#fromUri` has a bug where it fails to recognize hostnames containing underscores (_) due to a limitation of `java.net.URI`. In contrast, `UriComponentsBuilder#fromUriString` successfully parses these hostnames using `URI_PATTERN`.

For example, `UriComponentsBuilder.fromUri(URI("kakaopay://payweb_tab"))` results in a null `host` but `payweb_tab` becomes its `authority`, unlike `UriComponentsBuilder.fromUriString("kakaopay://payweb_tab")` says its `host` and `authority` are both `payweb_tab`.

This issue arises because [java.net.URI](https://docs.oracle.com/en/java/javase/23/docs/api/java.base/java/net/URI.html) adheres to RFC 2396 and RFC 2732 but does not conform to RFC 3986, which allows underscores in hostnames as per the `URI_PATTERN`. This inconsistency can lead to problems when parsing such URIs with the standard URI class, potentially resulting in the `getHost()` method returning null.

https://github.com/openjdk/jdk/blob/ae4d2f15901bf02efceaac26ee4aa3ae666bf467/src/java.base/share/classes/java/net/URI.java#L3513-L3520
