### PR TITLE
Fix a typo in the filters documentation

### DIFF
--- a/framework-docs/modules/ROOT/pages/web/webmvc/filters.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc/filters.adoc
@@ -30,7 +30,7 @@ available through the `ServletRequest.getParameter{asterisk}()` family of method
 
 
 
-[[forwarded-headers]]
+[[filters-forwarded-headers]]
 == Forwarded Headers
 [.small]#xref:web/webflux/reactive-spring.adoc#webflux-forwarded-headers[See equivalent in the Reactive stack]#
 


### PR DESCRIPTION
When I click [Forwarded Headers](https://docs.spring.io/spring-framework/reference/6.1/web/webmvc/filters.html#filters-forwarded-headers), page does not go to Forwarded Headers section
