### PR TITLE
Optimize `BeanMap#entrySet`

### DIFF
--- a/spring-core/src/main/java/org/springframework/cglib/beans/BeanMap.java
+++ b/spring-core/src/main/java/org/springframework/cglib/beans/BeanMap.java
@@ -17,10 +17,11 @@
 package org.springframework.cglib.beans;
 
 import java.security.ProtectionDomain;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -307,14 +308,11 @@ abstract public class BeanMap implements Map {
 		return code;
 	}
 
-	// TODO: optimize
 	@Override
 	public Set entrySet() {
-		HashMap copy = new HashMap();
-		for (Object key : keySet()) {
-			copy.put(key, get(key));
-		}
-		return Collections.unmodifiableMap(copy).entrySet();
+		Set set = new HashSet<>(keySet().size());
+		keySet().forEach(key -> set.add(new SimpleImmutableEntry<>(key, get(key))));
+		return Collections.unmodifiableSet(set);
 	}
 
 	@Override

--- a/spring-core/src/test/java/org/springframework/cglib/beans/BeanMapTests.java
+++ b/spring-core/src/test/java/org/springframework/cglib/beans/BeanMapTests.java
@@ -1,0 +1,64 @@
+package org.springframework.cglib.beans;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link BeanMap}.
+ *
+ * @author gudrb33333
+ */
+public class BeanMapTests {
+	private BeanMap beanMap;
+
+	private static class TestBean {
+		private String name = "Jane Morris Goodall";
+		private int age = 90;
+
+		public String getName() {
+			return name;
+		}
+
+		public int getAge() {
+			return age;
+		}
+	}
+
+	@BeforeEach
+	public void setUp() {
+		TestBean testBean = new TestBean();
+		beanMap = BeanMap.create(testBean);
+	}
+
+	@Test
+	public void entrySetCorrectSize() {
+		Set entrySet = beanMap.entrySet();
+		assertEquals(2, entrySet.size());
+	}
+
+	@Test
+	public void entrySetFieldsCorrectly() {
+		Set entrySet = beanMap.entrySet();
+		for (Object entryObject : entrySet) {
+			Map.Entry<?, ?> entry = (Map.Entry<?, ?>) entryObject;
+
+			String key = (String) entry.getKey();
+			Object value = entry.getValue();
+
+			if ("name".equals(key)) {
+				assertEquals("Jane Morris Goodall", value);
+			}
+			else if ("age".equals(key)) {
+				assertEquals(90, value);
+			}
+			else {
+				fail("Unexpected key: " + key);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Hello, I have been learning a lot while analyzing this open source project recently. During my analysis, I noticed a TODO message and came up with an simple idea.

- Enhancing memory efficiency by setting the initial capacity of a HashMap.

I have read the contributor guidelines in detail, but there may still be some mistakes.