### PR TITLE
Allow customization of cookie parsing in Jetty and JDK HttpClient connectors

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/reactive/JdkClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/JdkClientHttpConnector.java
@@ -28,6 +28,8 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Flow;
 import java.util.function.Function;
 
+import org.springframework.http.support.DefaultHttpCookieParser;
+import org.springframework.http.support.HttpCookieParser;
 import reactor.core.publisher.Mono;
 
 import org.springframework.core.io.buffer.DataBufferFactory;
@@ -49,6 +51,8 @@ public class JdkClientHttpConnector implements ClientHttpConnector {
 	private final HttpClient httpClient;
 
 	private DataBufferFactory bufferFactory = DefaultDataBufferFactory.sharedInstance;
+
+	private HttpCookieParser httpCookieParser = new DefaultHttpCookieParser();
 
 	@Nullable
 	private Duration readTimeout;
@@ -106,6 +110,16 @@ public class JdkClientHttpConnector implements ClientHttpConnector {
 		this.readTimeout = readTimeout;
 	}
 
+	/**
+	 * Set the {@code HttpCookieParser} to be used in response parsing.
+	 * <p>Default is {@code DefaultHttpCookieParser} based on {@code java.net.HttpCookie} capabilities</p>
+	 * @param httpCookieParser
+	 */
+	public void setHttpCookieParser(HttpCookieParser httpCookieParser) {
+		Assert.notNull(readTimeout, "httpCookieParser is required");
+		this.httpCookieParser = httpCookieParser;
+	}
+
 
 	@Override
 	public Mono<ClientHttpResponse> connect(
@@ -121,7 +135,7 @@ public class JdkClientHttpConnector implements ClientHttpConnector {
 					this.httpClient.sendAsync(httpRequest, HttpResponse.BodyHandlers.ofPublisher());
 
 			return Mono.fromCompletionStage(future)
-					.map(response -> new JdkClientHttpResponse(response, this.bufferFactory));
+					.map(response -> new JdkClientHttpResponse(response, this.bufferFactory, this.httpCookieParser));
 		}));
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/JdkClientHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/JdkClientHttpResponse.java
@@ -16,7 +16,20 @@
 
 package org.springframework.http.client.reactive;
 
-import java.net.HttpCookie;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.core.io.buffer.DataBufferFactory;
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.support.HttpCookieParser;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.LinkedCaseInsensitiveMap;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import reactor.adapter.JdkFlowAdapter;
+import reactor.core.publisher.Flux;
+
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
 import java.nio.ByteBuffer;
@@ -25,23 +38,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.Flow;
 import java.util.function.Function;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import reactor.adapter.JdkFlowAdapter;
