### PR TITLE
Update scheduling.adoc

### DIFF
--- a/framework-docs/modules/ROOT/pages/integration/scheduling.adoc
+++ b/framework-docs/modules/ROOT/pages/integration/scheduling.adoc
@@ -691,7 +691,7 @@ reached, does the executor create a new thread beyond the core size. If the max 
 has also been reached, then the executor rejects the task.
 
 By default, the queue is unbounded, but this is rarely the desired configuration,
-because it can lead to `OutOfMemoryErrors` if enough tasks are added to that queue while
+because it can lead to `OutOfMemoryError` if enough tasks are added to that queue while
 all pool threads are busy. Furthermore, if the queue is unbounded, the max size has
 no effect at all. Since the executor always tries the queue before creating a new
 thread beyond the core size, a queue must have a finite capacity for the thread pool to


### PR DESCRIPTION
Change 'OutOfMemoryErrors' to 'OutOfMemoryError'.
I think 'OutOfMemoryError' is more accurate proper noun.