### PR TITLE
Refactor -> StringUtils replace Optimization

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -450,17 +450,19 @@ public abstract class StringUtils {
 		}
 
 		int capacity = inString.length();
-		if (newPattern.length() > oldPattern.length()) {
-			capacity += 16;
+
+		int newPatternLen = newPattern.length();
+		int oldPatternLen = oldPattern.length();
+		if (newPatternLen > oldPatternLen) {
+			capacity += Math.min(Integer.MAX_VALUE, newPatternLen - oldPatternLen);
 		}
 		StringBuilder sb = new StringBuilder(capacity);
 
 		int pos = 0;  // our position in the old string
-		int patLen = oldPattern.length();
 		while (index >= 0) {
 			sb.append(inString, pos, index);
 			sb.append(newPattern);
-			pos = index + patLen;
+			pos = index + oldPatternLen;
 			index = inString.indexOf(oldPattern, pos);
 		}
 


### PR DESCRIPTION
The += 16 used before is too abstract.

-If NewPattern is longer than 16, StringBuilder must be re -permitted again. 
-If NewPattern is shorter than 16, you will be assigned a memory to StringBuilder.

For this reason, we request optimized code that allocates memory equal to the length of NewPattern.

There is also a possibility that the length of the 
++ NewPattern will be abnormally longer, To prevent the maximum size assignment, the maximum value is set to the maximum value of the int range.