### PR TITLE
RestClient does not expose full URI template as attribute

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/DefaultRestClient.java
+++ b/spring-web/src/main/java/org/springframework/web/client/DefaultRestClient.java
@@ -313,19 +313,22 @@ final class DefaultRestClient implements RestClient {
 
 		@Override
 		public RequestBodySpec uri(String uriTemplate, Object... uriVariables) {
-			attribute(URI_TEMPLATE_ATTRIBUTE, uriTemplate);
+			UriBuilder uriBuilder = uriBuilderFactory.uriString(uriTemplate);
+			attribute(URI_TEMPLATE_ATTRIBUTE, uriBuilder.toUriString());
 			return uri(DefaultRestClient.this.uriBuilderFactory.expand(uriTemplate, uriVariables));
 		}
 
 		@Override
 		public RequestBodySpec uri(String uriTemplate, Map<String, ?> uriVariables) {
-			attribute(URI_TEMPLATE_ATTRIBUTE, uriTemplate);
+			UriBuilder uriBuilder = uriBuilderFactory.uriString(uriTemplate);
+			attribute(URI_TEMPLATE_ATTRIBUTE, uriBuilder.toUriString());
 			return uri(DefaultRestClient.this.uriBuilderFactory.expand(uriTemplate, uriVariables));
 		}
 
 		@Override
 		public RequestBodySpec uri(String uriTemplate, Function<UriBuilder, URI> uriFunction) {
-			attribute(URI_TEMPLATE_ATTRIBUTE, uriTemplate);
+			UriBuilder uriBuilder = uriBuilderFactory.uriString(uriTemplate);
+			attribute(URI_TEMPLATE_ATTRIBUTE, uriBuilder.toUriString());
 			return uri(uriFunction.apply(DefaultRestClient.this.uriBuilderFactory.uriString(uriTemplate)));
 		}
 

--- a/spring-web/src/test/java/org/springframework/web/client/RestClientObservationTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/RestClientObservationTests.java
@@ -83,6 +83,7 @@ class RestClientObservationTests {
 
 	RestClient.Builder createBuilder() {
 		return RestClient.builder()
+				.baseUrl("https://example.com/base")
 				.messageConverters(converters -> converters.add(0, this.converter))
 				.requestFactory(this.requestFactory)
 				.observationRegistry(this.observationRegistry);
@@ -90,26 +91,37 @@ class RestClientObservationTests {
 
 	@Test
 	void shouldContributeTemplateWhenUriVariables() throws Exception {
-		mockSentRequest(GET, "https://example.com/hotels/42/bookings/21");
+		mockSentRequest(GET, "https://example.com/base/hotels/42/bookings/21");
 		mockResponseStatus(HttpStatus.OK);
 
-		client.get().uri("https://example.com/hotels/{hotel}/bookings/{booking}", "42", "21")
+		client.get().uri("/hotels/{hotel}/bookings/{booking}", "42", "21")
 				.retrieve().toBodilessEntity();
 
-		assertThatHttpObservation().hasLowCardinalityKeyValue("uri", "/hotels/{hotel}/bookings/{booking}");
+		assertThatHttpObservation().hasLowCardinalityKeyValue("uri", "/base/hotels/{hotel}/bookings/{booking}");
 	}
 
 	@Test
 	void shouldContributeTemplateWhenMap() throws Exception {
-		mockSentRequest(GET, "https://example.com/hotels/42/bookings/21");
+		mockSentRequest(GET, "https://example.com/base/hotels/42/bookings/21");
 		mockResponseStatus(HttpStatus.OK);
 
 		Map<String, String> vars = Map.of("hotel", "42", "booking", "21");
 
-		client.get().uri("https://example.com/hotels/{hotel}/bookings/{booking}", vars)
+		client.get().uri("/hotels/{hotel}/bookings/{booking}", vars)
 				.retrieve().toBodilessEntity();
 
-		assertThatHttpObservation().hasLowCardinalityKeyValue("uri", "/hotels/{hotel}/bookings/{booking}");
+		assertThatHttpObservation().hasLowCardinalityKeyValue("uri", "/base/hotels/{hotel}/bookings/{booking}");
+	}
+
+	@Test
+	void shouldContributeTemplateWhenFunction() throws Exception {
+		mockSentRequest(GET, "https://example.com/base/hotels/42/bookings/21");
+		mockResponseStatus(HttpStatus.OK);
+
+		client.get().uri("/hotels/{hotel}/bookings/{booking}", builder -> builder.build("42", "21"))
+				.retrieve().toBodilessEntity();
+
+		assertThatHttpObservation().hasLowCardinalityKeyValue("uri", "/base/hotels/{hotel}/bookings/{booking}");
 	}
 
 	@Test


### PR DESCRIPTION
This PR closes #33927 by using the same fix that has been applied to the `WebClient` in 2e07f9ab33d882876f46912fcea08030b2593d49 and 2b4ffe03915187746c30d76f69c1f27bf1af0895.