### PR TITLE
Add getters to ServerResponseResultHandler

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/support/ServerResponseResultHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/support/ServerResponseResultHandler.java
@@ -47,6 +47,12 @@ public class ServerResponseResultHandler implements HandlerResultHandler, Initia
 
 	private int order = 0;
 
+	/**
+	 * Return the configured {@link HttpMessageWriter}'s.
+	 */
+	public List<HttpMessageWriter<?>> getMessageWriters() {
+		return this.messageWriters;
+	}
 
 	/**
 	 * Configure HTTP message writers to serialize the request body with.
@@ -56,6 +62,16 @@ public class ServerResponseResultHandler implements HandlerResultHandler, Initia
 		this.messageWriters = configurer;
 	}
 
+	/**
+	 * Return the configured {@link ViewResolver}'s.
+	 */
+	public List<ViewResolver> getViewResolvers() {
+		return this.viewResolvers;
+	}
+
+	/**
+	 * Set the current view resolvers.
+	 */
 	public void setViewResolvers(List<ViewResolver> viewResolvers) {
 		this.viewResolvers = viewResolvers;
 	}


### PR DESCRIPTION
I have a case where I'd like to configure the message writers of `ServerResponseResultHandler` without completely replacing the ones configured by `ServerCodecConfigurer`. Therefore, I've added the corresponding getter methods to the already existing setter methods.
I based this on the form of the `AbstractMessageWriterResultHandler`, where they are also already present.
Thank your very much for your effort in advance! Let me know if there are questions ore any suggestions for improvement.