### PR TITLE
Replace TestObservationRegistryAssert.assertThat() with Assertions.assertThat()

### DIFF
--- a/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessorObservabilityTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/annotation/ScheduledAnnotationBeanPostProcessorObservabilityTests.java
@@ -175,8 +175,7 @@ class ScheduledAnnotationBeanPostProcessorObservabilityTests {
 	}
 
 	private TestObservationRegistryAssert.TestObservationRegistryAssertReturningObservationContextAssert assertThatTaskObservation() {
-		return TestObservationRegistryAssert.assertThat(this.observationRegistry)
-				.hasObservationWithNameEqualTo("tasks.scheduled.execution").that();
+		return assertThat(this.observationRegistry).hasObservationWithNameEqualTo("tasks.scheduled.execution").that();
 	}
 
 

--- a/spring-web/src/test/java/org/springframework/web/client/RestClientObservationTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/RestClientObservationTests.java
@@ -178,8 +178,7 @@ class RestClientObservationTests {
 
 		restClient.get().uri("https://example.org").retrieve().toBodilessEntity();
 
-		TestObservationRegistryAssert.assertThat(this.observationRegistry)
-				.hasObservationWithNameEqualTo("custom.requests");
+		assertThat(this.observationRegistry).hasObservationWithNameEqualTo("custom.requests");
 	}
 
 	@Test
