### PR TITLE
Refactor constants for sendTimeLimit and sendBufferSizeLimit to improve maintainability

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/messaging/SubProtocolWebSocketHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/messaging/SubProtocolWebSocketHandler.java
@@ -70,6 +70,10 @@ import org.springframework.web.socket.sockjs.transport.session.StreamingSockJsSe
 public class SubProtocolWebSocketHandler
 		implements WebSocketHandler, SubProtocolCapable, MessageHandler, SmartLifecycle {
 
+	private static final int DEFAULT_SEND_TIME_LIMIT = 10 * 1000;
+
+	private static final int DEFAULT_SEND_BUFFER_SIZE_LIMIT = 512 * 1024;
+	
 	/** The default value for {@link #setTimeToFirstMessage(int) timeToFirstMessage}. */
 	private static final int DEFAULT_TIME_TO_FIRST_MESSAGE = 60 * 1000;
 
@@ -91,9 +95,9 @@ public class SubProtocolWebSocketHandler
 
 	private final Map<String, WebSocketSessionHolder> sessions = new ConcurrentHashMap<>();
 
-	private int sendTimeLimit = 10 * 1000;
+	private int sendTimeLimit = DEFAULT_SEND_TIME_LIMIT;
 
-	private int sendBufferSizeLimit = 512 * 1024;
+	private int sendBufferSizeLimit = DEFAULT_SEND_BUFFER_SIZE_LIMIT;
 
 	private int timeToFirstMessage = DEFAULT_TIME_TO_FIRST_MESSAGE;
 


### PR DESCRIPTION
Summary:
This PR refactors the sendTimeLimit and sendBufferSizeLimit constants within the class to improve the overall code maintainability. The refactor involves moving magic numbers to well-defined constants and applying them consistently throughout the class. These changes make the code more readable and easier to modify in the future.

Changes:
Refactored sendTimeLimit and sendBufferSizeLimit:

- Moved default values for sendTimeLimit and sendBufferSizeLimit into static final constants.
- Default values for sendTimeLimit and sendBufferSizeLimit are now clearly defined using DEFAULT_SEND_TIME_LIMIT and DEFAULT_SEND_BUFFER_SIZE_LIMIT.
- Ensured that these constants are applied consistently across the class.

Constants added:

- DEFAULT_SEND_TIME_LIMIT: Default time limit for sending a message (set to 10 * 1000 milliseconds).
- DEFAULT_SEND_BUFFER_SIZE_LIMIT: Default buffer size limit for sending a message (set to 512 * 1024 bytes).

Impact:
- Maintainability: The use of constants for default values improves the maintainability of the code by providing clear, centralized definitions for these values. Future changes to the time or buffer limits can now be made easily in one place.
- No functional changes: This is purely a refactor and does not alter the existing behavior of the code. The functionality remains the same as before.

This is my first time contributing to an open-source project, so there might be areas for improvement. I would greatly appreciate any feedback or suggestions. Thank you!
