### PR TITLE
Fail with full description for XML diff in `XmlExpectationsHelper`

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/util/XmlExpectationsHelper.java
+++ b/spring-test/src/main/java/org/springframework/test/util/XmlExpectationsHelper.java
@@ -110,7 +110,7 @@ public class XmlExpectationsHelper {
 
 		@Override
 		public String toString() {
-			return this.diff.toString();
+			return this.diff.fullDescription();
 		}
 
 	}

--- a/spring-test/src/test/java/org/springframework/test/util/XmlExpectationsHelperTests.java
+++ b/spring-test/src/test/java/org/springframework/test/util/XmlExpectationsHelperTests.java
@@ -74,4 +74,15 @@ class XmlExpectationsHelperTests {
 			.withMessageContaining("Expected child nodelist length '3' but was '2'");
 	}
 
+	@Test
+	void assertXmlEqualExceptionWithFullDescription() {
+		String control = "<root><field1>f1</field1><field2>f2</field2></root>";
+		String test = "<root><field2>f2</field2><field3>f3</field3></root>";
+		XmlExpectationsHelper xmlHelper = new XmlExpectationsHelper();
+		assertThatExceptionOfType(AssertionError.class).isThrownBy(() ->
+						xmlHelper.assertXmlEqual(control, test))
+				.withMessageContaining("Expected child 'field1' but was 'null'")
+				.withMessageContaining("Expected child 'null' but was 'field3'");
+	}
+
 }


### PR DESCRIPTION
Only first difference is printed in assertion error when xml comparison is failed.
For example comparison of two xmls:
```xml
<root><a>a</a><b>b</b></root>
```
and
```xml
<root><b>b</b><c>c</c></root>
```
fails with message `Body content Expected child 'a' but was 'null' - comparing <a...> at /root[1]/a[1] to <NULL>`. There is nothing about child `c` in this message.

That is a strange behaviour of a xml-unit and it was updated with https://github.com/xmlunit/xmlunit/issues/232

To fail with full diff description we should use `fullDescription()` method instead of `toString()` on `Diff` class.

With the full description fail message would be:
```
Body content Expected child 'a' but was 'null' - comparing <a...> at /root[1]/a[1] to <NULL>
Expected child 'null' but was 'c' - comparing <NULL> to <c...> at /root[1]/c[1]
```

Full description is better for bug fixing.