### PR TITLE
Fix a typo in documentation

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/validation/beanvalidation.adoc
+++ b/framework-docs/modules/ROOT/pages/core/validation/beanvalidation.adoc
@@ -196,7 +196,7 @@ Kotlin::
 
 When used as `org.springframework.validation.Validator`, `LocalValidatorFactoryBean`
 invokes the underlying `jakarta.validation.Validator`, and then adapts
-``ContraintViolation``s to ``FieldError``s, and registers them with the `Errors` object
+``ConstraintViolation``s to ``FieldError``s, and registers them with the `Errors` object
 passed into the `validate` method.
 
 


### PR DESCRIPTION
`ContraintViolation => ConstraintViolation`