### PR TITLE
Polish use of constants in `StringUtils`

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -60,6 +60,7 @@ import org.springframework.lang.Nullable;
  * @author Sam Brannen
  * @author Brian Clozel
  * @author Sebastien Deleuze
+ * @author SungJun Park
  * @since 16 April 2001
  */
 public abstract class StringUtils {
@@ -71,6 +72,8 @@ public abstract class StringUtils {
 	private static final char FOLDER_SEPARATOR_CHAR = '/';
 
 	private static final String WINDOWS_FOLDER_SEPARATOR = "\\";
+
+	private static final char WINDOWS_FOLDER_SEPARATOR_CHAR = '\\';
 
 	private static final String DOUBLE_BACKSLASHES = "\\\\";
 
@@ -712,7 +715,7 @@ public abstract class StringUtils {
 
 		String normalizedPath;
 		// Optimize when there is no backslash
-		if (path.indexOf('\\') != -1) {
+		if (path.indexOf(WINDOWS_FOLDER_SEPARATOR_CHAR) != -1) {
 			normalizedPath = replace(path, DOUBLE_BACKSLASHES, FOLDER_SEPARATOR);
 			normalizedPath = replace(normalizedPath, WINDOWS_FOLDER_SEPARATOR, FOLDER_SEPARATOR);
 		}
@@ -722,7 +725,7 @@ public abstract class StringUtils {
 		String pathToUse = normalizedPath;
 
 		// Shortcut if there is no work to do
-		if (pathToUse.indexOf('.') == -1) {
+		if (pathToUse.indexOf(EXTENSION_SEPARATOR) == -1) {
 			return pathToUse;
 		}
 


### PR DESCRIPTION
I modified the hardcoded '.' and '\\' parts to 
EXTENSION_SEPARATOR,
WINDOWS_FOLDER_SEPARATOR_CHAR.

The '\\' part can be maintained by adding WINDOWS_FOLDER_SEPARATOR_CHAR
to maintain the overall consistency of the code base.

ps. This is my first Spring Framework PR, so even if there are some shortcomings, I will improve it to a good code through future activities.