### PR TITLE
Fix value accumulation for case-sensitive keys in NettyHeadersAdapter

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/support/Netty4HeadersAdapter.java
+++ b/spring-web/src/main/java/org/springframework/http/support/Netty4HeadersAdapter.java
@@ -17,6 +17,7 @@
 package org.springframework.http.support;
 
 import java.util.AbstractSet;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -61,7 +62,10 @@ public final class Netty4HeadersAdapter implements MultiValueMap<String, String>
 	@Override
 	public void add(String key, @Nullable String value) {
 		if (value != null) {
-			this.headers.add(key, value);
+			List<String> values = this.get(key);
+			values = values == null ? new ArrayList<>() : new ArrayList<>(values);
+			values.add(value);
+			this.headers.set(key, values);
 		}
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/support/Netty4HeadersAdapter.java
+++ b/spring-web/src/main/java/org/springframework/http/support/Netty4HeadersAdapter.java
@@ -19,6 +19,7 @@ package org.springframework.http.support;
 import java.util.AbstractSet;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -52,6 +53,12 @@ public final class Netty4HeadersAdapter implements MultiValueMap<String, String>
 		this.headers = headers;
 	}
 
+	private void addAllIgnoreCase(String key, List<? extends String> values) {
+		List<String> listToUpdate = this.get(key);
+		listToUpdate = listToUpdate == null ? new ArrayList<>() : new ArrayList<>(listToUpdate);
+		listToUpdate.addAll(values);
+		this.headers.set(key, listToUpdate);
+	}
 
 	@Override
 	@Nullable
@@ -62,21 +69,18 @@ public final class Netty4HeadersAdapter implements MultiValueMap<String, String>
 	@Override
 	public void add(String key, @Nullable String value) {
 		if (value != null) {
-			List<String> values = this.get(key);
-			values = values == null ? new ArrayList<>() : new ArrayList<>(values);
-			values.add(value);
-			this.headers.set(key, values);
+			addAllIgnoreCase(key, Collections.singletonList(value));
 		}
 	}
 
 	@Override
 	public void addAll(String key, List<? extends String> values) {
-		this.headers.add(key, values);
+		addAllIgnoreCase(key, values);
 	}
 
 	@Override
 	public void addAll(MultiValueMap<String, String> values) {
-		values.forEach(this.headers::add);
+		values.forEach(this::addAllIgnoreCase);
 	}
 
 	@Override

--- a/spring-web/src/main/java/org/springframework/http/support/Netty5HeadersAdapter.java
+++ b/spring-web/src/main/java/org/springframework/http/support/Netty5HeadersAdapter.java
@@ -64,7 +64,10 @@ public final class Netty5HeadersAdapter implements MultiValueMap<String, String>
 	@Override
 	public void add(String key, @Nullable String value) {
 		if (value != null) {
-			this.headers.add(key, value);
+			List<String> values = this.get(key);
+			values = values == null ? new ArrayList<>() : new ArrayList<>(values);
+			values.add(value);
+			this.headers.set(key, values);
 		}
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/support/Netty5HeadersAdapter.java
+++ b/spring-web/src/main/java/org/springframework/http/support/Netty5HeadersAdapter.java
@@ -53,6 +53,12 @@ public final class Netty5HeadersAdapter implements MultiValueMap<String, String>
 		this.headers = headers;
 	}
 
+	private void addAllIgnoreCase(String key, List<? extends String> values) {
+		List<String> listToUpdate = this.get(key);
+		listToUpdate = listToUpdate == null ? new ArrayList<>() : new ArrayList<>(listToUpdate);
+		listToUpdate.addAll(values);
+		this.headers.set(key, listToUpdate);
+	}
 
 	@Override
 	@Nullable
@@ -64,21 +70,18 @@ public final class Netty5HeadersAdapter implements MultiValueMap<String, String>
 	@Override
 	public void add(String key, @Nullable String value) {
 		if (value != null) {
-			List<String> values = this.get(key);
-			values = values == null ? new ArrayList<>() : new ArrayList<>(values);
-			values.add(value);
-			this.headers.set(key, values);
+			addAllIgnoreCase(key, Collections.singletonList(value));
 		}
 	}
 
 	@Override
 	public void addAll(String key, List<? extends String> values) {
-		this.headers.add(key, values);
+		addAllIgnoreCase(key, values);
 	}
 
 	@Override
 	public void addAll(MultiValueMap<String, String> values) {
-		values.forEach(this.headers::add);
+		values.forEach(this::addAllIgnoreCase);
 	}
 
 	@Override

