### PR TITLE
Remove unused method checkSchemeAndHost in UriComponentsBuilder

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -243,15 +243,6 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 		return fromUriString(httpUrl);
 	}
 
-	private static void checkSchemeAndHost(String uri, @Nullable String scheme, @Nullable String host) {
-		if (StringUtils.hasLength(scheme) && scheme.startsWith("http") && !StringUtils.hasLength(host)) {
-			throw new IllegalArgumentException("[" + uri + "] is not a valid HTTP URL");
-		}
-		if (StringUtils.hasLength(host) && host.startsWith("[") && !host.endsWith("]")) {
-			throw new IllegalArgumentException("Invalid IPV6 host in [" + uri + "]");
-		}
-	}
-
 	/**
 	 * Create a new {@code UriComponents} object from the URI associated with
 	 * the given HttpRequest while also overlaying with values from the headers


### PR DESCRIPTION
HierarchicalUriComponents.Type.isReserved() also unused 

![QQ_1728651785325](https://github.com/user-attachments/assets/5514eb2b-f052-406b-81cf-07e94642c72b)
