### PR TITLE
Add Javadoc since for headers() in Delete/Patch/Post/PutExchange

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/service/annotation/DeleteExchange.java
+++ b/spring-web/src/main/java/org/springframework/web/service/annotation/DeleteExchange.java
@@ -62,6 +62,7 @@ public @interface DeleteExchange {
 
 	/**
 	 * Alias for {@link HttpExchange#headers()}.
+	 * @since 6.2
 	 */
 	@AliasFor(annotation = HttpExchange.class)
 	String[] headers() default {};

--- a/spring-web/src/main/java/org/springframework/web/service/annotation/PatchExchange.java
+++ b/spring-web/src/main/java/org/springframework/web/service/annotation/PatchExchange.java
@@ -62,6 +62,7 @@ public @interface PatchExchange {
 
 	/**
 	 * Alias for {@link HttpExchange#headers()}.
+	 * @since 6.2
 	 */
 	@AliasFor(annotation = HttpExchange.class)
 	String[] headers() default {};

--- a/spring-web/src/main/java/org/springframework/web/service/annotation/PostExchange.java
+++ b/spring-web/src/main/java/org/springframework/web/service/annotation/PostExchange.java
@@ -62,6 +62,7 @@ public @interface PostExchange {
 
 	/**
 	 * Alias for {@link HttpExchange#headers()}.
+	 * @since 6.2
 	 */
 	@AliasFor(annotation = HttpExchange.class)
 	String[] headers() default {};

--- a/spring-web/src/main/java/org/springframework/web/service/annotation/PutExchange.java
+++ b/spring-web/src/main/java/org/springframework/web/service/annotation/PutExchange.java
@@ -62,6 +62,7 @@ public @interface PutExchange {
 
 	/**
 	 * Alias for {@link HttpExchange#headers()}.
+	 * @since 6.2
 	 */
 	@AliasFor(annotation = HttpExchange.class)
 	String[] headers() default {};


### PR DESCRIPTION
This PR add Javadoc `@since` tags for `headers()` in `DeleteExchange`, `PatchExchange`, `PostExchange`, and `PutExchange`.

See gh-33309