### PR TITLE
fix: Ensure protocol slashes are preserved in `getSanitizedPath`

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -908,16 +908,20 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 		}
 
 		private static String getSanitizedPath(final StringBuilder path) {
-			int index = path.indexOf("//");
-			if (index >= 0) {
-				StringBuilder sanitized = new StringBuilder(path);
-				while (index != -1) {
-					sanitized.deleteCharAt(index);
-					index = sanitized.indexOf("//", index);
-				}
-				return sanitized.toString();
+			String pathString = path.toString();
+			int protocolIndex = pathString.indexOf("://");
+			boolean hasProtocol = protocolIndex != -1;
+
+			if (hasProtocol) {
+				String protocol = path.substring(0, protocolIndex + 3);
+				String restOfPath = path.substring(protocolIndex + 3);
+
+				String sanitizedRestPath = restOfPath.replaceAll("/{2,}", "/");
+
+				return protocol + sanitizedRestPath;
 			}
-			return path.toString();
+
+			return pathString.replaceAll("/{2,}", "/");
 		}
 
 		public void removeTrailingSlash() {

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.web.util;
 
+import java.lang.reflect.Method;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
@@ -917,7 +918,7 @@ class UriComponentsBuilderTests {
 					.findFirst()
 					.orElseThrow(() -> new ClassNotFoundException("FullPathComponentBuilder not found"));
 
-			var method = innerClass.getDeclaredMethod("getSanitizedPath", StringBuilder.class);
+			Method method = innerClass.getDeclaredMethod("getSanitizedPath", StringBuilder.class);
 			method.setAccessible(true);
 			return (String) method.invoke(null, path);
 		} catch (Exception e) {

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -902,7 +902,7 @@ class UriComponentsBuilderTests {
 
 	private static Stream<Arguments> providePathsForSanitization() {
 		return Stream.of(
-				Arguments.of(new StringBuilder("http://example.com//path/to//resource"), "http://example.com/path/to/resource"),
+				Arguments.of(new StringBuilder("https://example.com//path/to//resource"), "https://example.com/path/to/resource"),
 				Arguments.of(new StringBuilder("https://example.com//path"), "https://example.com/path"),
 				Arguments.of(new StringBuilder("example.com//path"), "example.com/path"),
 				Arguments.of(new StringBuilder("example.com//////////////path//to"), "example.com/path/to")

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -25,11 +25,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder.ParserType;
@@ -888,6 +891,38 @@ class UriComponentsBuilderTests {
 				.buildAndExpand(7777, "test")
 				.toUri();
 		assertThat(uri.toString()).isEqualTo("ws://localhost:7777/test");
+	}
+
+	@ParameterizedTest
+	@MethodSource("providePathsForSanitization")
+	void verifySanitizedPath(StringBuilder inputPath, String expected) {
+		assertThat(invokeGetSanitizedPath(inputPath)).isEqualTo(expected);
+	}
+
+	private static Stream<Arguments> providePathsForSanitization() {
+		return Stream.of(
+				Arguments.of(new StringBuilder("http://example.com//path/to//resource"), "http://example.com/path/to/resource"),
+				Arguments.of(new StringBuilder("https://example.com//path"), "https://example.com/path"),
+				Arguments.of(new StringBuilder("example.com//path"), "example.com/path"),
+				Arguments.of(new StringBuilder("example.com//////////////path//to"), "example.com/path/to")
+		);
+	}
+
+	private String invokeGetSanitizedPath(StringBuilder path) {
+		try {
+			Class<?> outerClass = Class.forName("org.springframework.web.util.UriComponentsBuilder");
+
+			Class<?> innerClass = Arrays.stream(outerClass.getDeclaredClasses())
+					.filter(clazz -> clazz.getSimpleName().equals("FullPathComponentBuilder"))
+					.findFirst()
+					.orElseThrow(() -> new ClassNotFoundException("FullPathComponentBuilder not found"));
+
+			var method = innerClass.getDeclaredMethod("getSanitizedPath", StringBuilder.class);
+			method.setAccessible(true);
+			return (String) method.invoke(null, path);
+		} catch (Exception e) {
+			throw new RuntimeException("Failed to invoke getSanitizedPath", e);
+		}
 	}
 
 }

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -32,8 +32,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
-
 import org.junit.jupiter.params.provider.MethodSource;
+
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder.ParserType;
@@ -921,7 +921,8 @@ class UriComponentsBuilderTests {
 			Method method = innerClass.getDeclaredMethod("getSanitizedPath", StringBuilder.class);
 			method.setAccessible(true);
 			return (String) method.invoke(null, path);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			throw new RuntimeException("Failed to invoke getSanitizedPath", e);
 		}
 	}


### PR DESCRIPTION
## Description
When using `WebClient` with `UriBuilder` to construct URIs, I encountered a problem where the protocol's double slashes (`://`) were incorrectly reduced to a single slash (`:/`).
As a result, malformed URIs such as **http:`/`jsonplaceholder.typicode.com/users** were generated, causing WebClient to throw a `Host is not specified` exception.
This prevented the request from reaching the server and resulted in a `500 error`.

This behavior occurred because the `getSanitizedPath` method in the `UriComponentsBuilder class` attempted to remove redundant slashes, but inadvertently changed the protocol structure by failing to preserve the `://` delimiter.


## Error Sample
```
org.springframework.web.reactive.function.client.WebClientRequestException: Host is not specified
	at org.springframework.web.reactive.function.client.ExchangeFunctions$DefaultExchangeFunction.lambda$wrapException$9(ExchangeFunctions.java:137) ~[spring-webflux-6.2.0.jar:6.2.0]
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException: 
Assembly trace from producer [reactor.core.publisher.MonoErrorSupplied] :
	reactor.core.publisher.Mono.error(Mono.java:315)
	org.springframework.web.reactive.function.client.ExchangeFunctions$DefaultExchangeFunction.wrapException(ExchangeFunctions.java:137)
Error has been observed at the following site(s):
	*____________Mono.error ⇢ at org.springframework.web.reactive.function.client.ExchangeFunctions$DefaultExchangeFunction.wrapException(ExchangeFunctions.java:137)
	*____Mono.onErrorResume ⇢ at org.springframework.web.reactive.function.client.ExchangeFunctions$DefaultExchangeFunction.exchange(ExchangeFunctions.java:106)
	|_             Mono.map ⇢ at org.springframework.web.reactive.function.client.ExchangeFunctions$DefaultExchangeFunction.exchange(ExchangeFunctions.java:107)
	|_        Mono.doOnNext ⇢ at org.springframework.web.reactive.function.client.DefaultWebClient$ObservationFilterFunction.filter(DefaultWebClient.java:745)
	*____________Mono.defer ⇢ at org.springframework.web.reactive.function.client.DefaultWebClient$DefaultRequestBodyUriSpec.lambda$exchange$12(DefaultWebClient.java:467)
	|_           checkpoint ⇢ Request to GET http:/jsonplaceholder.typicode.com/users [DefaultWebClient]
	|_   Mono.switchIfEmpty ⇢ at 
...
```

## Changes
- Refined logic to ensure protocol slashes are preserved.
- Cleaned up redundant slashes in the path without affecting the protocol.

## Test
- To validate and fix this behavior, I tested the **private** `getSanitizedPath` method using **reflection**. 
   - Since the method is private and part of an internal class, reflection was necessary to access and evaluate its behavior in isolation.
- Verified with multiple inputs, including paths with and without protocols, to ensure correct behavior.

| AS-IS (Existing Issue) | TO-BE (Fixed Behavior) |
|-------|--------|
| <img width="1579" alt="스크린샷 2024-11-27 오후 11 50 32" src="https://github.com/user-attachments/assets/e3c9da74-5156-492d-82c8-b193ab1860c1"> | <img width="1579" alt="image" src="https://github.com/user-attachments/assets/2f878196-26f6-4799-ae31-95bc477d6405">|

## Example Test Case
Input: `http://example.com//path/to//resource`  
Output: `http://example.com/path/to/resource`

Input: `https://example.com//path`  
Output: `https://example.com/path`

Input: `example.com//path`  
Output: `example.com/path`
