### PR TITLE
Fix the issue in MappingJackson2MessageConverter where deserializatio…

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/converter/MappingJackson2MessageConverter.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/converter/MappingJackson2MessageConverter.java
@@ -316,7 +316,8 @@ public class MappingJackson2MessageConverter extends AbstractMessageConverter {
 		else if (conversionHint instanceof JsonView jsonView) {
 			return extractViewClass(jsonView, conversionHint);
 		}
-		else if (conversionHint instanceof Class<?> clazz) {
+		else if (conversionHint instanceof Class<?> clazz &&
+				objectMapper.getSerializationConfig().isEnabled(MapperFeature.DEFAULT_VIEW_INCLUSION)) {
 			return clazz;
 		}
 

--- a/spring-messaging/src/test/java/org/springframework/messaging/converter/MappingJackson2MessageConverterTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/converter/MappingJackson2MessageConverterTests.java
@@ -25,6 +25,9 @@ import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.core.MethodParameter;
@@ -160,6 +163,18 @@ class MappingJackson2MessageConverterTests {
 	}
 
 	@Test
+	public void fromMessageToMessageWithPojoClass(){
+		// #16793 https://github.com/spring-projects/spring-framework/issues/16793
+		//ObjectMapper objectMapper = JsonMapper.builder().configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false).build();
+		MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
+		String payload = "{\"string\":\"foo\"}";
+		Message<?> message = MessageBuilder.withPayload(payload.getBytes(StandardCharsets.UTF_8)).build();
+		Object actual = converter.fromMessage(message, MyBean.class, MyBean.class);
+		assertThat(actual).isInstanceOf(MyBean.class);
+		assertThat(((MyBean) actual).getString()).isEqualTo("foo");
+	}
+
+	@Test
 	void toMessage() {
 		MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
 		MyBean payload = new MyBean();
@@ -233,7 +248,6 @@ class MappingJackson2MessageConverterTests {
 		assertThat(back.getWithView2()).isEqualTo("with");
 		assertThat(back.getWithoutView()).isNull();
 	}
-
 
 
 	@JsonView(MyJacksonView1.class)


### PR DESCRIPTION
Fix the issue in MappingJackson2MessageConverter where deserialization returns null values for POJOs that do not have ```@JsonView``` annotations

When a POJO does not have the JsonView annotation set, and Jackson's DEFAULT_VIEW_INCLUSION is false (the default value in Spring framework #16793), deserialization fails and returns an object with all properties empty.

I added a test in ```MappingJackson2MessageConverterTests```  that will fail before I fix it.
```java
	@Test
	public void fromMessageToMessageWithPojoClass(){
		// #16793 https://github.com/spring-projects/spring-framework/issues/16793
		//ObjectMapper objectMapper = JsonMapper.builder().configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false).build();
		MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
		String payload = "{\"string\":\"foo\"}";
		Message<?> message = MessageBuilder.withPayload(payload.getBytes(StandardCharsets.UTF_8)).build();
		Object actual = converter.fromMessage(message, MyBean.class, MyBean.class);
		assertThat(actual).isInstanceOf(MyBean.class);
		assertThat(((MyBean) actual).getString()).isEqualTo("foo");
	}
```

PS:   Discussion with jackson-databind  [issues](https://github.com/FasterXML/jackson-databind/issues/4748).