### PR TITLE
Document that Spring Boot will auto-configure `RestClient.Builder` beans with the observation registry

### DIFF
--- a/framework-docs/modules/ROOT/pages/integration/observability.adoc
+++ b/framework-docs/modules/ROOT/pages/integration/observability.adoc
@@ -305,6 +305,7 @@ Instrumentation uses the `org.springframework.http.client.observation.ClientRequ
 === RestClient
 
 Applications must configure an `ObservationRegistry` on the `RestClient.Builder` to enable the instrumentation; without that, observations are "no-ops".
+Spring Boot will auto-configure `RestClient.Builder` beans with the observation registry already set.
 
 Instrumentation uses the `org.springframework.http.client.observation.ClientRequestObservationConvention` by default, backed by the `ClientRequestObservationContext`.
 


### PR DESCRIPTION
See https://github.com/spring-projects/spring-boot/issues/38500