@@ -289,9 +288,8 @@ class RestClientObservationTests {
 
 
 	private TestObservationRegistryAssert.TestObservationRegistryAssertReturningObservationContextAssert assertThatHttpObservation() {
-		TestObservationRegistryAssert.assertThat(this.observationRegistry).hasNumberOfObservationsWithNameEqualTo("http.client.requests",1);
-		return TestObservationRegistryAssert.assertThat(this.observationRegistry)
-				.hasObservationWithNameEqualTo("http.client.requests").that();
+		assertThat(this.observationRegistry).hasNumberOfObservationsWithNameEqualTo("http.client.requests",1);
+		return assertThat(this.observationRegistry).hasObservationWithNameEqualTo("http.client.requests").that();
 	}
 
 	static class ContextAssertionObservationHandler implements ObservationHandler<ClientRequestObservationContext> {

--- a/spring-web/src/test/java/org/springframework/web/client/RestTemplateObservationTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/RestTemplateObservationTests.java
@@ -214,8 +214,7 @@ class RestTemplateObservationTests {
 
 
 	private TestObservationRegistryAssert.TestObservationRegistryAssertReturningObservationContextAssert assertThatHttpObservation() {
-		return TestObservationRegistryAssert.assertThat(this.observationRegistry)
-				.hasObservationWithNameEqualTo("http.client.requests").that();
+		return assertThat(this.observationRegistry).hasObservationWithNameEqualTo("http.client.requests").that();
 	}
 
 	static class ContextAssertionObservationHandler implements ObservationHandler<ClientRequestObservationContext> {

--- a/spring-web/src/test/java/org/springframework/web/client/support/RestClientAdapterTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/support/RestClientAdapterTests.java
@@ -27,7 +27,6 @@ import java.util.function.BiFunction;
 import java.util.stream.Stream;
 
 import io.micrometer.observation.tck.TestObservationRegistry;
-import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
@@ -131,9 +130,8 @@ class RestClientAdapterTests {
 		assertThat(response).isEqualTo("Hello Spring!");
 		assertThat(request.getMethod()).isEqualTo("GET");
 		assertThat(request.getPath()).isEqualTo("/greeting");
-		TestObservationRegistryAssert.assertThat(observationRegistry)
-				.hasObservationWithNameEqualTo("http.client.requests")
-				.that().hasLowCardinalityKeyValue("uri", "/greeting");
+		assertThat(observationRegistry).hasObservationWithNameEqualTo("http.client.requests").that()
+				.hasLowCardinalityKeyValue("uri", "/greeting");
 	}
 
 	@ParameterizedAdapterTest
@@ -147,9 +145,8 @@ class RestClientAdapterTests {
 		assertThat(response.getBody()).isEqualTo("Hello Spring!");
 		assertThat(request.getMethod()).isEqualTo("GET");
 		assertThat(request.getPath()).isEqualTo("/greeting/456");
-		TestObservationRegistryAssert.assertThat(observationRegistry)
-				.hasObservationWithNameEqualTo("http.client.requests")
-				.that().hasLowCardinalityKeyValue("uri", "/greeting/{id}");
+		assertThat(observationRegistry).hasObservationWithNameEqualTo("http.client.requests").that()
+				.hasLowCardinalityKeyValue("uri", "/greeting/{id}");
 	}
 
 	@ParameterizedAdapterTest
@@ -163,9 +160,8 @@ class RestClientAdapterTests {
 		assertThat(response.orElse("empty")).isEqualTo("Hello Spring!");
 		assertThat(request.getMethod()).isEqualTo("GET");
 		assertThat(request.getRequestUrl().uri()).isEqualTo(dynamicUri);
-		TestObservationRegistryAssert.assertThat(observationRegistry)
-				.hasObservationWithNameEqualTo("http.client.requests")
-				.that().hasLowCardinalityKeyValue("uri", "none");
+		assertThat(observationRegistry).hasObservationWithNameEqualTo("http.client.requests").that()
+				.hasLowCardinalityKeyValue("uri", "none");
 	}
 
 	@ParameterizedAdapterTest

--- a/spring-web/src/test/java/org/springframework/web/filter/ServerHttpObservationFilterTests.java
+++ b/spring-web/src/test/java/org/springframework/web/filter/ServerHttpObservationFilterTests.java
@@ -187,18 +187,14 @@ class ServerHttpObservationFilterTests {
 		this.mockFilterChain = new MockFilterChain(new ScopeCheckingServlet(this.observationRegistry));
 		this.request.setDispatcherType(DispatcherType.ASYNC);
 		this.filter.doFilter(this.request, this.response, this.mockFilterChain);
-		TestObservationRegistryAssert.assertThat(this.observationRegistry)
-				.hasObservationWithNameEqualTo("http.server.requests")
-				.that().isNotStopped();
+		assertThat(this.observationRegistry).hasObservationWithNameEqualTo("http.server.requests").that()
+				.isNotStopped();
 	}
 
 	private TestObservationRegistryAssert.TestObservationRegistryAssertReturningObservationContextAssert assertThatHttpObservation() {
-		TestObservationRegistryAssert.assertThat(this.observationRegistry)
-				.hasNumberOfObservationsWithNameEqualTo("http.server.requests", 1);
+		assertThat(this.observationRegistry).hasNumberOfObservationsWithNameEqualTo("http.server.requests", 1);
 
-		return TestObservationRegistryAssert.assertThat(this.observationRegistry)
-				.hasObservationWithNameEqualTo("http.server.requests")
-				.that()
+		return assertThat(this.observationRegistry).hasObservationWithNameEqualTo("http.server.requests").that()
 				.hasBeenStopped();
 	}
 

--- a/spring-web/src/test/java/org/springframework/web/filter/reactive/ServerHttpObservationFilterTests.java
+++ b/spring-web/src/test/java/org/springframework/web/filter/reactive/ServerHttpObservationFilterTests.java
@@ -137,7 +137,6 @@ class ServerHttpObservationFilterTests {
 	}
 
 	private TestObservationRegistryAssert.TestObservationRegistryAssertReturningObservationContextAssert assertThatHttpObservation() {
-		return TestObservationRegistryAssert.assertThat(this.observationRegistry)
-				.hasObservationWithNameEqualTo("http.server.requests").that();
+		return assertThat(this.observationRegistry).hasObservationWithNameEqualTo("http.server.requests").that();
 	}
 }

--- a/spring-web/src/test/java/org/springframework/web/server/adapter/HttpWebHandlerAdapterObservabilityTests.java
+++ b/spring-web/src/test/java/org/springframework/web/server/adapter/HttpWebHandlerAdapterObservabilityTests.java
@@ -95,8 +95,7 @@ class HttpWebHandlerAdapterObservabilityTests {
 	}
 
 	private TestObservationRegistryAssert.TestObservationRegistryAssertReturningObservationContextAssert assertThatHttpObservation() {
-		return TestObservationRegistryAssert.assertThat(this.observationRegistry)
-				.hasObservationWithNameEqualTo("http.server.requests").that();
+		return assertThat(this.observationRegistry).hasObservationWithNameEqualTo("http.server.requests").that();
 	}
 
 

--- a/spring-web/src/test/java/org/springframework/web/server/adapter/WebHttpHandlerBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/server/adapter/WebHttpHandlerBuilderTests.java
@@ -23,7 +23,6 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import io.micrometer.observation.tck.TestObservationRegistry;
-import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -171,8 +170,8 @@ class WebHttpHandlerBuilderTests {
 		handler.handle(MockServerHttpRequest.get("/").build(), response).block();
 
 		TestObservationRegistry observationRegistry = applicationContext.getBean(TestObservationRegistry.class);
-		TestObservationRegistryAssert.assertThat(observationRegistry).hasObservationWithNameEqualTo("http.server.requests")
-				.that().hasLowCardinalityKeyValue("uri", "UNKNOWN");
+		assertThat(observationRegistry).hasObservationWithNameEqualTo("http.server.requests").that()
+				.hasLowCardinalityKeyValue("uri", "UNKNOWN");
 	}
 
 	@Test

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientObservationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientObservationTests.java
@@ -183,8 +183,7 @@ class WebClientObservationTests {
 	}
 
 	private TestObservationRegistryAssert.TestObservationRegistryAssertReturningObservationContextAssert assertThatHttpObservation() {
-		return TestObservationRegistryAssert.assertThat(this.observationRegistry)
-				.hasObservationWithNameEqualTo("http.client.requests").that();
+		return assertThat(this.observationRegistry).hasObservationWithNameEqualTo("http.client.requests").that();
 	}
 
 	private ClientRequest verifyAndGetRequest() {


### PR DESCRIPTION
This PR replaces `TestObservationRegistryAssert.assertThat()` with `Assertions.assertThat()`.

See https://github.com/micrometer-metrics/micrometer/pull/5551