### PR TITLE
DataBufferUtils and BodyInserters: allow consumers of OutputStream to throw IOException

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/buffer/DataBufferUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/io/buffer/DataBufferUtils.java
@@ -439,22 +439,22 @@ public abstract class DataBufferUtils {
 	 * @since 6.1
 	 */
 	public static Publisher<DataBuffer> outputStreamPublisher(
-			Consumer<OutputStream> consumer, DataBufferFactory bufferFactory, Executor executor) {
+			OutputStreamHandler consumer, DataBufferFactory bufferFactory, Executor executor) {
 
 		return new OutputStreamPublisher<>(
-				consumer::accept, new DataBufferMapper(bufferFactory), executor, null);
+				consumer, new DataBufferMapper(bufferFactory), executor, null);
 	}
 
 	/**
-	 * Variant of {@link #outputStreamPublisher(Consumer, DataBufferFactory, Executor)}
+	 * Variant of {@link #outputStreamPublisher(OutputStreamHandler, DataBufferFactory, Executor)}
 	 * providing control over the chunk sizes to be produced by the publisher.
 	 * @since 6.1
 	 */
 	public static Publisher<DataBuffer> outputStreamPublisher(
-			Consumer<OutputStream> consumer, DataBufferFactory bufferFactory, Executor executor, int chunkSize) {
+			OutputStreamHandler consumer, DataBufferFactory bufferFactory, Executor executor, int chunkSize) {
 
 		return new OutputStreamPublisher<>(
-				consumer::accept, new DataBufferMapper(bufferFactory), executor, chunkSize);
+				consumer, new DataBufferMapper(bufferFactory), executor, chunkSize);
 	}
 
 	/**

--- a/spring-core/src/main/java/org/springframework/core/io/buffer/OutputStreamHandler.java
+++ b/spring-core/src/main/java/org/springframework/core/io/buffer/OutputStreamHandler.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.io.buffer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Contract to provide callback access to the {@link OutputStream}.
+ * @author Rossen Stoyanchev
+ * @author Federico Pettinari
+ */
+@FunctionalInterface
+public interface OutputStreamHandler {
+
+	void handle(OutputStream outputStream) throws IOException;
+
+}

--- a/spring-core/src/main/java/org/springframework/core/io/buffer/OutputStreamPublisher.java
+++ b/spring-core/src/main/java/org/springframework/core/io/buffer/OutputStreamPublisher.java
@@ -100,17 +100,6 @@ final class OutputStreamPublisher<T> implements Publisher<T> {
 
 
 	/**
-	 * Contract to provide callback access to the {@link OutputStream}.
-	 */
-	@FunctionalInterface
-	public interface OutputStreamHandler {
-
-		void handle(OutputStream outputStream) throws Exception;
-
-	}
-
-
-	/**
 	 * Maps from bytes to byte buffers.
 	 * @param <T> the type of byte buffer to map to
 	 */

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/BodyInserters.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/BodyInserters.java
@@ -19,7 +19,6 @@ package org.springframework.web.reactive.function;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.concurrent.Executor;
-import java.util.function.Consumer;
 
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/BodyInserters.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/BodyInserters.java
@@ -32,6 +32,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferFactory;
 import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.core.io.buffer.OutputStreamHandler;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
 import org.springframework.http.ReactiveHttpOutputMessage;
@@ -397,10 +398,10 @@ public abstract class BodyInserters {
 	 * separate thread
 	 * @return an inserter that writes what is written to the output stream
 	 * @since 6.1
-	 * @see DataBufferUtils#outputStreamPublisher(Consumer, DataBufferFactory, Executor)
+	 * @see DataBufferUtils#outputStreamPublisher(OutputStreamHandler, DataBufferFactory, Executor)
 	 */
 	public static <T extends Publisher<DataBuffer>> BodyInserter<T, ReactiveHttpOutputMessage> fromOutputStream(
-			Consumer<OutputStream> outputStreamConsumer, Executor executor) {
+			OutputStreamHandler outputStreamConsumer, Executor executor) {
 
 		Assert.notNull(outputStreamConsumer, "OutputStreamConsumer must not be null");
 		Assert.notNull(executor, "Executor must not be null");
@@ -418,10 +419,10 @@ public abstract class BodyInserters {
 	 * @param chunkSize minimum size of the buffer produced by the publisher
 	 * @return an inserter that writes what is written to the output stream
 	 * @since 6.1
-	 * @see DataBufferUtils#outputStreamPublisher(Consumer, DataBufferFactory, Executor, int)
+	 * @see DataBufferUtils#outputStreamPublisher(OutputStreamHandler, DataBufferFactory, Executor, int)
 	 */
 	public static <T extends Publisher<DataBuffer>> BodyInserter<T, ReactiveHttpOutputMessage> fromOutputStream(
-			Consumer<OutputStream> outputStreamConsumer, Executor executor, int chunkSize) {
+			OutputStreamHandler outputStreamConsumer, Executor executor, int chunkSize) {
 
 		Assert.notNull(outputStreamConsumer, "OutputStreamConsumer must not be null");
 		Assert.notNull(executor, "Executor must not be null");


### PR DESCRIPTION
At the moment, users of DataBufferUtils.outputStreamPublisher are forced to catch and re-throw IOException whenever they actually write to the OutputStream.

Example:
```
DataBufferUtils.outputStreamPublisher(
    outputStream -> {
        try {
            outputStream.write(1);
            ...
        } catch (IOException e) {
            throw new RuntimeException(e);
        }
    },
new DefaultDataBufferFactory(),
Runnable::run)
```

This PR aims to allow users to write cleaner code, example:
```
DataBufferUtils.outputStreamPublisher(
    outputStream -> {
        outputStream.write(1);
        ...
    },
new DefaultDataBufferFactory(),
Runnable::run)
```

As exceptions are already handled nicely under the hoods.

Same concept for BodyInserters.