### PR TITLE
Skip runtime hint registration for validation constraint with missing dependencies

### DIFF
--- a/spring-context/src/main/java/org/springframework/validation/beanvalidation/BeanValidationBeanRegistrationAotProcessor.java
+++ b/spring-context/src/main/java/org/springframework/validation/beanvalidation/BeanValidationBeanRegistrationAotProcessor.java
@@ -43,6 +43,7 @@ import org.springframework.aot.hint.ReflectionHints;
 import org.springframework.beans.factory.aot.BeanRegistrationAotContribution;
 import org.springframework.beans.factory.aot.BeanRegistrationAotProcessor;
 import org.springframework.beans.factory.aot.BeanRegistrationCode;
+import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.RegisteredBean;
 import org.springframework.core.KotlinDetector;
 import org.springframework.core.ResolvableType;
@@ -98,7 +99,7 @@ class BeanValidationBeanRegistrationAotProcessor implements BeanRegistrationAotP
 
 		@Nullable
 		public static BeanRegistrationAotContribution processAheadOfTime(RegisteredBean registeredBean) {
-			if (validator == null) {
+			if (validator == null || BeanDefinition.ROLE_INFRASTRUCTURE == registeredBean.getMergedBeanDefinition().getRole()) {
 				return null;
 			}
 

--- a/spring-context/src/main/java/org/springframework/validation/beanvalidation/BeanValidationBeanRegistrationAotProcessor.java
+++ b/spring-context/src/main/java/org/springframework/validation/beanvalidation/BeanValidationBeanRegistrationAotProcessor.java
@@ -127,18 +127,19 @@ class BeanValidationBeanRegistrationAotProcessor implements BeanRegistrationAotP
 			try {
 				descriptor = validator.getConstraintsForClass(clazz);
 			}
-			catch (RuntimeException ex) {
+			catch (RuntimeException | LinkageError ex) {
+				String className = clazz.getName();
 				if (KotlinDetector.isKotlinType(clazz) && ex instanceof ArrayIndexOutOfBoundsException) {
 					// See https://hibernate.atlassian.net/browse/HV-1796 and https://youtrack.jetbrains.com/issue/KT-40857
-					logger.warn("Skipping validation constraint hint inference for class " + clazz +
+					logger.warn("Skipping validation constraint hint inference for class " + className +
 							" due to an ArrayIndexOutOfBoundsException at validator level");
 				}
 				else if (ex instanceof TypeNotPresentException) {
 					logger.debug("Skipping validation constraint hint inference for class " +
-							clazz + " due to a TypeNotPresentException at validator level: " + ex.getMessage());
+							className + " due to a TypeNotPresentException at validator level: " + ex.getMessage());
 				}
 				else {
-					logger.warn("Skipping validation constraint hint inference for class " + clazz, ex);
+					logger.warn("Skipping validation constraint hint inference for class " + className, ex);
 				}
 				return;
 			}


### PR DESCRIPTION
Prior to this commit, AOT processing for bean validation failed with `NoClassDefFoundError` for constraints with missing dependencies. With this change, the processing no longer fails, and a warning is logged instead.

- Fixes #33940

<details><summary>Example Log Message</summary>

```
16:16:31.245 [Test worker] WARN  o.s.v.b.BeanValidationBeanRegistrationAotProcessor - Skipping validation constraint hint inference for class org.springframework.validation.beanvalidation.BeanValidationBeanRegistrationAotProcessorTests$ConstraintWithMissingDependency
java.lang.NoClassDefFoundError: org.springframework.validation.beanvalidation.BeanValidationBeanRegistrationAotProcessorTests$Filtered
	at org.springframework.validation.beanvalidation.BeanValidationBeanRegistrationAotProcessorTests$FilteringClassLoader.loadClassForOverriding(BeanValidationBeanRegistrationAotProcessorTests.java:278) ~[test/:?]
	at org.springframework.core.OverridingClassLoader.loadClass(OverridingClassLoader.java:88) ~[spring-core-7.0.0-SNAPSHOT.jar:7.0.0-SNAPSHOT]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525) ~[?:?]
	at org.springframework.core.OverridingClassLoader.loadClass(OverridingClassLoader.java:82) ~[spring-core-7.0.0-SNAPSHOT.jar:7.0.0-SNAPSHOT]
	at java.base/java.lang.Class.getDeclaredFields0(Native Method) ~[?:?]
	at java.base/java.lang.Class.privateGetDeclaredFields(Class.java:3297) ~[?:?]
	at java.base/java.lang.Class.getDeclaredFields(Class.java:2371) ~[?:?]
	at org.hibernate.validator.internal.util.privilegedactions.GetDeclaredFields.run(GetDeclaredFields.java:30) ~[hibernate-validator-7.0.5.Final.jar:7.0.5.Final]
	at org.hibernate.validator.internal.util.privilegedactions.GetDeclaredFields.run(GetDeclaredFields.java:17) ~[hibernate-validator-7.0.5.Final.jar:7.0.5.Final]
	at org.hibernate.validator.internal.metadata.provider.AnnotationMetaDataProvider.run(AnnotationMetaDataProvider.java:602) ~[hibernate-validator-7.0.5.Final.jar:7.0.5.Final]
	at org.hibernate.validator.internal.metadata.provider.AnnotationMetaDataProvider.getFieldMetaData(AnnotationMetaDataProvider.java:217) ~[hibernate-validator-7.0.5.Final.jar:7.0.5.Final]
	at org.hibernate.validator.internal.metadata.provider.AnnotationMetaDataProvider.retrieveBeanConfiguration(AnnotationMetaDataProvider.java:130) ~[hibernate-validator-7.0.5.Final.jar:7.0.5.Final]
	at org.hibernate.validator.internal.metadata.provider.AnnotationMetaDataProvider.getBeanConfiguration(AnnotationMetaDataProvider.java:121) ~[hibernate-validator-7.0.5.Final.jar:7.0.5.Final]
	at org.hibernate.validator.internal.metadata.BeanMetaDataManagerImpl.getBeanConfigurationForHierarchy(BeanMetaDataManagerImpl.java:234) ~[hibernate-validator-7.0.5.Final.jar:7.0.5.Final]
	at org.hibernate.validator.internal.metadata.BeanMetaDataManagerImpl.createBeanMetaData(BeanMetaDataManagerImpl.java:201) ~[hibernate-validator-7.0.5.Final.jar:7.0.5.Final]
	at org.hibernate.validator.internal.metadata.BeanMetaDataManagerImpl.getBeanMetaData(BeanMetaDataManagerImpl.java:165) ~[hibernate-validator-7.0.5.Final.jar:7.0.5.Final]
	at org.hibernate.validator.internal.engine.ValidatorImpl.getConstraintsForClass(ValidatorImpl.java:316) ~[hibernate-validator-7.0.5.Final.jar:7.0.5.Final]
	at org.springframework.validation.beanvalidation.BeanValidationBeanRegistrationAotProcessor$BeanValidationDelegate.processAheadOfTime(BeanValidationBeanRegistrationAotProcessor.java:125) ~[main/:?]
	at org.springframework.validation.beanvalidation.BeanValidationBeanRegistrationAotProcessor$BeanValidationDelegate.processAheadOfTime(BeanValidationBeanRegistrationAotProcessor.java:110) ~[main/:?]
	at org.springframework.validation.beanvalidation.BeanValidationBeanRegistrationAotProcessor.processAheadOfTime(BeanValidationBeanRegistrationAotProcessor.java:75) ~[main/:?]
	at org.springframework.validation.beanvalidation.BeanValidationBeanRegistrationAotProcessorTests.createContribution(BeanValidationBeanRegistrationAotProcessorTests.java:144) ~[test/:?]
	at org.springframework.validation.beanvalidation.BeanValidationBeanRegistrationAotProcessorTests.process(BeanValidationBeanRegistrationAotProcessorTests.java:134) ~[test/:?]
	at org.springframework.validation.beanvalidation.BeanValidationBeanRegistrationAotProcessorTests.shouldSkipConstraintWithMissingDependency(BeanValidationBeanRegistrationAotProcessorTests.java:129) ~[test/:?]
```

</details> 