### PR TITLE
PathMatchingResourcePatternResolver should not log directory-skip messages at info level

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/support/PathMatchingResourcePatternResolver.java
+++ b/spring-core/src/main/java/org/springframework/core/io/support/PathMatchingResourcePatternResolver.java
@@ -978,8 +978,8 @@ public class PathMatchingResourcePatternResolver implements ResourcePatternResol
 		}
 
 		if (!Files.exists(rootPath)) {
-			if (logger.isInfoEnabled()) {
-				logger.info("Skipping search for files matching pattern [%s]: directory [%s] does not exist"
+			if (logger.isDebugEnabled()) {
+				logger.debug("Skipping search for files matching pattern [%s]: directory [%s] does not exist"
 						.formatted(subPattern, rootPath.toAbsolutePath()));
 			}
 			return result;


### PR DESCRIPTION
Fixed as suggested in the https://github.com/spring-projects/spring-framework/issues/33954#issuecomment-2497550624
---

## Fixes:
- #33954: switch to debug log level 
