### PR TITLE
Replace hardcoded GET method with HttpMethod.GET for better readability

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/support/WebSocketHandlerMapping.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/support/WebSocketHandlerMapping.java
@@ -22,6 +22,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.context.Lifecycle;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.lang.Nullable;
 import org.springframework.web.context.ServletContextAware;
 import org.springframework.web.servlet.HandlerExecutionChain;
@@ -127,7 +128,7 @@ public class WebSocketHandlerMapping extends SimpleUrlHandlerMapping implements 
 		handler = (handler instanceof HandlerExecutionChain chain ? chain.getHandler() : handler);
 		if (this.webSocketUpgradeMatch && handler instanceof WebSocketHttpRequestHandler) {
 			String header = request.getHeader(HttpHeaders.UPGRADE);
-			return (request.getMethod().equals("GET") &&
+			return (HttpMethod.GET.matches(request.getMethod()) &&
 					header != null && header.equalsIgnoreCase("websocket"));
 		}
 		return true;


### PR DESCRIPTION
Changes
- Replaced the hardcoded "GET" string comparison in the matchWebSocketUpgrade method with HttpMethod.GET.matches(request.getMethod()).
- This change improves code readability and prevents potential errors caused by hardcoded strings.
- It also aligns with Spring's convention for handling HTTP method matching, providing a more consistent approach.
- Noticed that HttpMethod.GET.matches is used in other parts of the codebase, so this change also improves overall consistency.

Reason
- Using constants from Spring's HttpMethod class enhances the maintainability of the code.
- Avoiding hardcoded strings reduces the risk of typos and other potential errors.
- Ensuring consistency across the codebase by using the same method for HTTP method matching where applicable.