### PR TITLE
Introduce default method `checked()` for throwable functional interface

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/function/ThrowingConsumer.java
+++ b/spring-core/src/main/java/org/springframework/util/function/ThrowingConsumer.java
@@ -19,12 +19,15 @@ package org.springframework.util.function;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
+import static org.springframework.util.function.ThrowingFunction.throwAsUnchecked;
+
 /**
  * A {@link Consumer} that allows invocation of code that throws a checked
  * exception.
  *
  * @author Stephane Nicoll
  * @author Phillip Webb
+ * @author Yanming Zhou
  * @since 6.0
  * @param <T> the type of the input to the operation
  */
@@ -84,6 +87,32 @@ public interface ThrowingConsumer<T> extends Consumer<T> {
 			@Override
 			public void accept(T t) {
 				accept(t, exceptionWrapper);
+			}
+		};
+	}
+
+	/**
+	 * Return a new {@link ThrowingConsumer} where the {@link #accept(Object)}
+	 * method will throw original checked exceptions.
+	 * @return the replacement {@link ThrowingConsumer} instance
+	 */
+	@SuppressWarnings("NullAway")
+	default ThrowingConsumer<T> checked() {
+		ThrowingConsumer<T> consumer = this;
+		return new ThrowingConsumer<>() {
+			@Override
+			public void acceptWithException(T t) throws Exception {
+				consumer.acceptWithException(t);
+			}
+
+			@Override
+			public void accept(T t) {
+				try {
+					consumer.acceptWithException(t);
+				}
+				catch (Exception ex) {
+					throwAsUnchecked(ex);
+				}
 			}
 		};
 	}

--- a/spring-core/src/main/java/org/springframework/util/function/ThrowingSupplier.java
+++ b/spring-core/src/main/java/org/springframework/util/function/ThrowingSupplier.java
@@ -19,11 +19,14 @@ package org.springframework.util.function;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
+import static org.springframework.util.function.ThrowingFunction.throwAsUnchecked;
+
 /**
  * A {@link Supplier} that allows invocation of code that throws a checked exception.
  *
  * @author Stephane Nicoll
  * @author Phillip Webb
+ * @author Yanming Zhou
  * @since 6.0
  * @param <T> the type of results supplied by this supplier
  */
@@ -82,6 +85,33 @@ public interface ThrowingSupplier<T> extends Supplier<T> {
 			@Override
 			public T get() {
 				return get(exceptionWrapper);
+			}
+		};
+	}
+
+	/**
+	 * Return a new {@link ThrowingSupplier} where the {@link #get()}
+	 * method will throw original checked exceptions.
+	 * @return the replacement {@link ThrowingSupplier} instance
+	 */
+	@SuppressWarnings("NullAway")
+	default ThrowingSupplier<T> checked() {
+		ThrowingSupplier<T> supplier = this;
+		return new ThrowingSupplier<>() {
+			@Override
+			public T getWithException() throws Exception {
+				return supplier.getWithException();
+			}
+
+			@Override
+			public T get() {
+				try {
+					return supplier.getWithException();
+				}
+				catch (Exception ex) {
+					throwAsUnchecked(ex);
+					return null; // Never happens
+				}
 			}
 		};
 	}

--- a/spring-core/src/test/java/org/springframework/util/function/ThrowingBiFunctionTests.java
+++ b/spring-core/src/test/java/org/springframework/util/function/ThrowingBiFunctionTests.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIOException;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
@@ -28,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * Tests for {@link ThrowingBiFunction}.
  *
  * @author Phillip Webb
