### PR TITLE
Fix minor typo in reference documentation for Kotlin annotations

### DIFF
--- a/framework-docs/modules/ROOT/pages/languages/kotlin/annotations.adoc
+++ b/framework-docs/modules/ROOT/pages/languages/kotlin/annotations.adoc
@@ -14,7 +14,7 @@ For example, `@Autowired lateinit var thing: Thing` implies that a bean
 of type `Thing` must be registered in the application context, while `@Autowired lateinit var thing: Thing?`
 does not raise an error if such a bean does not exist.
 
-Following the same principle, `@Bean fun play(toy: Toy, car: Car?) = Baz(toy, Car)` implies
+Following the same principle, `@Bean fun play(toy: Toy, car: Car?) = Baz(toy, car)` implies
 that a bean of type `Toy` must be registered in the application context, while a bean of
 type `Car` may or may not exist. The same behavior applies to autowired constructor parameters.
 


### PR DESCRIPTION
Minor typo of Car instead of car