### PR TITLE
Refactor getHeaders() method to use early return

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/AbstractClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/AbstractClientHttpRequest.java
@@ -50,13 +50,11 @@ public abstract class AbstractClientHttpRequest implements ClientHttpRequest {
 		if (this.readOnlyHeaders != null) {
 			return this.readOnlyHeaders;
 		}
-		else if (this.executed) {
+		if (this.executed) {
 			this.readOnlyHeaders = HttpHeaders.readOnlyHttpHeaders(this.headers);
 			return this.readOnlyHeaders;
 		}
-		else {
-			return this.headers;
-		}
+		return this.headers;
 	}
 
 	@Override


### PR DESCRIPTION
## Changes & Considerations

- In this case, the if-else if structure was used for the conditions, but since there aren’t too many scattered branches, I thought it might be better to refactor the code for readability using an early return approach. So, I’ve proposed the following changes!