### PR TITLE
Fix broken links in the web reference documentation

### DIFF
--- a/framework-docs/modules/ROOT/pages/testing/webtestclient.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/webtestclient.adoc
@@ -193,7 +193,7 @@ Kotlin::
 [[webtestclient-fn-config]]
 === Bind to Router Function
 
-This setup allows you to test <<web-reactive.adoc#webflux-fn, functional endpoints>> via
+This setup allows you to test xref:web/webflux-functional.adoc[functional endpoints] via
 mock request and response objects, without a running server.
 
 For WebFlux, use the following which delegates to `RouterFunctions.toWebHandler` to

--- a/framework-docs/modules/ROOT/pages/web/webflux-cors.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webflux-cors.adoc
@@ -1,5 +1,6 @@
 [[webflux-cors]]
 = CORS
+
 [.small]#xref:web/webmvc-cors.adoc[See equivalent in the Servlet stack]#
 
 Spring WebFlux lets you handle CORS (Cross-Origin Resource Sharing). This section
@@ -364,7 +365,7 @@ Kotlin::
 
 You can apply CORS support through the built-in
 {spring-framework-api}/web/cors/reactive/CorsWebFilter.html[`CorsWebFilter`], which is a
-good fit with <<webflux-fn, functional endpoints>>.
+good fit with xref:web/webflux-functional.adoc[functional endpoints].
 
 NOTE: If you try to use the `CorsFilter` with Spring Security, keep in mind that Spring
 Security has {docs-spring-security}/servlet/integrations/cors.html[built-in support] for

--- a/framework-docs/modules/ROOT/pages/web/webflux-functional.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webflux-functional.adoc
@@ -1,5 +1,6 @@
 [[webflux-fn]]
 = Functional Endpoints
+
 [.small]#xref:web/webmvc-functional.adoc[See equivalent in the Servlet stack]#
 
 Spring WebFlux includes WebFlux.fn, a lightweight functional programming model in which functions

--- a/framework-docs/modules/ROOT/pages/web/webflux-websocket.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webflux-websocket.adoc
@@ -1,5 +1,6 @@
 [[webflux-websocket]]
 = WebSockets
+
 [.small]#xref:web/websocket.adoc[See equivalent in the Servlet stack]#
 
 This part of the reference documentation covers support for reactive-stack WebSocket

--- a/framework-docs/modules/ROOT/pages/web/webflux/new-framework.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webflux/new-framework.adoc
@@ -101,7 +101,7 @@ On that foundation, Spring WebFlux provides a choice of two programming models:
 from the `spring-web` module. Both Spring MVC and WebFlux controllers support reactive
 (Reactor and RxJava) return types, and, as a result, it is not easy to tell them apart. One notable
 difference is that WebFlux also supports reactive `@RequestBody` arguments.
-* <<webflux-fn>>: Lambda-based, lightweight, and functional programming model. You can think of
+* xref:web/webflux-functional.adoc[Functional Endpoints]: Lambda-based, lightweight, and functional programming model. You can think of
 this as a small library or a set of utilities that an application can use to route and
 handle requests. The big difference with annotated controllers is that the application
 is in charge of request handling from start to finish versus declaring intent through

--- a/framework-docs/modules/ROOT/pages/web/webmvc-cors.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc-cors.adoc
@@ -1,5 +1,6 @@
 [[mvc-cors]]
 = CORS
+
 [.small]#xref:web/webflux-cors.adoc[See equivalent in the Reactive stack]#
 
 Spring MVC lets you handle CORS (Cross-Origin Resource Sharing). This section

--- a/framework-docs/modules/ROOT/pages/web/webmvc-functional.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc-functional.adoc
@@ -1,6 +1,7 @@
 [[webmvc-fn]]
 = Functional Endpoints
-[.small]#<<web-reactive.adoc#webflux-fn, See equivalent in the Reactive stack>>#
+
+[.small]#xref:web/webflux-functional.adoc[See equivalent in the Reactive stack]#
 
 Spring Web MVC includes WebMvc.fn, a lightweight functional programming model in which functions
 are used to route and handle requests and contracts are designed for immutability.

--- a/framework-docs/modules/ROOT/pages/web/websocket.adoc
+++ b/framework-docs/modules/ROOT/pages/web/websocket.adoc
@@ -1,6 +1,7 @@
 [[websocket]]
 = WebSockets
 :page-section-summary-toc: 1
+
 [.small]#xref:web/webflux-websocket.adoc[See equivalent in the Reactive stack]#
 
 This part of the reference documentation covers support for Servlet stack, WebSocket


### PR DESCRIPTION
- Fix reference link `functional endpoints` 
- Add breakline to display `See equivalent in the Reactive stack` or `See equivalent in the Servlet stack`