### PR TITLE
Improve check to preserve case sensitivity of scheme if URI variable present

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/RfcUriParser.java
+++ b/spring-web/src/main/java/org/springframework/web/util/RfcUriParser.java
@@ -29,6 +29,7 @@ import org.springframework.util.Assert;
  * Parser for URI's based on RFC 3986 syntax.
  *
  * @author Rossen Stoyanchev
+ * @author Yanming Zhou
  * @since 6.2
  *
  * @see <a href="https://www.rfc-editor.org/info/rfc3986">RFC 3986</a>
@@ -510,7 +511,7 @@ abstract class RfcUriParser {
 
 		public InternalParser captureScheme() {
 			String scheme = captureComponent("scheme");
-			this.scheme = (!scheme.startsWith("{") ? scheme.toLowerCase(Locale.ROOT) : scheme);
+			this.scheme = (!scheme.contains("{") ? scheme.toLowerCase(Locale.ROOT) : scheme);
 			return this;
 		}
 

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -47,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  * @author Juergen Hoeller
  * @author Sam Brannen
  * @author David Eckel
+ * @author Yanming Zhou
  */
 class UriComponentsBuilderTests {
 
@@ -637,6 +638,24 @@ class UriComponentsBuilderTests {
 				.buildAndExpand(Map.of("TheScheme", "ws"))
 				.toUri();
 		assertThat(uri.toString()).isEqualTo("ws://example.org");
+
+		uri = UriComponentsBuilder
+				.fromUriString("{TheScheme}s://example.org", parserType)
+				.buildAndExpand(Map.of("TheScheme", "ws"))
+				.toUri();
+		assertThat(uri.toString()).isEqualTo("wss://example.org");
+
+		uri = UriComponentsBuilder
+				.fromUriString("s{TheScheme}://example.org", parserType)
+				.buildAndExpand(Map.of("TheScheme", "ws"))
+				.toUri();
+		assertThat(uri.toString()).isEqualTo("sws://example.org");
+
+		uri = UriComponentsBuilder
+				.fromUriString("s{TheScheme}s://example.org", parserType)
+				.buildAndExpand(Map.of("TheScheme", "ws"))
+				.toUri();
+		assertThat(uri.toString()).isEqualTo("swss://example.org");
 	}
 
 	@ParameterizedTest


### PR DESCRIPTION
See GH-33699, Continue c261ca3102414053677c40cf17f4b70b28b4b170

```
Map has no value for 'thescheme'
java.lang.IllegalArgumentException: Map has no value for 'thescheme'
	at org.springframework.web.util.UriComponents$MapTemplateVariables.getValue(UriComponents.java:348)
	at org.springframework.web.util.UriComponents.expandUriComponent(UriComponents.java:263)
	at org.springframework.web.util.HierarchicalUriComponents.expandInternal(HierarchicalUriComponents.java:436)
	at org.springframework.web.util.HierarchicalUriComponents.expandInternal(HierarchicalUriComponents.java:53)
	at org.springframework.web.util.UriComponents.expand(UriComponents.java:161)
	at org.springframework.web.util.UriComponentsBuilder.buildAndExpand(UriComponentsBuilder.java:364)
```