### PR TITLE
Refactor MimeType BitSet initialization for improved readability and maintainability

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/MimeType.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeType.java
@@ -62,6 +62,11 @@ public class MimeType implements Comparable<MimeType>, Serializable {
 
 	private static final BitSet TOKEN;
 
+	private static final char[] SEPARATORS = {
+			'(', ')', '<', '>', '@', ',', ';', ':', '\\', '\"', '/',
+			'[', ']', '?', '=', '{', '}', ' ', '\t'
+	};
+
 	static {
 		// variable names refer to RFC 2616, section 2.2
 		BitSet ctl = new BitSet(128);
@@ -71,25 +76,9 @@ public class MimeType implements Comparable<MimeType>, Serializable {
 		ctl.set(127);
 
 		BitSet separators = new BitSet(128);
-		separators.set('(');
-		separators.set(')');
-		separators.set('<');
-		separators.set('>');
-		separators.set('@');
-		separators.set(',');
-		separators.set(';');
-		separators.set(':');
-		separators.set('\\');
-		separators.set('\"');
-		separators.set('/');
-		separators.set('[');
-		separators.set(']');
-		separators.set('?');
-		separators.set('=');
-		separators.set('{');
-		separators.set('}');
-		separators.set(' ');
-		separators.set('\t');
+		for (char separator : SEPARATORS) {
+			separators.set(separator);
+		}
 
 		TOKEN = new BitSet(128);
 		TOKEN.set(0, 128);


### PR DESCRIPTION
Refactored BitSet initialization to remove repetitive set calls by introducing a char array (SEPARATORS).

- Enhanced readability: Separator characters are now defined in one place, making the code easier to understand.
- Improved maintainability: Adding or modifying separator characters is now simpler, requiring updates only to the SEPARATORS array.