--- a/spring-web/src/test/java/org/springframework/http/server/reactive/HeadersAdaptersTests.java
+++ b/spring-web/src/test/java/org/springframework/http/server/reactive/HeadersAdaptersTests.java
@@ -126,6 +126,16 @@ class HeadersAdaptersTests {
 		assertThatThrownBy(names::remove).isInstanceOf(IllegalStateException.class);
 	}
 
+	@ParameterizedHeadersTest
+	void testHeadersOutput(MultiValueMap<String, String> headers) {
+		headers.add("TestHeader", "first");
+		headers.add("testHeader", "second");
+		MultiValueMap<String, String> multiValueMap =
+				CollectionUtils.toMultiValueMap(new LinkedCaseInsensitiveMap<>(8, Locale.ENGLISH));
+		headers.forEach(multiValueMap::addAll);
+		assertThat(multiValueMap.toString()).isEqualToIgnoringCase("{testheader=[first, second]}");
+	}
+
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target(ElementType.METHOD)
 	@ParameterizedTest

--- a/spring-web/src/test/java/org/springframework/http/server/reactive/HeadersAdaptersTests.java
+++ b/spring-web/src/test/java/org/springframework/http/server/reactive/HeadersAdaptersTests.java
@@ -20,6 +20,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -127,9 +128,35 @@ class HeadersAdaptersTests {
 	}
 
 	@ParameterizedHeadersTest
-	void testHeadersOutput(MultiValueMap<String, String> headers) {
+	void testAddHeadersOutput(MultiValueMap<String, String> headers) {
 		headers.add("TestHeader", "first");
 		headers.add("testHeader", "second");
+		MultiValueMap<String, String> multiValueMap =
+				CollectionUtils.toMultiValueMap(new LinkedCaseInsensitiveMap<>(8, Locale.ENGLISH));
+		headers.forEach(multiValueMap::addAll);
+		assertThat(multiValueMap.toString()).isEqualToIgnoringCase("{testheader=[first, second]}");
+	}
+
+	@ParameterizedHeadersTest
+	void testAddAllSingletonHeadersOutput(MultiValueMap<String, String> headers) {
+		headers.addAll("TestHeader", Collections.singletonList("first"));
+		headers.addAll("testHeader", Collections.singletonList("second"));
+		MultiValueMap<String, String> multiValueMap =
+				CollectionUtils.toMultiValueMap(new LinkedCaseInsensitiveMap<>(8, Locale.ENGLISH));
+		headers.forEach(multiValueMap::addAll);
+		assertThat(multiValueMap.toString()).isEqualToIgnoringCase("{testheader=[first, second]}");
+	}
+
+	@ParameterizedHeadersTest
+	void testAddAllMultipleHeadersOutput(MultiValueMap<String, String> headers) {
+		MultiValueMap<String, String> map1 =
+				CollectionUtils.toMultiValueMap(new LinkedCaseInsensitiveMap<>(8, Locale.ENGLISH));
+		map1.add("TestHeader", "first");
+		headers.addAll(map1);
+		MultiValueMap<String, String> map2 =
+				CollectionUtils.toMultiValueMap(new LinkedCaseInsensitiveMap<>(8, Locale.ENGLISH));
+		map2.add("testHeader", "second");
+		headers.addAll(map2);
 		MultiValueMap<String, String> multiValueMap =
 				CollectionUtils.toMultiValueMap(new LinkedCaseInsensitiveMap<>(8, Locale.ENGLISH));
 		headers.forEach(multiValueMap::addAll);


### PR DESCRIPTION
The current `NettyHeaders` supports case-sensitive storage of entry values when using the `add` method. This causes the `NettyHeadersAdapter` to accumulate the values for the corresponding key when retrieving headers(see unit test). 

Add a unit test testHeadersOutput to verify the final output of the headers.