### PR TITLE
Replace hardcoded `"null"` with `NULL_STRING` constant in `ObjectUtils.nullSafeConciseToString()`

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/ObjectUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ObjectUtils.java
@@ -901,7 +901,7 @@ public abstract class ObjectUtils {
 	 */
 	public static String nullSafeConciseToString(@Nullable Object obj) {
 		if (obj == null) {
-			return "null";
+			return NULL_STRING;
 		}
 		if (obj instanceof Optional<?> optional) {
 			return (optional.isEmpty() ? "Optional.empty" :


### PR DESCRIPTION
#### Description:
This pull request replaces the hardcoded "null" string in the nullSafeConciseToString method with the existing NULL_STRING constant to improve maintainability and readability.

#### Changes:
Replaced occurrences of the hardcoded "null" string with the already declared NULL_STRING constant.