+ * @author Yanming Zhou
  * @since 6.0
  */
 class ThrowingBiFunctionTests {
@@ -74,6 +76,12 @@ class ThrowingBiFunctionTests {
 				this::throwIOException, IllegalStateException::new);
 		assertThatIllegalStateException().isThrownBy(
 				() -> function.apply(this, this)).withCauseInstanceOf(IOException.class);
+	}
+
+	@Test
+	void checked() {
+		ThrowingBiFunction<Object, Object, Object> function = ThrowingBiFunction.of(this::throwIOException).checked();
+		assertThatIOException().isThrownBy(() -> function.apply(this, this));
 	}
 
 	private Object throwIOException(Object o, Object u) throws IOException {

--- a/spring-core/src/test/java/org/springframework/util/function/ThrowingConsumerTests.java
+++ b/spring-core/src/test/java/org/springframework/util/function/ThrowingConsumerTests.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIOException;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
@@ -28,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * Tests for {@link ThrowingConsumer}.
  *
  * @author Phillip Webb
+ * @author Yanming Zhou
  * @since 6.0
  */
 class ThrowingConsumerTests {
@@ -74,6 +76,12 @@ class ThrowingConsumerTests {
 				IllegalStateException::new);
 		assertThatIllegalStateException().isThrownBy(
 				() -> consumer.accept(this)).withCauseInstanceOf(IOException.class);
+	}
+
+	@Test
+	void checked() {
+		ThrowingConsumer<Object> consumer = ThrowingConsumer.of(this::throwIOException).checked();
+		assertThatIOException().isThrownBy(() -> consumer.accept(this));
 	}
 
 	private void throwIOException(Object o) throws IOException {

--- a/spring-core/src/test/java/org/springframework/util/function/ThrowingFunctionTests.java
+++ b/spring-core/src/test/java/org/springframework/util/function/ThrowingFunctionTests.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIOException;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
@@ -28,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * Tests for {@link ThrowingFunction}.
  *
  * @author Phillip Webb
+ * @author Yanming Zhou
  * @since 6.0
  */
 class ThrowingFunctionTests {
@@ -74,6 +76,12 @@ class ThrowingFunctionTests {
 				this::throwIOException, IllegalStateException::new);
 		assertThatIllegalStateException().isThrownBy(
 				() -> function.apply(this)).withCauseInstanceOf(IOException.class);
+	}
+
+	@Test
+	void checked() {
+		ThrowingFunction<Object, Object> function = ThrowingFunction.of(this::throwIOException).checked();
+		assertThatIOException().isThrownBy(() -> function.apply(this));
 	}
 
 	private Object throwIOException(Object o) throws IOException {

--- a/spring-core/src/test/java/org/springframework/util/function/ThrowingSupplierTests.java
+++ b/spring-core/src/test/java/org/springframework/util/function/ThrowingSupplierTests.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIOException;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
@@ -28,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * Tests for {@link ThrowingSupplier}.
  *
  * @author Phillip Webb
+ * @author Yanming Zhou
  * @since 6.0
  */
 class ThrowingSupplierTests {
@@ -75,6 +77,12 @@ class ThrowingSupplierTests {
 				this::throwIOException, IllegalStateException::new);
 		assertThatIllegalStateException().isThrownBy(
 				supplier::get).withCauseInstanceOf(IOException.class);
+	}
+
+	@Test
+	void checked() {
+		ThrowingSupplier<Object> supplier = ThrowingSupplier.of(this::throwIOException).checked();
+		assertThatIOException().isThrownBy(supplier::get);
 	}
 
 	private Object throwIOException() throws IOException {


### PR DESCRIPTION
Allow throwing original checked exception instead of wrapping unchecked exception.

Use case:
https://github.com/spring-projects/spring-boot/blob/23fe3977d2d319f9f1bd0101f40dbb639ade7082/spring-boot-project/spring-boot/src/main/java/org/springframework/boot/type/classreading/ConcurrentReferenceCachingMetadataReaderFactory.java#L71-L89

```java
	@Override
	public MetadataReader getMetadataReader(String className) throws IOException {
		MetadataReader metadataReader = this.classNameCache.get(className);
		if (metadataReader == null) {
			metadataReader = super.getMetadataReader(className);
			this.classNameCache.put(className, metadataReader);
		}
		return metadataReader;
	}

	@Override
	public MetadataReader getMetadataReader(Resource resource) throws IOException {
		MetadataReader metadataReader = this.resourceCache.get(resource);
		if (metadataReader == null) {
			metadataReader = createMetadataReader(resource);
			this.resourceCache.put(resource, metadataReader);
		}
		return metadataReader;
	}
```
can be rewritten to:
```java
	@Override
	public MetadataReader getMetadataReader(String className) throws IOException {
		return this.classNameCache.computeIfAbsent(className,ThrowingFunction.of((ThrowingFunction<String, MetadataReader>)super::getMetadataReader).checked());
	}

	@Override
	public MetadataReader getMetadataReader(Resource resource) throws IOException {
		return this.resourceCache.computeIfAbsent(resource,ThrowingFunction.of(this::createMetadataReader).checked());
	}
```


WDYT @philwebb 
