### PR TITLE
Fix link to MockMvcBuilders in reference documentation

### DIFF
--- a/framework-docs/modules/ROOT/pages/testing/webtestclient.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/webtestclient.adoc
@@ -127,7 +127,7 @@ Kotlin::
 ======
 
 For Spring MVC, use the following where the Spring `ApplicationContext` is passed to
-{spring-framework-api}/test/web/servlet/setup/MockMvcBuilders.html#webAppContextSetup-org.springframework.web.context.WebApplicationContext-[MockMvcBuilders.webAppContextSetup]
+{spring-framework-api}/test/web/servlet/setup/MockMvcBuilders.html#webAppContextSetup(org.springframework.web.context.WebApplicationContext)[MockMvcBuilders.webAppContextSetup]
 to create a xref:testing/mockmvc.adoc[MockMvc] instance to handle
 requests:
 


### PR DESCRIPTION
Javadoc page does not go to `MockMvcBuilders#webAppContextSetup`

Reference 

https://docs.spring.io/spring-framework/reference/7.0-SNAPSHOT/testing/webtestclient.html