### PR TITLE
Fix ReflectionUtils#getDeclaredMethods to provide consistent result

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,7 @@ import org.springframework.lang.Nullable;
  * @author Costin Leau
  * @author Sam Brannen
  * @author Chris Beams
+ * @author Yong-Hyun Kim
  * @since 1.2.2
  */
 public abstract class ReflectionUtils {
@@ -463,6 +464,7 @@ public abstract class ReflectionUtils {
 		if (result == null) {
 			try {
 				Method[] declaredMethods = clazz.getDeclaredMethods();
+				Arrays.sort(declaredMethods, ReflectionUtils::methodDeclaringClassHierarchySorter);
 				List<Method> defaultMethods = findDefaultMethodsOnInterfaces(clazz);
 				if (defaultMethods != null) {
 					result = new Method[declaredMethods.length + defaultMethods.size()];
@@ -484,6 +486,18 @@ public abstract class ReflectionUtils {
 			}
 		}
 		return (result.length == 0 || !defensive) ? result : result.clone();
+	}
+
+	private static int methodDeclaringClassHierarchySorter(Method method1, Method method2) {
+		Class<?> clazz1 = method1.getDeclaringClass();
+		Class<?> clazz2 = method2.getDeclaringClass();
+		if (clazz1 == clazz2) {
+			return 0;
+		}
+		if (clazz1.isAssignableFrom(clazz2)) {
+			return 1;
+		}
+		return -1;
 	}
 
 	@Nullable

--- a/spring-core/src/test/java/org/springframework/util/ReflectionUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/ReflectionUtilsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  * @author Juergen Hoeller
  * @author Sam Brannen
  * @author Arjen Poutsma
+ * @author Yong-Hyun Kim
  */
 class ReflectionUtilsTests {
 
@@ -231,6 +232,8 @@ class ReflectionUtilsTests {
 		assertThat(ReflectionUtils.findMethod(B.class, "bar", String.class)).isNotNull();
 		assertThat(ReflectionUtils.findMethod(B.class, "foo", Integer.class)).isNotNull();
 		assertThat(ReflectionUtils.findMethod(B.class, "getClass")).isNotNull();
+		assertThat(ReflectionUtils.findMethod(B.class, "baz", String[].class).isBridge()).isFalse();
+		assertThat(ReflectionUtils.findMethod(B.class, "baz", String[].class).isVarArgs()).isTrue();
 	}
 
 	@Test
@@ -381,6 +384,10 @@ class ReflectionUtilsTests {
 		@SuppressWarnings({ "unused", "RedundantThrows" })
 		private void foo(Integer i) throws RemoteException {
 		}
+
+		protected Object baz(String... args) {
+			return "A";
+		}
 	}
 
 	@SuppressWarnings("unused")
@@ -395,6 +402,11 @@ class ReflectionUtilsTests {
 				sum += arg;
 			}
 			return sum;
+		}
+
+		@Override
+		protected String baz(String... args) {
+			return "B";
 		}
 	}
 


### PR DESCRIPTION
Hi. This PR is inspired by gh-34082.

As @welovelain pointed in it, the test below sometimes passes but sometimes doesn't.

```java
import jakarta.servlet.http.Cookie;
import org.junit.jupiter.api.Test;
import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
import org.springframework.util.ReflectionUtils;
import java.lang.reflect.Method;

import static org.assertj.core.api.Assertions.assertThat;

class ReflectionTests {
    @Test
    void test() {
        Method cookie = ReflectionUtils.findMethod(MockHttpServletRequestBuilder.class, "cookie", Cookie[].class);
        assertThat(cookie.isVarArgs()).isTrue();
    }
}
```

I've tested with IntelliJ IDEA 2024.3 and on several JDKs such as Temurin 17.0.13, Temurin 21.0.3, Corretto 21.0.5, etc., but the problem occurred upon all these JDKs.

You can check it out with this reproducer.

[sample.zip](https://github.com/user-attachments/files/18175606/sample.zip)

The problem is, how Class#getDeclaredMethods() returns a Method[] in a different order on each run. However `ReflectionUtils#getDeclaredMethods()` just iterates through this array and returns the first matched method.

Even `ReflectionUtilsTests#findMethod()` sometimes fails if you remove the sorting line introduced in this changes.

FWIW [ReflectionUtils in junit5](https://github.com/junit-team/junit5/blob/main/junit-platform-commons/src/main/java/org/junit/platform/commons/util/ReflectionUtils.java#L1771) (heavily contributed  by @sbrannen) also sorts methods of `Class#getDeclaredMethods()` and I believe this is worth it.

My sorter would not be optimized but I intended that the methods declared in actual source come first.