### PR TITLE
Clarify documentation for the default uri client request observation metric

### DIFF
--- a/framework-docs/modules/ROOT/pages/integration/observability.adoc
+++ b/framework-docs/modules/ROOT/pages/integration/observability.adoc
@@ -285,7 +285,7 @@ Instrumentation uses the `org.springframework.http.client.observation.ClientRequ
 |===
 |Name | Description
 |`method` _(required)_|Name of the HTTP request method or `"none"` if not a well-known method.
-|`uri` _(required)_|URI template used for HTTP request, or `"none"` if none was provided. Only the path part of the URI is considered.
+|`uri` _(required)_|URI template used for HTTP request, or `"none"` if none was provided. The protocol, host and port part of the URI are not considered.
 |`client.name` _(required)_|Client name derived from the request URI host.
 |`status` _(required)_|HTTP response raw status code, or `"IO_ERROR"` in case of `IOException`, or `"CLIENT_ERROR"` if no response was received.
 |`outcome` _(required)_|Outcome of the HTTP client exchange.
@@ -313,7 +313,7 @@ Instrumentation uses the `org.springframework.http.client.observation.ClientRequ
 |===
 |Name | Description
 |`method` _(required)_|Name of the HTTP request method or `"none"` if the request could not be created.
-|`uri` _(required)_|URI template used for HTTP request, or `"none"` if none was provided. Only the path part of the URI is considered.
+|`uri` _(required)_|URI template used for HTTP request, or `"none"` if none was provided. The protocol, host and port part of the URI are not considered.
 |`client.name` _(required)_|Client name derived from the request URI host.
 |`status` _(required)_|HTTP response raw status code, or `"IO_ERROR"` in case of `IOException`, or `"CLIENT_ERROR"` if no response was received.
 |`outcome` _(required)_|Outcome of the HTTP client exchange.
@@ -342,7 +342,7 @@ Instrumentation uses the `org.springframework.web.reactive.function.client.Clien
 |===
 |Name | Description
 |`method` _(required)_|Name of the HTTP request method or `"none"` if not a well-known method.
-|`uri` _(required)_|URI template used for HTTP request, or `"none"` if none was provided. Only the path part of the URI is considered.
+|`uri` _(required)_|URI template used for HTTP request, or `"none"` if none was provided. The protocol, host and port part of the URI are not considered.
 |`client.name` _(required)_|Client name derived from the request URI host.
 |`status` _(required)_|HTTP response raw status code, or `"IO_ERROR"` in case of `IOException`, or `"CLIENT_ERROR"` if no response was received.
 |`outcome` _(required)_|Outcome of the HTTP client exchange.

--- a/spring-web/src/main/java/org/springframework/http/client/observation/ClientHttpObservationDocumentation.java
+++ b/spring-web/src/main/java/org/springframework/http/client/observation/ClientHttpObservationDocumentation.java
@@ -74,7 +74,7 @@ public enum ClientHttpObservationDocumentation implements ObservationDocumentati
 		/**
 		 * URI template used for HTTP request, or {@value KeyValue#NONE_VALUE} if
 		 * none was provided.
-		 * <p>Only the path part of the URI is considered.
+		 * <p>The protocol, host and port part of the URI are not considered.
 		 */
 		URI {
 			@Override

--- a/spring-web/src/test/java/org/springframework/http/client/observation/DefaultClientRequestObservationConventionTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/observation/DefaultClientRequestObservationConventionTests.java
@@ -89,6 +89,17 @@ class DefaultClientRequestObservationConventionTests {
 	}
 
 	@Test
+	void addsKeyValuesForRequestWithUriTemplateWithHostAndQuery() {
+		ClientRequestObservationContext context = createContext(
+				new MockClientHttpRequest(HttpMethod.GET, "https://example.org/resource/{id}?queryKey={queryValue}", 42, "Query"), response);
+		context.setUriTemplate("https://example.org/resource/{id}?queryKey={queryValue}");
+		assertThat(this.observationConvention.getLowCardinalityKeyValues(context))
+				.contains(KeyValue.of("exception", "none"), KeyValue.of("method", "GET"), KeyValue.of("uri", "/resource/{id}?queryKey={queryValue}"),
+						KeyValue.of("status", "200"), KeyValue.of("client.name", "example.org"), KeyValue.of("outcome", "SUCCESS"));
+		assertThat(this.observationConvention.getHighCardinalityKeyValues(context)).contains(KeyValue.of("http.url", "https://example.org/resource/42?queryKey=Query"));
+	}
+
+	@Test
 	void addsKeyValuesForRequestWithUriTemplateWithoutPath() {
 		ClientRequestObservationContext context = createContext(
 				new MockClientHttpRequest(HttpMethod.GET, "https://example.org"), response);

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientHttpObservationDocumentation.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ClientHttpObservationDocumentation.java
@@ -71,7 +71,7 @@ public enum ClientHttpObservationDocumentation implements ObservationDocumentati
 		/**
 		 * URI template used for HTTP request, or {@value KeyValue#NONE_VALUE} if
 		 * none was provided.
-		 * <p>Only the path part of the URI is considered.
+		 * <p>The protocol, host and port part of the URI are not considered.
 		 */
 		URI {
 			@Override

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/DefaultClientRequestObservationConventionTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/DefaultClientRequestObservationConventionTests.java
@@ -119,6 +119,13 @@ class DefaultClientRequestObservationConventionTests {
 		assertThat(this.observationConvention.getLowCardinalityKeyValues(context)).contains(KeyValue.of("uri", "/resource/{id}"));
 	}
 
+	@Test
+	void shouldKeepQueryParameterForUriKeyValue() {
+		ClientRequestObservationContext context = createContext(ClientRequest.create(HttpMethod.GET, URI.create("https://example.org/resource/42?queryKey=Query")));
+		context.setUriTemplate("https://example.org/resource/{id}?queryKey={queryValue}");
+		assertThat(this.observationConvention.getLowCardinalityKeyValues(context)).contains(KeyValue.of("uri", "/resource/{id}?queryKey={queryValue}"));
+	}
+
 	private ClientRequestObservationContext createContext(ClientRequest.Builder request) {
 		ClientRequestObservationContext context = new ClientRequestObservationContext(request);
 		context.setResponse(ClientResponse.create(HttpStatus.OK).build());


### PR DESCRIPTION
Change the description for the uri client request observation metric to clarify that only the protocol, host and port parts are removed from the template with the default observability convention.

Adds tests to illustrate that it is intentional that the query parameters are kept as part of the template.

closes #34107