### PR TITLE
Release connection after transaction if using Hibernate and open-in-view is on (turned off by default)

### DIFF
--- a/spring-orm/src/main/java/org/springframework/orm/jpa/JpaTransactionManager.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/JpaTransactionManager.java
@@ -624,6 +624,9 @@ public class JpaTransactionManager extends AbstractPlatformTransactionManager
 		if (getDataSource() != null && txObject.hasConnectionHolder()) {
 			TransactionSynchronizationManager.unbindResource(getDataSource());
 		}
+
+		getJpaDialect().cleanupTransaction(txObject.getTransactionData());
+
 		// Give JpaDialect it's chance to release JDBC connection
 		if (getDataSource() != null && txObject.hasConnectionHolder()) {
 			ConnectionHandle conHandle = txObject.getConnectionHolder().getConnectionHandle();
@@ -638,8 +641,6 @@ public class JpaTransactionManager extends AbstractPlatformTransactionManager
 				}
 			}
 		}
-
-		getJpaDialect().cleanupTransaction(txObject.getTransactionData());
 
 		// Remove the entity manager holder from the thread.
 		if (txObject.isNewEntityManagerHolder()) {

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/JpaTransactionManager.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/JpaTransactionManager.java
@@ -623,6 +623,9 @@ public class JpaTransactionManager extends AbstractPlatformTransactionManager
 		// Remove the JDBC connection holder from the thread, if exposed.
 		if (getDataSource() != null && txObject.hasConnectionHolder()) {
 			TransactionSynchronizationManager.unbindResource(getDataSource());
+		}
+		// Give JpaDialect it's chance to release JDBC connection
+		if (getDataSource() != null && txObject.hasConnectionHolder()) {
 			ConnectionHandle conHandle = txObject.getConnectionHolder().getConnectionHandle();
 			if (conHandle != null) {
 				try {

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/JpaTransactionManager.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/JpaTransactionManager.java
@@ -627,21 +627,6 @@ public class JpaTransactionManager extends AbstractPlatformTransactionManager
 
 		getJpaDialect().cleanupTransaction(txObject.getTransactionData());
 
-		// Give JpaDialect it's chance to release JDBC connection
-		if (getDataSource() != null && txObject.hasConnectionHolder()) {
-			ConnectionHandle conHandle = txObject.getConnectionHolder().getConnectionHandle();
-			if (conHandle != null) {
-				try {
-					getJpaDialect().releaseJdbcConnection(conHandle,
-							txObject.getEntityManagerHolder().getEntityManager());
-				}
-				catch (Throwable ex) {
-					// Just log it, to keep a transaction-related exception.
-					logger.error("Failed to release JDBC connection after transaction", ex);
-				}
-			}
-		}
-
 		// Remove the entity manager holder from the thread.
 		if (txObject.isNewEntityManagerHolder()) {
 			EntityManager em = txObject.getEntityManagerHolder().getEntityManager();
@@ -652,6 +637,20 @@ public class JpaTransactionManager extends AbstractPlatformTransactionManager
 		}
 		else {
 			logger.debug("Not closing pre-bound JPA EntityManager after transaction");
+			// Give JpaDialect it's chance to release JDBC connection
+			if (getDataSource() != null && txObject.hasConnectionHolder()) {
+				ConnectionHandle conHandle = txObject.getConnectionHolder().getConnectionHandle();
+				if (conHandle != null) {
+					try {
+						getJpaDialect().releaseJdbcConnection(conHandle,
+								txObject.getEntityManagerHolder().getEntityManager());
+					}
+					catch (Throwable ex) {
+						// Just log it, to keep a transaction-related exception.
+						logger.error("Failed to release JDBC connection after transaction", ex);
+					}
+				}
+			}
 		}
 	}
 

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/vendor/HibernateJpaVendorAdapter.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/vendor/HibernateJpaVendorAdapter.java
@@ -109,6 +109,34 @@ public class HibernateJpaVendorAdapter extends AbstractJpaVendorAdapter {
 		this.jpaDialect.setPrepareConnection(prepareConnection);
 	}
 
+	/**
+	 * Set, whether to release connection after transaction is commited or rolled
+	 * back. Only works for pre-bound sessions.
+	 * <p> This setting is needed to work around the fact, that it is not possible
+	 * to use {@link org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode#DELAYED_ACQUISITION_AND_RELEASE_AFTER_TRANSACTION}
+	 * handling mode without sacrificing setting non-default isolation levels
+	 * or read-only flag. Releasing connection might prevent connection pool
+	 * starvation if open-in-view is on.
+	 * <p> Default is "false" for backward compatibility. If you turn this flag
+	 * on it still does nothing unless session is pre-bound (most likely if
+	 * open-in-view) is off. If session is pre-bound and the flag is on, then
+	 * after transaction is finished (successfully or not), underlying JDBC
+	 * connection will be released and acquired later according to {@link org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode}
+	 * (is set to {@link org.hibernate.resource.jdbc.spi.PhysicalConnectionHandlingMode#DELAYED_ACQUISITION_AND_HOLD}
+	 * with {@link HibernateJpaVendorAdapter#getJpaPropertyMap()} if you don't
+	 * specify it yourself).
+	 * <p> Please pay attention, that this setting doesn't affect how Hibernate
+	 * handles connections, which were acquired on-demand, to lazily load
+	 * collections outside of transaction context.
+	 * <p> Specifically, connections, acquired to serialize entities, returned
+	 * by rest controller method will only be closed, after serialization is
+	 * complete. Hibernate will not acquire and release connections for each
+	 * lazy field loading.
+	 */
+	public void setReleaseConnectionAfterTransaction(boolean releaseConnectionAfterTransaction) {
+		this.jpaDialect.setReleaseConnectionAfterTransaction(releaseConnectionAfterTransaction);
+	}
+
 
 	@Override
 	public PersistenceProvider getPersistenceProvider() {

--- a/spring-orm/src/test/java/org/springframework/orm/jpa/JpaTransactionManagerConnectionReleaseTests.java
+++ b/spring-orm/src/test/java/org/springframework/orm/jpa/JpaTransactionManagerConnectionReleaseTests.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.orm.jpa;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.EntityTransaction;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.springframework.jdbc.datasource.ConnectionHandle;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import javax.sql.DataSource;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+/**
+ * @author Ilia Sazonov
+ */
+class JpaTransactionManagerConnectionReleaseTests {
+
+	private EntityManagerFactory factory = mock();
+
+	private EntityManager manager = mock();
+
+	private EntityTransaction tx = mock();
+
+	private JpaTransactionManager tm = new JpaTransactionManager(factory);
+
+	private TransactionTemplate tt = new TransactionTemplate(tm);
+
+	private DataSource ds = mock();
+
+	private ConnectionHandle connHandle = mock();
+
+	private JpaDialect jpaDialect = spy(new DefaultJpaDialect());
+
+
+	@BeforeEach
+	void setup() throws SQLException {
+		given(factory.createEntityManager()).willReturn(manager);
+		given(manager.getTransaction()).willReturn(tx);
+		given(manager.isOpen()).willReturn(true);
+		given(jpaDialect.getJdbcConnection(same(manager), anyBoolean())).willReturn(connHandle);
+		tm.setJpaDialect(jpaDialect);
+		tm.setDataSource(ds);
+	}
+
+	@AfterEach
+	void verifyTransactionSynchronizationManagerState() {
+		assertThat(TransactionSynchronizationManager.getResourceMap()).isEmpty();
+		assertThat(TransactionSynchronizationManager.isSynchronizationActive()).isFalse();
+		assertThat(TransactionSynchronizationManager.isCurrentTransactionReadOnly()).isFalse();
+		assertThat(TransactionSynchronizationManager.isActualTransactionActive()).isFalse();
+	}
+
+	@Test
+	void testConnectionIsReleasedAfterTransactionCleanup() throws SQLException {
+		given(manager.getTransaction()).willReturn(tx);
+
+		final List<String> l = new ArrayList<>();
+		l.add("test");
+
+		assertThat(TransactionSynchronizationManager.hasResource(factory)).isFalse();
+		assertThat(TransactionSynchronizationManager.isSynchronizationActive()).isFalse();
+		TransactionSynchronizationManager.bindResource(factory, new EntityManagerHolder(manager));
+
+		try {
+			Object result = tt.execute(status -> {
+				assertThat(TransactionSynchronizationManager.hasResource(factory)).isTrue();
+				assertThat(TransactionSynchronizationManager.isSynchronizationActive()).isTrue();
+				EntityManagerFactoryUtils.getTransactionalEntityManager(factory);
+				return l;
+			});
+			assertThat(result).isSameAs(l);
+
+			assertThat(TransactionSynchronizationManager.hasResource(factory)).isTrue();
+			assertThat(TransactionSynchronizationManager.isSynchronizationActive()).isFalse();
+		}
+		finally {
+			TransactionSynchronizationManager.unbindResource(factory);
+		}
+
+		verify(tx).begin();
+		verify(tx).commit();
+
+		InOrder cleanupBeforeRelease = inOrder(jpaDialect);
+		cleanupBeforeRelease.verify(jpaDialect).cleanupTransaction(any());
+		cleanupBeforeRelease.verify(jpaDialect).releaseJdbcConnection(same(connHandle), same(manager));
+	}
+}

--- a/spring-orm/src/test/java/org/springframework/orm/jpa/hibernate/HibernateEntityManagerFactoryReleaseConnectionAfterTransactionIntegrationTests.java
+++ b/spring-orm/src/test/java/org/springframework/orm/jpa/hibernate/HibernateEntityManagerFactoryReleaseConnectionAfterTransactionIntegrationTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.orm.jpa.hibernate;
+
+import jakarta.persistence.EntityManager;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.resource.jdbc.spi.LogicalConnectionImplementor;
+import org.junit.jupiter.api.Test;
+import org.springframework.orm.jpa.AbstractContainerEntityManagerFactoryIntegrationTests;
+import org.springframework.orm.jpa.EntityManagerHolder;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link org.springframework.orm.jpa.vendor.HibernateJpaDialect#releaseConnectionAfterTransaction}
+ *
+ * @author Ilia Sazonov
+ */
+class HibernateEntityManagerFactoryReleaseConnectionAfterTransactionIntegrationTests extends AbstractContainerEntityManagerFactoryIntegrationTests {
+
+	@Override
+	protected String[] getConfigLocations() {
+		return new String[] {"/org/springframework/orm/jpa/hibernate/hibernate-manager-release-after-transaction.xml",
+				"/org/springframework/orm/jpa/memdb.xml", "/org/springframework/orm/jpa/inject.xml"};
+	}
+
+	@Test
+	public void testReleaseConnectionAfterTransaction() {
+		endTransaction();
+
+		try (EntityManager em = entityManagerFactory.createEntityManager()) {
+			EntityManagerHolder emHolder = new EntityManagerHolder(em);
+			TransactionSynchronizationManager.bindResource(entityManagerFactory, emHolder);
+
+			startNewTransaction();
+			endTransaction();
+
+			assertThat(em.isOpen()).isTrue();
+			final LogicalConnectionImplementor logicalConnection = em.unwrap(SessionImplementor.class)
+					.getJdbcCoordinator().getLogicalConnection();
+			assertThat(logicalConnection.isPhysicallyConnected()).isFalse();
+
+		} finally {
+			TransactionSynchronizationManager.unbindResource(entityManagerFactory);
+		}
+	}
+}

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/hibernate/hibernate-manager-release-after-transaction.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/hibernate/hibernate-manager-release-after-transaction.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+
+	<bean id="entityManagerFactory" class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean" primary="true">
+		<property name="persistenceXmlLocation" value="org/springframework/orm/jpa/domain/persistence-context.xml"/>
+		<property name="dataSource" ref="dataSource"/>
+		<property name="jpaVendorAdapter">
+			<bean class="org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter">
+				<property name="database" value="HSQL"/>
+				<property name="showSql" value="true"/>
+				<property name="generateDdl" value="true"/>
+				<property name="releaseConnectionAfterTransaction" value="true"/>
+			</bean>
+		</property>
+		<property name="jpaPropertyMap">
+			<props>
+				<prop key="hibernate.current_session_context_class">org.springframework.orm.hibernate5.SpringSessionContext</prop>
+				<prop key="hibernate.cache.provider_class">org.hibernate.cache.HashtableCacheProvider</prop>
+			</props>
+		</property>
+		<property name="bootstrapExecutor">
+			<bean class="org.springframework.core.task.SimpleAsyncTaskExecutor"/>
+		</property>
+	</bean>
+
+	<bean id="transactionManager" class="org.springframework.orm.jpa.JpaTransactionManager">
+		<property name="entityManagerFactory" ref="entityManagerFactory"/>
+	</bean>
+
+	<bean id="hibernateStatistics" factory-bean="entityManagerFactory" factory-method="getStatistics" lazy-init="true"/>
+
+	<bean class="org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator"/>
+
+</beans>


### PR DESCRIPTION
One of the issues with open-in-view is that connections are not released for a long time, which can lead to connection pool starvation.

Sometimes, controller method even makes no queries for seconds and doesn't really need to keep the connection for itself all that time. For example that is often the case, when application makes REST call after making database query.

This pull request gives user setting, which tells transaction manager, that it should release JDBC connection after transaction is finished (successfully or not). Connection release only happens if the setting is turned on and if open-in-view is enabled. If open-in-view is disabled, then entity manager is closed after transaction is finished and connection is released anyway.

# What this pull request changes in existing behaviour

1.  JpaDialect#releaseJdbcConnection is now only called if entity manager is pre-bound. This happens if open-in-view is turned on.
2.  JpaDialect#cleanupTransaction is now called *before* JpaDialect#releaseJdbcConnection ,
because if connection is released, transaction manager can't reset isolation level and read-only flag. I think the only reason nobody noticed that before is that nobody tried to override JpaDialect#releaseJdbcConnection for HibernateJpaDialect

# What this pull request adds

1.  releaseConnectionAfterTransaction setting for HibernateJpaDialect and which user can configure through HibernateJpaVendorAdapter (like showSql and generateDdl).
2.  HibernateJpaDialect#releaseJdbcConnection method now really releases JDBC connection if releaseConnectionAfterTransaction setting is enabled.

P. S. I think those changes are ok, because the behaviour is copied from HibernateTransactionManager. Hibernate 6 is officially only supported through JpaTransactionManager, so it would be nice to port this HibernateTransactionManager feature.