### PR TITLE
Include exception trace and causes into a log produced by AbstractApplicationContext#refresh

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
+++ b/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
@@ -629,10 +629,8 @@ public abstract class AbstractApplicationContext extends DefaultResourceLoader
 			}
 
 			catch (RuntimeException | Error ex ) {
-				if (logger.isWarnEnabled()) {
-					logger.warn("Exception encountered during context initialization - " +
-							"cancelling refresh attempt: " + ex);
-				}
+				logger.warn("Exception encountered during context initialization - " +
+						"cancelling refresh attempt", ex);
 
 				// Destroy already created singletons to avoid dangling resources.
 				destroyBeans();


### PR DESCRIPTION
This PR fixes an issue that AbstractApplicationContext#refresh loses the stack trace and the causes of the happening exception. 

Closes #34007