### PR TITLE
Remove Javadoc `@since` tag from `MapAccessor` default constructor

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/expression/MapAccessor.java
+++ b/spring-context/src/main/java/org/springframework/context/expression/MapAccessor.java
@@ -43,7 +43,6 @@ public class MapAccessor implements CompilablePropertyAccessor {
 
 	/**
 	 * Create a new {@code MapAccessor} for reading as well as writing.
-	 * @since 6.2
 	 * @see #MapAccessor(boolean)
 	 */
 	public MapAccessor() {


### PR DESCRIPTION
## Overview

This PR removes Javadoc `@since` tag from `MapAccessor()` as it seems to have been added accidentally.

## Related Issues

- #33222
