### PR TITLE
Fix incorrect status code check in checkNotModified()

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/context/request/ServletWebRequest.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/ServletWebRequest.java
@@ -213,7 +213,7 @@ public class ServletWebRequest extends ServletRequestAttributes implements Nativ
 			return this.notModified;
 		}
 		// 2) If-Unmodified-Since
-		else if (validateIfUnmodifiedSince(lastModifiedTimestamp)) {
+		if (validateIfUnmodifiedSince(lastModifiedTimestamp)) {
 			updateResponseStateChanging(etag, lastModifiedTimestamp);
 			return this.notModified;
 		}

--- a/spring-web/src/main/java/org/springframework/web/context/request/ServletWebRequest.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/ServletWebRequest.java
@@ -203,7 +203,7 @@ public class ServletWebRequest extends ServletRequestAttributes implements Nativ
 	@Override
 	public boolean checkNotModified(@Nullable String etag, long lastModifiedTimestamp) {
 		HttpServletResponse response = getResponse();
-		if (this.notModified || (response != null && HttpStatus.OK.value() != response.getStatus())) {
+		if (this.notModified || (response != null && HttpStatus.NOT_MODIFIED.value() != response.getStatus())) {
 			return this.notModified;
 		}
 		// Evaluate conditions in order of precedence.

--- a/spring-web/src/main/java/org/springframework/web/context/request/ServletWebRequest.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/ServletWebRequest.java
@@ -202,10 +202,15 @@ public class ServletWebRequest extends ServletRequestAttributes implements Nativ
 
 	@Override
 	public boolean checkNotModified(@Nullable String etag, long lastModifiedTimestamp) {
-		HttpServletResponse response = getResponse();
-		if (this.notModified || (response != null && HttpStatus.NOT_MODIFIED.value() != response.getStatus())) {
-			return this.notModified;
+		if (this.notModified) {
+			return true;
 		}
+
+		HttpServletResponse response = getResponse();
+		if (response != null && HttpStatus.NOT_MODIFIED.value() != response.getStatus()) {
+			return false;
+		}
+
 		// Evaluate conditions in order of precedence.
 		// See https://datatracker.ietf.org/doc/html/rfc9110#section-13.2.2
 		if (validateIfMatch(etag)) {


### PR DESCRIPTION
- Updated the logic in checkNotModified() to check for HttpStatus.NOT_MODIFIED (304) instead of HttpStatus.OK (200). 

- Remove unnecessary else