### PR TITLE
Prevent execution of Antora jobs on forks

### DIFF
--- a/.github/workflows/update-antora-ui-spring.yml
+++ b/.github/workflows/update-antora-ui-spring.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   update-antora-ui-spring:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'spring-projects'
     name: Update on Supported Branches
     strategy:
       matrix:
@@ -26,6 +27,7 @@ jobs:
           antora-file-path: 'framework-docs/antora-playbook.yml'
   update-antora-ui-spring-docs-build:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'spring-projects'
     name: Update on docs-build
     steps:
       - uses: spring-io/spring-doc-actions/update-antora-spring-ui@5a57bcc6a0da2a1474136cf29571b277850432bc


### PR DESCRIPTION
Prior to this commit, any fork that copied the `main` branch only experienced daily failures at 10am UTC due to the scheduled execution of the `update-antora-ui-spring` workflow. With this change, the workflow jobs are executed only when under the `spring-projects` GitHub organization.

The failures of my fork: https://github.com/scordio/spring-framework/actions/workflows/update-antora-ui-spring.yml

An alternative solution would be [disabling the workflow](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/disabling-and-enabling-a-workflow#disabling-a-workflow) on each affected fork.