### PR TITLE
Add coroutine extensions for RowsFetchSpec in Spring WebFlux

### DIFF
--- a/spring-r2dbc/src/main/kotlin/org/springframework/r2dbc/core/RowsFetchSpecExtensions.kt
+++ b/spring-r2dbc/src/main/kotlin/org/springframework/r2dbc/core/RowsFetchSpecExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,3 +67,16 @@ suspend fun <T> RowsFetchSpec<T>.awaitSingleOrNull(): T? =
  * @author Sebastien Deleuze
  */
 fun <T : Any> RowsFetchSpec<T>.flow(): Flow<T> = all().asFlow()
+
+/**
+ * Collects all rows in the result set into a list.
+ *
+ * @return A list containing all rows from the query result, or an empty list if no rows are found.
+ * This function collects all rows asynchronously and returns them as a single list,
+ * providing a convenient alternative when all results are needed at once.
+ *
+ * @author Jimin Jo
+ */
+suspend fun <T : Any> RowsFetchSpec<T>.awaitAllToList() =
+	all().collectList().awaitSingleOrNull() ?: emptyList()
+

--- a/spring-r2dbc/src/main/kotlin/org/springframework/r2dbc/core/RowsFetchSpecExtensions.kt
+++ b/spring-r2dbc/src/main/kotlin/org/springframework/r2dbc/core/RowsFetchSpecExtensions.kt
@@ -16,6 +16,7 @@
 package org.springframework.r2dbc.core
 
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.reactive.asFlow
 import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.springframework.dao.EmptyResultDataAccessException
@@ -78,5 +79,4 @@ fun <T : Any> RowsFetchSpec<T>.flow(): Flow<T> = all().asFlow()
  * @author Jimin Jo
  */
 suspend fun <T : Any> RowsFetchSpec<T>.awaitAllToList() =
-	all().collectList().awaitSingleOrNull() ?: emptyList()
-
+	all().asFlow().toList()

--- a/spring-r2dbc/src/test/kotlin/org/springframework/r2dbc/core/RowsFetchSpecExtensionsTests.kt
+++ b/spring-r2dbc/src/test/kotlin/org/springframework/r2dbc/core/RowsFetchSpecExtensionsTests.kt
@@ -163,4 +163,31 @@ class RowsFetchSpecExtensionsTests {
 		}
 	}
 
+	@Test
+	fun awaitSingleToListNotEmpty() {
+		val spec = mockk<RowsFetchSpec<String>>()
+		every { spec.all() } returns Flux.just("foo", "bar", "baz")
+
+		runBlocking {
+			 assertThat(spec.awaitAllToList()).contains("foo", "bar", "baz")
+		}
+
+		verify {
+			spec.all()
+		}
+	}
+
+	@Test
+	fun awaitSingleToListEmpty() {
+		val spec = mockk<RowsFetchSpec<String>>()
+		every { spec.all() } returns Flux.just()
+
+		runBlocking {
+			assertThat(spec.awaitAllToList()).isEmpty()
+		}
+		verify {
+			spec.all()
+		}
+	}
+
 }


### PR DESCRIPTION
Hello Spring Team,

I’m excited to submit this contribution, which adds coroutine-friendly extensions to enhance Kotlin support within Spring WebFlux. Inspired by the challenges of adapting Mono and Flux types in coroutine-based projects, these additions aim to simplify and streamline asynchronous database operations for Kotlin developers. Thank you for the opportunity to contribute to such a valuable framework, and I look forward to your feedback!

Best regards