-import reactor.core.publisher.Flux;
-
-import org.springframework.core.io.buffer.DataBuffer;
-import org.springframework.core.io.buffer.DataBufferFactory;
-import org.springframework.core.io.buffer.DataBufferUtils;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatusCode;
-import org.springframework.http.ResponseCookie;
-import org.springframework.lang.Nullable;
-import org.springframework.util.CollectionUtils;
-import org.springframework.util.LinkedCaseInsensitiveMap;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 
 /**
  * {@link ClientHttpResponse} for the Java {@link HttpClient}.
@@ -52,16 +48,12 @@ import org.springframework.util.MultiValueMap;
  */
 class JdkClientHttpResponse extends AbstractClientHttpResponse {
 
-	private static final Pattern SAME_SITE_PATTERN = Pattern.compile("(?i).*SameSite=(Strict|Lax|None).*");
-
-
-
 	public JdkClientHttpResponse(HttpResponse<Flow.Publisher<List<ByteBuffer>>> response,
-			DataBufferFactory bufferFactory) {
+			DataBufferFactory bufferFactory, HttpCookieParser httpCookieParser) {
 
 		super(HttpStatusCode.valueOf(response.statusCode()),
 				adaptHeaders(response),
-				adaptCookies(response),
+				adaptCookies(response, httpCookieParser),
 				adaptBody(response, bufferFactory)
 		);
 	}
@@ -74,27 +66,13 @@ class JdkClientHttpResponse extends AbstractClientHttpResponse {
 		return HttpHeaders.readOnlyHttpHeaders(multiValueMap);
 	}
 
-	private static MultiValueMap<String, ResponseCookie> adaptCookies(HttpResponse<Flow.Publisher<List<ByteBuffer>>> response) {
+	private static MultiValueMap<String, ResponseCookie> adaptCookies(HttpResponse<Flow.Publisher<List<ByteBuffer>>> response,
+																	  HttpCookieParser httpCookieParser) {
 		return response.headers().allValues(HttpHeaders.SET_COOKIE).stream()
-				.flatMap(header -> {
-					Matcher matcher = SAME_SITE_PATTERN.matcher(header);
-					String sameSite = (matcher.matches() ? matcher.group(1) : null);
-					return HttpCookie.parse(header).stream().map(cookie -> toResponseCookie(cookie, sameSite));
-				})
+				.flatMap(httpCookieParser::parse)
 				.collect(LinkedMultiValueMap::new,
 						(cookies, cookie) -> cookies.add(cookie.getName(), cookie),
 						LinkedMultiValueMap::addAll);
-	}
-
-	private static ResponseCookie toResponseCookie(HttpCookie cookie, @Nullable String sameSite) {
-		return ResponseCookie.from(cookie.getName(), cookie.getValue())
-				.domain(cookie.getDomain())
-				.httpOnly(cookie.isHttpOnly())
-				.maxAge(cookie.getMaxAge())
-				.path(cookie.getPath())
-				.secure(cookie.getSecure())
-				.sameSite(sameSite)
-				.build();
 	}
 
 	private static Flux<DataBuffer> adaptBody(HttpResponse<Flow.Publisher<List<ByteBuffer>>> response, DataBufferFactory bufferFactory) {

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/JettyClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/JettyClientHttpConnector.java
@@ -22,6 +22,8 @@ import java.util.function.Function;
 
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.Request;
+import org.springframework.http.support.DefaultHttpCookieParser;
+import org.springframework.http.support.HttpCookieParser;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -43,6 +45,8 @@ public class JettyClientHttpConnector implements ClientHttpConnector {
 	private final HttpClient httpClient;
 
 	private JettyDataBufferFactory bufferFactory = new JettyDataBufferFactory();
+
+	private HttpCookieParser httpCookieParser = new DefaultHttpCookieParser();
 
 
 	/**
@@ -99,6 +103,12 @@ public class JettyClientHttpConnector implements ClientHttpConnector {
 		this.bufferFactory = bufferFactory;
 	}
 
+	/**
+	 * Set the cookie parser to use.
+	 */
+	public void setHttpCookieParser(HttpCookieParser httpCookieParser) {
+		this.httpCookieParser = httpCookieParser;
+	}
 
 	@Override
 	public Mono<ClientHttpResponse> connect(HttpMethod method, URI uri,
@@ -127,7 +137,7 @@ public class JettyClientHttpConnector implements ClientHttpConnector {
 		return Mono.fromDirect(request.toReactiveRequest()
 				.response((reactiveResponse, chunkPublisher) -> {
 					Flux<DataBuffer> content = Flux.from(chunkPublisher).map(this.bufferFactory::wrap);
-					return Mono.just(new JettyClientHttpResponse(reactiveResponse, content));
+					return Mono.just(new JettyClientHttpResponse(reactiveResponse, content, this.httpCookieParser));
 				}));
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/JettyClientHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/JettyClientHttpResponse.java
@@ -16,24 +16,20 @@
 
 package org.springframework.http.client.reactive;
 
-import java.net.HttpCookie;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.reactive.client.ReactiveResponse;
-import reactor.core.publisher.Flux;
-
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseCookie;
+import org.springframework.http.support.HttpCookieParser;
 import org.springframework.http.support.JettyHeadersAdapter;
-import org.springframework.lang.Nullable;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import reactor.core.publisher.Flux;
+
+import java.util.List;
 
 /**
  * {@link ClientHttpResponse} implementation for the Jetty ReactiveStreams HTTP client.
@@ -45,14 +41,11 @@ import org.springframework.util.MultiValueMap;
  */
 class JettyClientHttpResponse extends AbstractClientHttpResponse {
 
-	private static final Pattern SAME_SITE_PATTERN = Pattern.compile("(?i).*SameSite=(Strict|Lax|None).*");
-
-
-	public JettyClientHttpResponse(ReactiveResponse reactiveResponse, Flux<DataBuffer> content) {
+	public JettyClientHttpResponse(ReactiveResponse reactiveResponse, Flux<DataBuffer> content, HttpCookieParser httpCookieParser) {
 
 		super(HttpStatusCode.valueOf(reactiveResponse.getStatus()),
 				adaptHeaders(reactiveResponse),
-				adaptCookies(reactiveResponse),
+				adaptCookies(reactiveResponse, httpCookieParser),
 				content);
 	}
 
@@ -60,27 +53,13 @@ class JettyClientHttpResponse extends AbstractClientHttpResponse {
 		MultiValueMap<String, String> headers = new JettyHeadersAdapter(response.getHeaders());
 		return HttpHeaders.readOnlyHttpHeaders(headers);
 	}
-	private static MultiValueMap<String, ResponseCookie> adaptCookies(ReactiveResponse response) {
-		MultiValueMap<String, ResponseCookie> result = new LinkedMultiValueMap<>();
+	private static MultiValueMap<String, ResponseCookie> adaptCookies(ReactiveResponse response, HttpCookieParser httpCookieParser) {
 		List<HttpField> cookieHeaders = response.getHeaders().getFields(HttpHeaders.SET_COOKIE);
-		cookieHeaders.forEach(header ->
-					HttpCookie.parse(header.getValue()).forEach(cookie -> result.add(cookie.getName(),
-							ResponseCookie.fromClientResponse(cookie.getName(), cookie.getValue())
-									.domain(cookie.getDomain())
-									.path(cookie.getPath())
-									.maxAge(cookie.getMaxAge())
-									.secure(cookie.getSecure())
-									.httpOnly(cookie.isHttpOnly())
-									.sameSite(parseSameSite(header.getValue()))
-									.build()))
-			);
+		MultiValueMap<String, ResponseCookie> result = cookieHeaders.stream()
+				.flatMap(header -> httpCookieParser.parse(header.getValue()))
+				.collect(LinkedMultiValueMap::new,
+						(cookies, cookie) -> cookies.add(cookie.getName(), cookie),
+						LinkedMultiValueMap::addAll);
 		return CollectionUtils.unmodifiableMultiValueMap(result);
 	}
-
-	@Nullable
-	private static String parseSameSite(String headerValue) {
-		Matcher matcher = SAME_SITE_PATTERN.matcher(headerValue);
-		return (matcher.matches() ? matcher.group(1) : null);
-	}
-
 }

--- a/spring-web/src/main/java/org/springframework/http/support/DefaultHttpCookieParser.java
+++ b/spring-web/src/main/java/org/springframework/http/support/DefaultHttpCookieParser.java
@@ -1,0 +1,32 @@
+package org.springframework.http.support;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.lang.Nullable;
+
+import java.net.HttpCookie;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public final class DefaultHttpCookieParser implements HttpCookieParser {
+
+	private static final Pattern SAME_SITE_PATTERN = Pattern.compile("(?i).*SameSite=(Strict|Lax|None).*");
+
+	@Override
+	public Stream<ResponseCookie> parse(String header) {
+		Matcher matcher = SAME_SITE_PATTERN.matcher(header);
+		String sameSite = (matcher.matches() ? matcher.group(1) : null);
+		return HttpCookie.parse(header).stream().map(cookie -> toResponseCookie(cookie, sameSite));
+	}
+
+	private static ResponseCookie toResponseCookie(HttpCookie cookie, @Nullable String sameSite) {
+		return ResponseCookie.from(cookie.getName(), cookie.getValue())
+				.domain(cookie.getDomain())
+				.httpOnly(cookie.isHttpOnly())
+				.maxAge(cookie.getMaxAge())
+				.path(cookie.getPath())
+				.secure(cookie.getSecure())
+				.sameSite(sameSite)
+				.build();
+	}
+}

--- a/spring-web/src/main/java/org/springframework/http/support/HttpCookieParser.java
+++ b/spring-web/src/main/java/org/springframework/http/support/HttpCookieParser.java
@@ -1,0 +1,10 @@
+package org.springframework.http.support;
+
+import org.springframework.http.ResponseCookie;
+
+import java.util.stream.Stream;
+
+public interface HttpCookieParser {
+
+	Stream<ResponseCookie> parse(String header);
+}


### PR DESCRIPTION
Add a way to set custom cookie parsers to be compliant with rfc6265 section 4.1.1

java.net.HttpCookie::parse still follows rfc2965: https://docs.oracle.com/javase/8/docs/api/java/net/HttpCookie.html#parse-java.lang.String-
That has been obsoleted from rfc6265: https://datatracker.ietf.org/doc/html/rfc6265
That in section 4.1.1 states the following:
```
Each cookie begins with a name-value-pair, followed by zero or more attribute-value pairs.
Servers SHOULD NOT send Set-Cookie headers that fail to conform to the following grammar:
```

So the MUST constraint from rfc2965 has been relaxed to SHOULD NOT in rfc6265

I think that taking this into account, it may also be a good idea to collapse some features between the Jetty response connector and the JDK response connector, and provide a way to customize the cookie parser.