### PR TITLE
Reparse URI when host is missing

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -471,6 +471,11 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 	 */
 	public UriComponentsBuilder uri(URI uri) {
 		Assert.notNull(uri, "URI must not be null");
+		if (uri.getHost() == null && uri.getAuthority() != null) {
+			// see gh-27774
+			uriComponents(UriComponentsBuilder.fromUriString(uri.toString()).build());
+			return this;
+		}
 		this.scheme = uri.getScheme();
 		if (uri.isOpaque()) {
 			this.ssp = uri.getRawSchemeSpecificPart();

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -160,6 +160,17 @@ class UriComponentsBuilderTests {
 		assertThat(fromUriString).isEqualTo(fromUri);
 	}
 
+	@Test  // see gh-27774
+	void fromUriRegistryBasedAuthority() {
+		URI uri = URI.create("http://elated_sutherland:8080/auth/realms/my-realm");
+		UriComponents result = UriComponentsBuilder.fromUri(uri).build();
+
+		assertThat(result.getScheme()).isEqualTo("http");
+		assertThat(result.getHost()).isEqualTo("elated_sutherland");
+		assertThat(result.getPort()).isEqualTo(8080);
+		assertThat(result.getPath()).isEqualTo("/auth/realms/my-realm");
+	}
+
 	@Test
 	void fromUriString() {
 		UriComponents result = UriComponentsBuilder.fromUriString("https://www.ietf.org/rfc/rfc3986.txt").build();


### PR DESCRIPTION
When a hostname contains an underscore, it is valid in RFC 3986, but only part of a registry-based authority under RFC 2396. Due to the fact, that `URI` only supports RFC 2396, we cannot simply use `getHost()` in these cases. Instead we need to parse the URI ourselves.

Only parsing the authority part seems too much effort, given the custom `UrlParser` we are using.

Closes https://github.com/spring-projects/spring-framework/issues/27774
Closes https://github.com/spring-projects/spring-security/issues/15852
