### PR TITLE
Refactor ResourceRegionHttpMessageConverter

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/ResourceRegionHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/ResourceRegionHttpMessageConverter.java
@@ -140,19 +140,15 @@ public class ResourceRegionHttpMessageConverter extends AbstractGenericHttpMessa
 
 	@Override
 	protected boolean supportsRepeatableWrites(Object object) {
-		if (object instanceof ResourceRegion resourceRegion) {
-			return supportsRepeatableWrites(resourceRegion);
-		}
-		else {
-			@SuppressWarnings("unchecked")
-			Collection<ResourceRegion> regions = (Collection<ResourceRegion>) object;
-			for (ResourceRegion region : regions) {
-				if (!supportsRepeatableWrites(region)) {
-					return false;
-				}
-			}
-			return true;
-		}
+		return (object instanceof ResourceRegion resourceRegion) ?
+				supportsRepeatableWrites(resourceRegion) :
+				supportsRepeatableWritesInRegionCollection(object);
+	}
+
+	private boolean supportsRepeatableWritesInRegionCollection(Object object) {
+		@SuppressWarnings("unchecked")
+		Collection<ResourceRegion> resourceRegions = (Collection<ResourceRegion>) object;
+		return resourceRegions.stream().allMatch(this::supportsRepeatableWrites);
 	}
 
 	private boolean supportsRepeatableWrites(ResourceRegion region) {

--- a/spring-web/src/test/java/org/springframework/http/converter/ResourceRegionHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/ResourceRegionHttpMessageConverterTests.java
@@ -25,10 +25,10 @@ import java.util.List;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
-
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;

--- a/spring-web/src/test/java/org/springframework/http/converter/ResourceRegionHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/ResourceRegionHttpMessageConverterTests.java
@@ -22,9 +22,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
@@ -179,6 +183,26 @@ class ResourceRegionHttpMessageConverterTests {
 		assertThat(ranges[13]).isEqualTo("Content-Type: text/plain");
 		assertThat(ranges[14]).isEqualTo("Content-Range: bytes 20-29/39");
 		assertThat(ranges[15]).isEqualTo("t resource");
+	}
+
+	@Test
+	void testSingleResourceRegionSupportsRepeatableWrites() {
+		ResourceRegion region = mock(ResourceRegion.class);
+		assertThat(converter.supportsRepeatableWrites(region)).isTrue();
+	}
+
+	@ParameterizedTest
+	@MethodSource("regionCollections")
+	void testCollectionOfResourceRegionSupportsRepeatableWrites(Object regionCollection, boolean expected) {
+		assertThat(converter.supportsRepeatableWrites(regionCollection)).isEqualTo(expected);
+	}
+
+	static Stream<Arguments> regionCollections() {
+		return Stream.of(
+				Arguments.of(Collections.emptyList(), true),
+				Arguments.of(Collections.singletonList(mock(ResourceRegion.class)), true),
+				Arguments.of(List.of(mock(ResourceRegion.class), mock(ResourceRegion.class)), true)
+		);
 	}
 
 	@Test // SPR-15041


### PR DESCRIPTION
Extract collection handling into a separate method and use a stream-based all-match check to improve readability and maintainability. 
Also introduce new test cases to verify functionality and reliability of the supportsRepeatableWrites function.