### PR TITLE
AsyncExecution fails to detect the return type of an annotated method from an interface with a generic

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/interceptor/AsyncExecutionInterceptor.java
+++ b/spring-aop/src/main/java/org/springframework/aop/interceptor/AsyncExecutionInterceptor.java
@@ -61,6 +61,7 @@ import org.springframework.lang.Nullable;
  * @author Juergen Hoeller
  * @author Chris Beams
  * @author Stephane Nicoll
+ * @author Bao Ngo
  * @since 3.0
  * @see org.springframework.scheduling.annotation.Async
  * @see org.springframework.scheduling.annotation.AsyncAnnotationAdvisor

--- a/spring-aop/src/main/java/org/springframework/aop/interceptor/AsyncExecutionInterceptor.java
+++ b/spring-aop/src/main/java/org/springframework/aop/interceptor/AsyncExecutionInterceptor.java
@@ -17,6 +17,7 @@
 package org.springframework.aop.interceptor;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
@@ -125,7 +126,16 @@ public class AsyncExecutionInterceptor extends AsyncExecutionAspectSupport imple
 			return null;
 		};
 
-		return doSubmit(task, executor, invocation.getMethod().getReturnType());
+		return doSubmit( task, executor, determineReturnType( invocation, userMethod ) );
+	}
+
+	private static Class<?> determineReturnType(MethodInvocation invocation, Method userMethod) {
+		Method originalMethod = invocation.getMethod();
+		if( Modifier.isAbstract( originalMethod.getModifiers() ) ) {
+			return userMethod.getReturnType();
+		}
+
+		return originalMethod.getReturnType();
 	}
 
 	/**

--- a/spring-aop/src/test/java/org/springframework/aop/interceptor/AsyncExecutionInterceptorTests.java
+++ b/spring-aop/src/test/java/org/springframework/aop/interceptor/AsyncExecutionInterceptorTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aop.interceptor;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.springframework.core.task.AsyncTaskExecutor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+
+/**
+ * Tests for {@link AsyncExecutionInterceptor}.
+ *
+ * @author Bao Ngo
+ * @since 7.0
+ */
+class AsyncExecutionInterceptorTests {
+
+	@Test
+	public void testInvokeOnInterface() throws Throwable {
+		AsyncExecutionInterceptor interceptor = spy( new AsyncExecutionInterceptor( null ) );
+		Impl impl = new Impl();
+		ArgumentCaptor<Class<?>> classArgumentCaptor = ArgumentCaptor.forClass( Class.class );
+		MethodInvocation mi = mock();
+		given( mi.getThis() ).willReturn( impl );
+		given( mi.getMethod() ).willReturn( I.class.getMethod( "doSomeThing" ) );
+		interceptor.invoke( mi );
+		verify( interceptor ).doSubmit(
+				any( Callable.class ),
+				any( AsyncTaskExecutor.class ),
+				classArgumentCaptor.capture()
+		);
+		assertThat( classArgumentCaptor.getValue() ).isEqualTo( Future.class );
+	}
+
+
+	private interface I<O> {
+		O doSomeThing();
+	}
+
+	private static final class Impl implements I<Future<Void>> {
+		@Override
+		public Future<Void> doSomeThing() {
+			return CompletableFuture.runAsync( () -> {
+			} );
+		}
+	}
+}


### PR DESCRIPTION
The last param of `AsyncExecutionAspectSupport.doSubmit` is a return type, which can be get from the `invocation`. But in case of interface with paramter type like:
```java
interface Service<O> {
  O doSomething();
}

class DefaultAsyncService implements Service<Future<String>> {
  @Override
  @Async
  public Future<String> doSomething() {
   return CompletableFuture.abc();
  }
}

@RestController
class Controller {
  @Autowire
  Service<Future<String>> service;

  @GetMapping
  public Future<String> api() {
    return service.doSomething();
  }
}
```
Return type retuned by `invocation.getMethod().getReturnType()` will be `Object` because we invoke `doSomething` by the interface, not by the impl.
My PR try to fix that