### PR TITLE
Avoid infinite recursion in BeanValidationBeanRegistrationAotProcessor with recursive generics

### DIFF
--- a/spring-context/src/main/java/org/springframework/validation/beanvalidation/BeanValidationBeanRegistrationAotProcessor.java
+++ b/spring-context/src/main/java/org/springframework/validation/beanvalidation/BeanValidationBeanRegistrationAotProcessor.java
@@ -18,7 +18,6 @@ package org.springframework.validation.beanvalidation;
 
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -104,10 +103,11 @@ class BeanValidationBeanRegistrationAotProcessor implements BeanRegistrationAotP
 			}
 
 			Class<?> beanClass = registeredBean.getBeanClass();
+			Set<Class<?>> visitedClasses = new HashSet<>();
 			Set<Class<?>> validatedClasses = new HashSet<>();
 			Set<Class<? extends ConstraintValidator<?, ?>>> constraintValidatorClasses = new HashSet<>();
 
-			processAheadOfTime(beanClass, validatedClasses, constraintValidatorClasses);
+			processAheadOfTime(beanClass, visitedClasses, validatedClasses, constraintValidatorClasses);
 
 			if (!validatedClasses.isEmpty() || !constraintValidatorClasses.isEmpty()) {
 				return new AotContribution(validatedClasses, constraintValidatorClasses);
@@ -115,9 +115,12 @@ class BeanValidationBeanRegistrationAotProcessor implements BeanRegistrationAotP
 			return null;
 		}
 
-		private static void processAheadOfTime(Class<?> clazz, Collection<Class<?>> validatedClasses,
-				Collection<Class<? extends ConstraintValidator<?, ?>>> constraintValidatorClasses) {
+		private static void processAheadOfTime(Class<?> clazz, Set<Class<?>> visitedClasses, Set<Class<?>> validatedClasses,
+				Set<Class<? extends ConstraintValidator<?, ?>>> constraintValidatorClasses) {
 
+			if (!visitedClasses.add(clazz)) {
+				return;
+			}
 			Assert.notNull(validator, "Validator can't be null");
 
 			BeanDescriptor descriptor;
@@ -149,12 +152,12 @@ class BeanValidationBeanRegistrationAotProcessor implements BeanRegistrationAotP
 
 			ReflectionUtils.doWithFields(clazz, field -> {
 				Class<?> type = field.getType();
-				if (Iterable.class.isAssignableFrom(type) || List.class.isAssignableFrom(type) || Optional.class.isAssignableFrom(type)) {
+				if (Iterable.class.isAssignableFrom(type) || Optional.class.isAssignableFrom(type)) {
 					ResolvableType resolvableType = ResolvableType.forField(field);
 					Class<?> genericType = resolvableType.getGeneric(0).toClass();
 					if (shouldProcess(genericType)) {
 						validatedClasses.add(clazz);
-						processAheadOfTime(genericType, validatedClasses, constraintValidatorClasses);
+						processAheadOfTime(genericType, visitedClasses, validatedClasses, constraintValidatorClasses);
 					}
 				}
 				if (Map.class.isAssignableFrom(type)) {
@@ -163,11 +166,11 @@ class BeanValidationBeanRegistrationAotProcessor implements BeanRegistrationAotP
 					Class<?> valueGenericType = resolvableType.getGeneric(1).toClass();
 					if (shouldProcess(keyGenericType)) {
 						validatedClasses.add(clazz);
-						processAheadOfTime(keyGenericType, validatedClasses, constraintValidatorClasses);
+						processAheadOfTime(keyGenericType, visitedClasses, validatedClasses, constraintValidatorClasses);
 					}
 					if (shouldProcess(valueGenericType)) {
 						validatedClasses.add(clazz);
-						processAheadOfTime(valueGenericType, validatedClasses, constraintValidatorClasses);
+						processAheadOfTime(valueGenericType, visitedClasses, validatedClasses, constraintValidatorClasses);
 					}
 				}
 			});


### PR DESCRIPTION
Prior to this commit, AOT processing for bean validation failed with `StackOverflowError` for constraints with fields having recursive generic types. With this change, the processing aborts preemptively when a cycle is detected.

- Fixes #33936