### PR TITLE
Remove label usage for improved efficiency

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
+++ b/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
@@ -311,17 +311,12 @@ public class AntPathMatcher implements PathMatcher {
 			int strLength = (pathIdxEnd - pathIdxStart + 1);
 			int foundIdx = -1;
 
-			strLoop:
 			for (int i = 0; i <= strLength - patLength; i++) {
-				for (int j = 0; j < patLength; j++) {
-					String subPat = pattDirs[pattIdxStart + j + 1];
-					String subStr = pathDirs[pathIdxStart + i + j];
-					if (!matchStrings(subPat, subStr, uriTemplateVariables)) {
-						continue strLoop;
-					}
+				MatchContext context = new MatchContext(pattDirs, pathDirs, pattIdxStart, pathIdxStart, uriTemplateVariables );
+				if(checkSubPatternMatch(context, i, patLength)){
+					foundIdx = pathIdxStart + i;
+					break;
 				}
-				foundIdx = pathIdxStart + i;
-				break;
 			}
 
 			if (foundIdx == -1) {
@@ -338,6 +333,32 @@ public class AntPathMatcher implements PathMatcher {
 			}
 		}
 
+		return true;
+	}
+	private static class MatchContext{
+		String[] pattDirs;
+		String[] pathDirs;
+		int pattIdxStart;
+		int pathIdxStart;
+		Map<String, String> uriTemplateVariables;
+
+		MatchContext(String[] pattDirs, String[] pathDirs, int pattIdxStart, int pathIdxStart, Map<String, String> uriTemplateVariables) {
+			this.pattDirs = pattDirs;
+			this.pathDirs = pathDirs;
+			this.pattIdxStart = pattIdxStart;
+			this.pathIdxStart = pathIdxStart;
+			this.uriTemplateVariables = uriTemplateVariables;
+		}
+	}
+
+	private boolean checkSubPatternMatch(MatchContext context, int i, int patLength) {
+		for (int j = 0; j < patLength; j++) {
+			String subPat = context.pattDirs[context.pattIdxStart + j + 1];
+			String subStr = context.pathDirs[context.pathIdxStart + i + j];
+			if (!matchStrings(subPat, subStr, context.uriTemplateVariables)) {
+				return false;
+			}
+		}
 		return true;
 	}
 

--- a/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
+++ b/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
@@ -340,9 +340,10 @@ public class AntPathMatcher implements PathMatcher {
 		String[] pathDirs;
 		int pattIdxStart;
 		int pathIdxStart;
+		@Nullable
 		Map<String, String> uriTemplateVariables;
 
-		MatchContext(String[] pattDirs, String[] pathDirs, int pattIdxStart, int pathIdxStart, Map<String, String> uriTemplateVariables) {
+		MatchContext(String[] pattDirs, String[] pathDirs, int pattIdxStart, int pathIdxStart, @Nullable Map<String, String> uriTemplateVariables) {
 			this.pattDirs = pattDirs;
 			this.pathDirs = pathDirs;
 			this.pattIdxStart = pattIdxStart;

--- a/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
+++ b/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
@@ -660,7 +660,7 @@ public class AntPathMatcher implements PathMatcher {
 			this.uriTemplateVariables = uriTemplateVariables;
 		}
 	}
-	
+
 	/**
 	 * Tests whether a string matches against a pattern via a {@link Pattern}.
 	 * <p>The pattern may contain special characters: '*' means zero or more characters; '?' means one and

--- a/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
+++ b/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
@@ -335,22 +335,6 @@ public class AntPathMatcher implements PathMatcher {
 
 		return true;
 	}
-	private static class MatchContext{
-		String[] pattDirs;
-		String[] pathDirs;
-		int pattIdxStart;
-		int pathIdxStart;
-		@Nullable
-		Map<String, String> uriTemplateVariables;
-
-		MatchContext(String[] pattDirs, String[] pathDirs, int pattIdxStart, int pathIdxStart, @Nullable Map<String, String> uriTemplateVariables) {
-			this.pattDirs = pattDirs;
-			this.pathDirs = pathDirs;
-			this.pattIdxStart = pattIdxStart;
-			this.pathIdxStart = pathIdxStart;
-			this.uriTemplateVariables = uriTemplateVariables;
-		}
-	}
 
 	private boolean checkSubPatternMatch(MatchContext context, int i, int patLength) {
 		for (int j = 0; j < patLength; j++) {
@@ -660,7 +644,23 @@ public class AntPathMatcher implements PathMatcher {
 		return new AntPatternComparator(path, this.pathSeparator);
 	}
 
+	private static class MatchContext{
+		String[] pattDirs;
+		String[] pathDirs;
+		int pattIdxStart;
+		int pathIdxStart;
+		@Nullable
+		Map<String, String> uriTemplateVariables;
 
+		MatchContext(String[] pattDirs, String[] pathDirs, int pattIdxStart, int pathIdxStart, @Nullable Map<String, String> uriTemplateVariables) {
+			this.pattDirs = pattDirs;
+			this.pathDirs = pathDirs;
+			this.pattIdxStart = pattIdxStart;
+			this.pathIdxStart = pathIdxStart;
+			this.uriTemplateVariables = uriTemplateVariables;
+		}
+	}
+	
 	/**
 	 * Tests whether a string matches against a pattern via a {@link Pattern}.
 	 * <p>The pattern may contain special characters: '*' means zero or more characters; '?' means one and


### PR DESCRIPTION
As far as I know, explicitly using "Label" is simple, but it's disorienting for a debugger, which is why I tried to create a more intuitive format.

- Create a class for Context
- Isolation of functions matching SubPatterns

Through this, we made it more readable.