### PR TITLE
Update `HttpHeaders.setHost()` to actually remove the Host header

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
@@ -1136,7 +1136,7 @@ public class HttpHeaders implements MultiValueMap<String, String>, Serializable 
 			set(HOST, value);
 		}
 		else {
-			remove(HOST, null);
+			remove(HOST);
 		}
 	}
 

--- a/spring-web/src/test/java/org/springframework/http/HttpHeadersTests.java
+++ b/spring-web/src/test/java/org/springframework/http/HttpHeadersTests.java
@@ -214,6 +214,15 @@ class HttpHeadersTests {
 	}
 
 	@Test
+	void hostDeletion() {
+		InetSocketAddress host = InetSocketAddress.createUnresolved("localhost", 8080);
+		headers.setHost(host);
+		headers.setHost(null);
+		assertThat(headers.getHost()).as("Host is not deleted").isEqualTo(null);
+		assertThat(headers.getFirst("Host")).as("Host is not deleted").isEqualTo(null);
+	}
+
+	@Test
 	void eTagWithoutQuotes() {
 		headers.setETag("v2.6");
 		assertThat(headers.getETag()).isEqualTo("\"v2.6\"");


### PR DESCRIPTION
This PR fixes a bug in `org.springframework.http.HttpHeaders` class.
It was not possible to delete/clear the `Host` header before this fix.

This bug was first introduced in this commit (in 2018): https://github.com/spring-projects/spring-framework/commit/5bbbc82e19e4c2ed443ce955949137ec8c0a2e02#diff-e2d6218e6585f8b7e32682f6f8f7aed22dbd76d862ec92e86e0902243889556aR1020

After that commit, the deletion logic line in `setHost()` method started to look like this: `remove(HOST, null)` 
Although for all other methods/headers it looks like this: `remove(CONTENT_TYPE)`, `remove(ETAG)`, etc.

And for `setHost()` method it also should be the same: `remove(HOST)`

I've also added a test for this case. Feel free to rollback my 1-line fix in `HttpHeaders` and check that `Host` header is not cleared indeed.
