### PR TITLE
Support record canonical constructor in `BeanUtils`

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.RecordComponent;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Collections;
@@ -250,6 +251,19 @@ public abstract class BeanUtils {
 			if (ctors.length == 1) {
 				// A single non-public constructor, for example, from a non-public record type
 				return (Constructor<T>) ctors[0];
+			}
+		}
+		else if (clazz.isRecord()) {
+			try {
+				// if record -> use canonical constructor, which is always presented
+				Class<?>[] paramTypes
+						= Arrays.stream(clazz.getRecordComponents())
+						.map(RecordComponent::getType)
+						.toArray(Class<?>[]::new);
+				return clazz.getDeclaredConstructor(paramTypes);
+			}
+			catch (NoSuchMethodException ex) {
+				// Giving up with record...
 			}
 		}
 

--- a/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
@@ -521,8 +521,24 @@ class BeanUtilsTests {
 		assertThat(BeanUtils.isSimpleProperty(type)).as("Type [" + type.getName() + "] should not be a simple property").isFalse();
 	}
 
+	@Test
+	void resolveRecordConstructor() throws NoSuchMethodException {
+		assertThat(BeanUtils.getResolvableConstructor(RecordWithMultiplePublicConstructors.class))
+				.isEqualTo(getRecordWithMultipleVariationsConstructor());
+	}
+
 	private void assertSignatureEquals(Method desiredMethod, String signature) {
 		assertThat(BeanUtils.resolveSignature(signature, MethodSignatureBean.class)).isEqualTo(desiredMethod);
+	}
+
+	public record RecordWithMultiplePublicConstructors(String value, String name) {
+		public RecordWithMultiplePublicConstructors(String value) {
+			this(value, "default value");
+		}
+	}
+
+	private Constructor<RecordWithMultiplePublicConstructors> getRecordWithMultipleVariationsConstructor() throws NoSuchMethodException {
+		return RecordWithMultiplePublicConstructors.class.getConstructor(String.class, String.class);
 	}
 
 


### PR DESCRIPTION
Affected version where noticed: spring-beans: 6.2.0-RC1
I'm not sure is it crucial or not, but method becomes to be invoked after migration from my MvcResult to MvcTestResult and to MockMvcTester

When one of the requestParameters is implemented as record with multiple public constructors, binding fails with 

```
java.lang.IllegalStateException: No primary or single unique constructor found for class org.myconfs.security.jwt.JwtUser
	at org.springframework.beans.BeanUtils.getResolvableConstructor(BeanUtils.java:265)
	at org.springframework.validation.DataBinder.createObject(DataBinder.java:928)
	at org.springframework.validation.DataBinder.construct(DataBinder.java:907)
	at org.springframework.web.bind.ServletRequestDataBinder.construct(ServletRequestDataBinder.java:116)
	at org.springframework.web.servlet.mvc.method.annotation.ServletModelAttributeMethodProcessor.constructAttribute(ServletModelAttributeMethodProcessor.java:157)
	at org.springframework.web.method.annotation.ModelAttributeMethodProcessor.resolveArgument(ModelAttributeMethodProcessor.java:148)
	at org.springframework.web.method.support.HandlerMethodArgumentResolverComposite.resolveArgument(HandlerMethodArgumentResolverComposite.java:122)
	at org.springframework.web.method.support.InvocableHandlerMethod.getMethodArgumentValues(InvocableHandlerMethod.java:224)
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:178)
	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:118)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:986)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:891)
	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1088)
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:978)
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1014)
	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:903)
	at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:564)
	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:885)
```
class implementation: 

```
public record JwtUser(Long id, String username, String email, String password,
                      Collection<GrantedAuthority> authorities, boolean enabled,
                      LocalDateTime lastPermissionResetDate) implements UserDetails {

    public JwtUser(String username, String password, Collection<GrantedAuthority> authorities) {
        this(null, username, "", password, authorities, false, null);
    }

    public static JwtUser withLastPermissionResetDate(JwtUser user, LocalDateTime lastPermissionResetDate) {
        return new JwtUser(user.id, user.username, user.email, user.password, user.authorities, user.enabled, lastPermissionResetDate);
    }

  ...
}
```
There is a suggestion to improve BeanUtils.getResolvableConstructor method to work with records with more than 1 public constructor using the fact that there is only one canonical record's constructor, which shall contain all record components