### PR TITLE
DurationFormatterUtils should not attempt to parse an empty duration

### DIFF
--- a/spring-context/src/main/java/org/springframework/format/datetime/standard/DurationFormatterUtils.java
+++ b/spring-context/src/main/java/org/springframework/format/datetime/standard/DurationFormatterUtils.java
@@ -35,6 +35,7 @@ import org.springframework.util.StringUtils;
  * @author Phillip Webb
  * @author Valentine Wu
  * @author Simon Baslé
+ * @author Kim Seungrae
  * @since 6.2
  */
 public abstract class DurationFormatterUtils {
@@ -62,6 +63,7 @@ public abstract class DurationFormatterUtils {
 	 * @return a duration
 	 */
 	public static Duration parse(String value, DurationFormat.Style style, @Nullable DurationFormat.Unit unit) {
+		Assert.hasText(value, () -> "Value must not be empty");
 		return switch (style) {
 			case ISO8601 -> parseIso8601(value);
 			case SIMPLE -> parseSimple(value, unit);
@@ -88,6 +90,7 @@ public abstract class DurationFormatterUtils {
 	 * @return the printed result
 	 */
 	public static String print(Duration value, DurationFormat.Style style, @Nullable DurationFormat.Unit unit) {
+		Assert.notNull(value, "Value must not be null");
 		return switch (style) {
 			case ISO8601 -> value.toString();
 			case SIMPLE -> printSimple(value, unit);
@@ -149,7 +152,7 @@ public abstract class DurationFormatterUtils {
 		try {
 			return Duration.parse(value);
 		}
-		catch (Throwable ex) {
+		catch (Exception ex) {
 			throw new IllegalArgumentException("'" + value + "' is not a valid ISO-8601 duration", ex);
 		}
 	}

--- a/spring-context/src/test/java/org/springframework/format/datetime/standard/DurationFormatterUtilsTests.java
+++ b/spring-context/src/test/java/org/springframework/format/datetime/standard/DurationFormatterUtilsTests.java
@@ -23,7 +23,10 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
+import org.springframework.format.annotation.DurationFormat;
 import org.springframework.format.annotation.DurationFormat.Unit;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -188,6 +191,22 @@ class DurationFormatterUtilsTests {
 				.havingCause().withMessage("Does not match composite duration pattern");
 	}
 
+	@ParameterizedTest
+	@EnumSource(DurationFormat.Style.class)
+	void parseEmptyStringThrowsForAllStyles(DurationFormat.Style style) {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> DurationFormatterUtils.parse("", style))
+				.withMessage("Value must not be empty");
+	}
+
+	@ParameterizedTest
+	@EnumSource(DurationFormat.Style.class)
+	void parseNullStringThrowsForAllStyles(DurationFormat.Style style) {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> DurationFormatterUtils.parse(null, style))
+				.withMessage("Value must not be empty");
+	}
+
 	@Test
 	void printSimple() {
 		assertThat(DurationFormatterUtils.print(Duration.ofNanos(12345), SIMPLE, Unit.NANOS))
@@ -238,6 +257,14 @@ class DurationFormatterUtilsTests {
 		Duration composite = DurationFormatterUtils.parse("-1d2h34m57s28ms3us2ns", COMPOSITE);
 		assertThat(DurationFormatterUtils.print(composite, COMPOSITE))
 				.isEqualTo("-1d2h34m57s28ms3us2ns");
+	}
+
+	@ParameterizedTest
+	@EnumSource(DurationFormat.Style.class)
+	void printNullDurationThrowsForAllStyles(DurationFormat.Style style) {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> DurationFormatterUtils.print(null, style))
+				.withMessage("Value must not be null");
 	}
 
 	@Test


### PR DESCRIPTION
Hi Team,

While testing the `DurationFormatterUtils` functionality, I came across a couple of issues that I'd like to address in this PR

1. **Empty String Handling in `parse` Method**:
   - Currently, when an empty string (`""`, `"    "`) is passed to the `parseComposite(value)` method, the result is `PT0S` instead of an exception being thrown. This doesn't seem like the correct behavior, as an empty string is an invalid input and returning `PT0S` can be misleading in this case.
   
2. **NullPointerException (NPE) in `print` Method**:
   - The `print` method does not handle `null` values properly for the `Duration` parameter, resulting in a `NullPointerException`. 
   
  ### Changes
  + **parse method**:
    + Added validation for empty strings and `null` values.
  + **print method**:
    + Added validation for `null` `Duration` values.
  +  Changed error handling to throw `Exception` instead of `Throwable`
  
Thank you for taking the time to review this PR! Please feel free to share any feedback or suggestions.
