### PR TITLE
Fix ApplicationListener no longer invoked for generic ApplicationEvent

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/ResolvableType.java
+++ b/spring-core/src/main/java/org/springframework/core/ResolvableType.java
@@ -342,15 +342,14 @@ public class ResolvableType implements Serializable {
 				return (ourBounds.isSameKind(typeBounds) &&
 						ourBounds.isAssignableFrom(typeBounds.getBounds(), matchedBefore));
 			}
-			else if (upUntilUnresolvable) {
+			if (upUntilUnresolvable || other.isUnresolvableTypeVariable()) {
 				return typeBounds.isAssignableFrom(this, matchedBefore);
 			}
-			else if (!exactMatch) {
+			if (!exactMatch) {
 				return typeBounds.isAssignableTo(this, matchedBefore);
 			}
-			else {
-				return false;
-			}
+
+			return false;
 		}
 
 		// In the form <? extends Number> is assignable to X...


### PR DESCRIPTION
Fix #33982
In case `typeBounds` WildcardBounds has `TypeVariable` bound, we should check whether `typeBounds` isAssignableFrom the current ResolvableType or not

NOTE:
1. I'm new contributor, so my code might be not perfect. But please give feebacks, I will try to address them!
2. Do you think we nee to handle case `typeBounds` WildcardBounds has `WildcardType` bound? If yes, I will add some more commits!

Thank you!!