### PR TITLE
Remove unnecessary array length check

### DIFF
--- a/spring-tx/src/main/java/org/springframework/transaction/annotation/TransactionBeanRegistrationAotProcessor.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/annotation/TransactionBeanRegistrationAotProcessor.java
@@ -83,9 +83,6 @@ class TransactionBeanRegistrationAotProcessor implements BeanRegistrationAotProc
 		public void applyTo(GenerationContext generationContext, BeanRegistrationCode beanRegistrationCode) {
 			RuntimeHints runtimeHints = generationContext.getRuntimeHints();
 			Class<?>[] proxyInterfaces = ClassUtils.getAllInterfacesForClass(this.beanClass);
-			if (proxyInterfaces.length == 0) {
-				return;
-			}
 			for (Class<?> proxyInterface : proxyInterfaces) {
 				runtimeHints.reflection().registerType(proxyInterface, MemberCategory.INVOKE_DECLARED_METHODS);
 			}


### PR DESCRIPTION
This is why I opened PR.

1. ClassUtils.getAllInterfacesForClass does not return null.
2. Even if the length of proxyInterfaces is 0, no error occurs in the loop.
So I think that conditional statement is unnecessary.