### PR TITLE
Polish

### DIFF
--- a/spring-context/src/main/java/org/springframework/format/annotation/DurationFormat.java
+++ b/spring-context/src/main/java/org/springframework/format/annotation/DurationFormat.java
@@ -94,7 +94,7 @@ public @interface DurationFormat {
 	 * allows conversion to and from a supported {@code ChronoUnit} as well as
 	 * conversion from durations to longs.
 	 *
-	 * <p>The enum includes its corresponding suffix in the {@link Style#SIMPLE simple}
+	 * <p>The enum includes its corresponding suffix in the {@link Style#SIMPLE SIMPLE}
 	 * {@code Duration} format style.
 	 */
 	enum Unit {

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpConnector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Update copyright header - see https://github.com/spring-projects/spring-framework/issues/33822
Use `SIMPLE` instead `simple` for consistently javadoc `Style#SIMPLE` in file `DurationFormat.java`