### PR TITLE
Fix incorrect regex rendering in MVC controller documentation

### DIFF
--- a/framework-docs/modules/ROOT/pages/web/webmvc/mvc-controller/ann-requestmapping.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc/mvc-controller/ann-requestmapping.adoc
@@ -119,7 +119,7 @@ Some example patterns:
 * `+"/resources/*.png"+` - match zero or more characters in a path segment
 * `+"/resources/**"+` - match multiple path segments
 * `+"/projects/{project}/versions"+` - match a path segment and capture it as a variable
-* `+"/projects/{project:[a-z]+}/versions"+` - match and capture a variable with a regex
+* `++"/projects/{project:[a-z]+}/versions"++` - match and capture a variable with a regex
 
 Captured URI variables can be accessed with `@PathVariable`. For example:
 


### PR DESCRIPTION
### Summary
Fix incorrect regex in documentation

### Step
- [x] running ./gradlew antora
- [x] then opening the framework-docs/build/site/6.1-SNAPSHOT/web/webmvc/mvc-controller/ann-requestmapping.html file in your browser


<img width="600" alt="image" src="https://github.com/user-attachments/assets/47d26759-00a4-4eb8-ae5d-e99127f806d7">
<img width="600" alt="image" src="https://github.com/user-attachments/assets/af794389-a6ce-4201-aed4-155fbf089eba">

### Other
All tests pass.