### PR TITLE
Refactor SourceFilteringListener use Assert.state for null check

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/event/SourceFilteringListener.java
+++ b/spring-context/src/main/java/org/springframework/context/event/SourceFilteringListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import org.springframework.context.ApplicationListener;
 import org.springframework.core.Ordered;
 import org.springframework.core.ResolvableType;
 import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 /**
  * {@link org.springframework.context.ApplicationListener} decorator that filters
@@ -102,10 +103,7 @@ public class SourceFilteringListener implements GenericApplicationListener {
 	 * @param event the event to process (matching the specified source)
 	 */
 	protected void onApplicationEventInternal(ApplicationEvent event) {
-		if (this.delegate == null) {
-			throw new IllegalStateException(
-					"Must specify a delegate object or override the onApplicationEventInternal method");
-		}
+		Assert.state(this.delegate != null, "Delegate must not be null");
 		this.delegate.onApplicationEvent(event);
 	}
 


### PR DESCRIPTION
### Description
This PR refactors the `SourceFilteringListener` class to replace the existing null check with `Assert.state`, in line with Spring's coding standards for handling null checks. The error message has been updated to follow the guideline: it starts with the identifier (in this case, "Delegate") and ends with "must not be null."

### Changes:
- Replaced manual null check with `Assert.state` in the `onApplicationEventInternal` method.
- Updated the exception message to: `"Delegate must not be null"` to improve clarity and ensure consistent error reporting across the codebase.

### Why this change?
Using `Assert.state` improves readability and ensures that error messages are consistent with Spring's coding style. This change also enhances the maintainability of the code by adhering to standard practices.
