### PR TITLE
Prevent further configuration once AbstractJdbcCall is compiled

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcCall.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/AbstractJdbcCall.java
@@ -249,14 +249,16 @@ public abstract class AbstractJdbcCall {
 	 * @param parameter the {@link SqlParameter} to add
 	 */
 	public void addDeclaredParameter(SqlParameter parameter) {
-		Assert.notNull(parameter, "The supplied parameter must not be null");
-		if (!StringUtils.hasText(parameter.getName())) {
-			throw new InvalidDataAccessApiUsageException(
-					"You must specify a parameter name when declaring parameters for \"" + getProcedureName() + "\"");
-		}
-		this.declaredParameters.add(parameter);
-		if (logger.isDebugEnabled()) {
-			logger.debug("Added declared parameter for [" + getProcedureName() + "]: " + parameter.getName());
+		if(!isCompiled()) {
+			Assert.notNull(parameter, "The supplied parameter must not be null");
+			if (!StringUtils.hasText(parameter.getName())) {
+				throw new InvalidDataAccessApiUsageException(
+						"You must specify a parameter name when declaring parameters for \"" + getProcedureName() + "\"");
+			}
+			this.declaredParameters.add(parameter);
+			if (logger.isDebugEnabled()) {
+				logger.debug("Added declared parameter for [" + getProcedureName() + "]: " + parameter.getName());
+			}
 		}
 	}
 
@@ -266,9 +268,11 @@ public abstract class AbstractJdbcCall {
 	 * @param rowMapper the RowMapper implementation to use
 	 */
 	public void addDeclaredRowMapper(String parameterName, RowMapper<?> rowMapper) {
-		this.declaredRowMappers.put(parameterName, rowMapper);
-		if (logger.isDebugEnabled()) {
-			logger.debug("Added row mapper for [" + getProcedureName() + "]: " + parameterName);
+		if(!isCompiled()) {
+			this.declaredRowMappers.put(parameterName, rowMapper);
+			if (logger.isDebugEnabled()) {
+				logger.debug("Added row mapper for [" + getProcedureName() + "]: " + parameterName);
+			}
 		}
 	}
 


### PR DESCRIPTION
During profiling of our application, we noticed a potential memory leak. We had a `SimpleJdbcCall` object as a field in a DAO. Typically, we would create and initialize this object during the `PostConstruct` phase and runtime would just need to set up the inputs and call execute.  However the developer accidentally put the declareParameters in the same method as execution so those paremeters kept getting added.

Example DAO:

```java
@Resource
private JdbcTemplate jdbcTemplate;

private SimpleJdbcCall procedure;

@PostConstruct
void buildProcedure() {
  procedure = new SimpleJdbcCall(jdbcTemplate).withProcedureName("some_procedure");
}

void executeProcedure(String input) {
  procedure.declareParameters(new SqlParameter("param", Types.VARCHAR));
  procedure.execute(Collections.singletonMap("param", input));
}
```
The first time `executeProcedure` is called, the procedure gets compiled and all the parameters get set in the `callMetaDataContext`.  Subsequent calls to `declareParameters` do not alter the `callMetaDataContext` and the procedure executes successfully.  

The problem: Each time `declareParameters` is called, that parameter gets added to `declaredParameters` in `AbstractJdbcCall` where it will sit there, never gets used, and never gets released for garbage collection.

This proposed solution here is to check to see if the call has been compiled before adding to the `declaredParameters` list.  If the call is not compiled, we'll proceed as normal.  Otherwise, `AbstractJdbcCall` will ignore the request because the parameter won't be added to the `callMetaDataContext`.