### PR TITLE
SSE: Make Handler and initialize method public to improve testing.

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ResponseBodyEmitter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ResponseBodyEmitter.java
@@ -117,7 +117,7 @@ public class ResponseBodyEmitter {
 	}
 
 
-	synchronized void initialize(Handler handler) throws IOException {
+	public synchronized void initialize(Handler handler) throws IOException {
 		this.handler = handler;
 
 		try {
@@ -315,7 +315,7 @@ public class ResponseBodyEmitter {
 	 * timeout, error, and completion for any reason (including from the
 	 * container side).
 	 */
-	interface Handler {
+	public interface Handler {
 
 		/**
 		 * Immediately write and flush the given data to the network.


### PR DESCRIPTION
Motivation: When I have my own SseEmitter and populate it with events, then I would like to write a unit test with TestHandler to assert events being sent