### PR TITLE
[5.3.x] Fix JettyWebSocketSession.getRemoteAddress throwing instead of returning null with Jetty 10

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/adapter/jetty/JettyWebSocketSession.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/adapter/jetty/JettyWebSocketSession.java
@@ -142,12 +142,14 @@ public class JettyWebSocketSession extends AbstractWebSocketSession<Session> {
 	}
 
 	@Override
+	@Nullable
 	public InetSocketAddress getLocalAddress() {
 		checkNativeSessionInitialized();
 		return this.sessionHelper.getLocalAddress(getNativeSession());
 	}
 
 	@Override
+	@Nullable
 	public InetSocketAddress getRemoteAddress() {
 		checkNativeSessionInitialized();
 		return this.sessionHelper.getRemoteAddress(getNativeSession());
@@ -250,8 +252,10 @@ public class JettyWebSocketSession extends AbstractWebSocketSession<Session> {
 
 		int getBinaryMessageSizeLimit(Session session);
 
+		@Nullable
 		InetSocketAddress getRemoteAddress(Session session);
 
+		@Nullable
 		InetSocketAddress getLocalAddress(Session session);
 
 	}
@@ -348,7 +352,9 @@ public class JettyWebSocketSession extends AbstractWebSocketSession<Session> {
 		@SuppressWarnings("ConstantConditions")
 		public InetSocketAddress getRemoteAddress(Session session) {
 			SocketAddress address = (SocketAddress) ReflectionUtils.invokeMethod(getRemoteAddressMethod, session);
-			Assert.isInstanceOf(InetSocketAddress.class, address);
+			if (address != null) {
+				Assert.isInstanceOf(InetSocketAddress.class, address);
+			}
 			return (InetSocketAddress) address;
 		}
 
@@ -356,7 +362,9 @@ public class JettyWebSocketSession extends AbstractWebSocketSession<Session> {
 		@SuppressWarnings("ConstantConditions")
 		public InetSocketAddress getLocalAddress(Session session) {
 			SocketAddress address = (SocketAddress) ReflectionUtils.invokeMethod(getLocalAddressMethod, session);
-			Assert.isInstanceOf(InetSocketAddress.class, address);
+			if (address != null) {
+				Assert.isInstanceOf(InetSocketAddress.class, address);
+			}
 			return (InetSocketAddress) address;
 		}
 	}


### PR DESCRIPTION
Add graceful processing of `org.eclipse.jetty.websocket.api.Session#getRemoteAddress` returning null for Jetty 10
Closes #33619

This PR doesn't need a port to 5.2.x or 6+ branches. [5.2.x](https://github.com/spring-projects/spring-framework/blob/5.2.x/spring-websocket/src/main/java/org/springframework/web/socket/adapter/jetty/JettyWebSocketSession.java#L139) and [6.x](https://github.com/spring-projects/spring-framework/blob/6.0.x/spring-websocket/src/main/java/org/springframework/web/socket/adapter/jetty/JettyWebSocketSession.java#L138) branches handle this code identically, in a simple way, for two different jetty versions not maintaining compatibility between them.
5.3.x has Jetty 9 and 10 compatibility layer which introduced the problem.