### PR TITLE
Remove "Spring Boot will auto-configure beans with the observation registry" from document

### DIFF
--- a/framework-docs/modules/ROOT/pages/integration/observability.adoc
+++ b/framework-docs/modules/ROOT/pages/integration/observability.adoc
@@ -276,7 +276,6 @@ Unlike their server counterparts, the instrumentation is implemented directly in
 === RestTemplate
 
 Applications must configure an `ObservationRegistry` on `RestTemplate` instances to enable the instrumentation; without that, observations are "no-ops".
-Spring Boot will auto-configure `RestTemplateBuilder` beans with the observation registry already set.
 
 Instrumentation uses the `org.springframework.http.client.observation.ClientRequestObservationConvention` by default, backed by the `ClientRequestObservationContext`.
 
@@ -333,7 +332,6 @@ Instrumentation uses the `org.springframework.http.client.observation.ClientRequ
 === WebClient
 
 Applications must configure an `ObservationRegistry` on the `WebClient` builder to enable the instrumentation; without that, observations are "no-ops".
-Spring Boot will auto-configure `WebClient.Builder` beans with the observation registry already set.
 
 Instrumentation uses the `org.springframework.web.reactive.function.client.ClientRequestObservationConvention` by default, backed by the `ClientRequestObservationContext`.
 


### PR DESCRIPTION
>> it should be in the Spring Boot reference doc.

See https://github.com/spring-projects/spring-framework/pull/33857#issuecomment-2466596967