### PR TITLE
Added checks at several places to make the XML parsing robust against XML eXternal Entity attacks

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/xml/DefaultDocumentLoader.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/xml/DefaultDocumentLoader.java
@@ -16,6 +16,7 @@
 
 package org.springframework.beans.factory.xml;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -90,6 +91,8 @@ public class DefaultDocumentLoader implements DocumentLoader {
 
 		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 		factory.setNamespaceAware(namespaceAware);
+		factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 
 		if (validationMode != XmlValidationModeDetector.VALIDATION_NONE) {
 			factory.setValidating(true);

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/persistenceunit/PersistenceUnitReader.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/persistenceunit/PersistenceUnitReader.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -158,6 +159,8 @@ final class PersistenceUnitReader {
 			throws ParserConfigurationException, SAXException, IOException {
 
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		dbf.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 		dbf.setNamespaceAware(true);
 		DocumentBuilder parser = dbf.newDocumentBuilder();
 		parser.setErrorHandler(handler);

--- a/spring-oxm/src/main/java/org/springframework/oxm/jaxb/Jaxb2Marshaller.java
+++ b/spring-oxm/src/main/java/org/springframework/oxm/jaxb/Jaxb2Marshaller.java
@@ -611,6 +611,8 @@ public class Jaxb2Marshaller implements MimeMarshaller, MimeUnmarshaller, Generi
 			this.schemaParserFactory = saxParserFactory;
 		}
 		SAXParser saxParser = saxParserFactory.newSAXParser();
+		saxParser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+		saxParser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 		XMLReader xmlReader = saxParser.getXMLReader();
 
 		for (int i = 0; i < resources.length; i++) {
@@ -621,6 +623,7 @@ public class Jaxb2Marshaller implements MimeMarshaller, MimeUnmarshaller, Generi
 		}
 
 		SchemaFactory schemaFactory = SchemaFactory.newInstance(schemaLanguage);
+		schemaFactory.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
 		if (this.schemaResourceResolver != null) {
 			schemaFactory.setResourceResolver(this.schemaResourceResolver);
 		}
@@ -919,6 +922,7 @@ public class Jaxb2Marshaller implements MimeMarshaller, MimeUnmarshaller, Generi
 					this.sourceParserFactory = saxParserFactory;
 				}
 				SAXParser saxParser = saxParserFactory.newSAXParser();
+				saxParser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 				xmlReader = saxParser.getXMLReader();
 			}
 			if (!isProcessExternalEntities()) {

--- a/spring-web/src/main/java/org/springframework/http/converter/xml/Jaxb2RootElementHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/xml/Jaxb2RootElementHttpMessageConverter.java
@@ -18,6 +18,7 @@ package org.springframework.http.converter.xml;
 
 import java.io.StringReader;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -175,6 +176,7 @@ public class Jaxb2RootElementHttpMessageConverter extends AbstractJaxb2HttpMessa
 					this.sourceParserFactory = saxParserFactory;
 				}
 				SAXParser saxParser = saxParserFactory.newSAXParser();
+				saxParser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
 				XMLReader xmlReader = saxParser.getXMLReader();
 				if (!isProcessExternalEntities()) {
 					xmlReader.setEntityResolver(NO_OP_ENTITY_RESOLVER);

--- a/spring-web/src/main/java/org/springframework/http/converter/xml/SourceHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/xml/SourceHttpMessageConverter.java
@@ -23,6 +23,7 @@ import java.io.OutputStream;
 import java.io.StringReader;
 import java.util.Set;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -224,6 +225,8 @@ public class SourceHttpMessageConverter<T extends Source> extends AbstractHttpMe
 				this.saxParserFactory = parserFactory;
 			}
 			SAXParser saxParser = parserFactory.newSAXParser();
+			saxParser.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+			saxParser.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
 			XMLReader xmlReader = saxParser.getXMLReader();
 			if (!isProcessExternalEntities()) {
 				xmlReader.setEntityResolver(NO_OP_ENTITY_RESOLVER);

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/xslt/XsltView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/xslt/XsltView.java
@@ -23,6 +23,7 @@ import java.util.Enumeration;
 import java.util.Map;
 import java.util.Properties;
 
+import javax.xml.XMLConstants;
 import javax.xml.transform.ErrorListener;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Result;
@@ -215,7 +216,10 @@ public class XsltView extends AbstractUrlBasedView {
 			}
 		}
 		else {
-			return TransformerFactory.newInstance();
+			TransformerFactory factory = TransformerFactory.newDefaultInstance();
+			factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+			factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "all");
+			return factory;
 		}
 	}
 


### PR DESCRIPTION
This pull request is to add checks at several places of the code to make the XML parsing robust against XML eXternal Entity (XXE) attacks.

Our static analysis tool reported this as a potential weakness. We have seen that at several places of the code, explicit checks are added (e.g., https://github.com/spring-projects/spring-framework/blob/34764252dcd1a74db7c965059835d3655b70e528/spring-oxm/src/main/java/org/springframework/oxm/support/AbstractMarshaller.java#L204)

Note we followed a different format (which is generated by our static analysis tool) for the checks. If you want them to be done differently, please advise.

We have checked that the style guide and the test cases pass.

## Sponsorship and Support

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.