### PR TITLE
Refactor: Replace hardcoded '.' with EXTENSION_SEPARATOR in StringUtils

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -60,6 +60,7 @@ import org.springframework.lang.Nullable;
  * @author Sam Brannen
  * @author Brian Clozel
  * @author Sebastien Deleuze
+ * @author Sungbin Yang
  * @since 16 April 2001
  */
 public abstract class StringUtils {
@@ -536,7 +537,7 @@ public abstract class StringUtils {
 	 * @param qualifiedName the qualified name
 	 */
 	public static String unqualify(String qualifiedName) {
-		return unqualify(qualifiedName, '.');
+		return unqualify(qualifiedName, EXTENSION_SEPARATOR);
 	}
 
 	/**
@@ -722,7 +723,7 @@ public abstract class StringUtils {
 		String pathToUse = normalizedPath;
 
 		// Shortcut if there is no work to do
-		if (pathToUse.indexOf('.') == -1) {
+		if (pathToUse.indexOf(EXTENSION_SEPARATOR) == -1) {
 			return pathToUse;
 		}
 


### PR DESCRIPTION
This pull request refactors the ```StringUtils``` class by substituting all occurrences of the hardcoded ```'.'``` character with the already-defined constant ```EXTENSION_SEPARATOR```. This refactor promotes cleaner code by removing magic values and enhancing maintainability, as separator characters are now managed centrally. Additionally, this change minimizes the risk of errors that may arise from inconsistent use of the ```'.'``` character throughout the codebase.

No changes have been made to the functionality of the methods, ensuring that the behavior remains intact.