### PR TITLE
Simplify implementation of `FilteredIterator`

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/FilteredIterator.java
+++ b/spring-core/src/main/java/org/springframework/util/FilteredIterator.java
@@ -55,17 +55,13 @@ final class FilteredIterator<E> implements Iterator<E> {
 		if (this.nextSet) {
 			return true;
 		}
-		else {
-			return setNext();
-		}
+		return setNext();
 	}
 
 	@Override
 	public E next() {
-		if (!this.nextSet) {
-			if (!setNext()) {
+		if (!this.nextSet && !setNext()) {
 				throw new NoSuchElementException();
-			}
 		}
 		this.nextSet = false;
 		Assert.state(this.next != null, "Next should not be null");


### PR DESCRIPTION
In my opinion, there are unnecessary 'else' phrases and if phrases.

This can be good in terms of readability, but deepening depth can actually be out of sight.

That's why I modified the same format to be used a little more concisely.