### PR TITLE
Add error handler for transactional event

### DIFF
--- a/spring-tx/src/main/java/org/springframework/transaction/annotation/AbstractTransactionManagementConfiguration.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/annotation/AbstractTransactionManagementConfiguration.java
@@ -30,6 +30,7 @@ import org.springframework.core.annotation.AnnotationAttributes;
 import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.transaction.TransactionManager;
 import org.springframework.transaction.config.TransactionManagementConfigUtils;
+import org.springframework.transaction.config.GlobalTransactionalEventErrorHandler;
 import org.springframework.transaction.event.TransactionalEventListenerFactory;
 import org.springframework.transaction.interceptor.RollbackRuleAttribute;
 import org.springframework.transaction.interceptor.TransactionAttributeSource;
@@ -93,8 +94,11 @@ public abstract class AbstractTransactionManagementConfiguration implements Impo
 
 	@Bean(name = TransactionManagementConfigUtils.TRANSACTIONAL_EVENT_LISTENER_FACTORY_BEAN_NAME)
 	@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
-	public static TransactionalEventListenerFactory transactionalEventListenerFactory() {
-		return new RestrictedTransactionalEventListenerFactory();
+	public static TransactionalEventListenerFactory transactionalEventListenerFactory(@Nullable GlobalTransactionalEventErrorHandler errorHandler) {
+		if (errorHandler == null) {
+			return new RestrictedTransactionalEventListenerFactory();
+		}
+		return new RestrictedTransactionalEventListenerFactory(errorHandler);
 	}
 
 }

--- a/spring-tx/src/main/java/org/springframework/transaction/annotation/RestrictedTransactionalEventListenerFactory.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/annotation/RestrictedTransactionalEventListenerFactory.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 
 import org.springframework.context.ApplicationListener;
 import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.transaction.config.GlobalTransactionalEventErrorHandler;
 import org.springframework.transaction.event.TransactionalEventListenerFactory;
 
 /**
@@ -34,6 +35,14 @@ import org.springframework.transaction.event.TransactionalEventListenerFactory;
  * @see Transactional
  */
 public class RestrictedTransactionalEventListenerFactory extends TransactionalEventListenerFactory {
+
+	public RestrictedTransactionalEventListenerFactory() {
+		super();
+	}
+
+	public RestrictedTransactionalEventListenerFactory(GlobalTransactionalEventErrorHandler errorHandler) {
+		super(errorHandler);
+	}
 
 	@Override
 	public ApplicationListener<?> createApplicationListener(String beanName, Class<?> type, Method method) {

--- a/spring-tx/src/main/java/org/springframework/transaction/config/GlobalTransactionalEventErrorHandler.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/config/GlobalTransactionalEventErrorHandler.java
@@ -1,0 +1,18 @@
+package org.springframework.transaction.config;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.context.ApplicationEvent;
+import org.springframework.transaction.event.TransactionalApplicationListener;
+
+public abstract class GlobalTransactionalEventErrorHandler implements TransactionalApplicationListener.SynchronizationCallback {
+
+	public abstract void handle(ApplicationEvent event, @Nullable Throwable ex);
+
+	@Override
+	public void postProcessEvent(ApplicationEvent event, @Nullable Throwable ex) {
+		if (ex != null) {
+			handle(event, ex);
+		}
+	}
+
+}


### PR DESCRIPTION
Exceptions propagated from the transactional event listener are handled by `TransactionSynchronizationUtils` and are not rethrown.
However, the lack of a configurable error handler for these exceptions makes it difficult to customize exception handling during transactional event processing.
To address this, I added an abstract error handler that can be defined as follows:

```java
@Component
public abstract class TransactionalEventErrorHandlerImpl extends TransactionalEventErrorHandler {

	// can inject other beans

	@Override
	public void handle(ApplicationEvent event, @Nullable Throwable ex) {
		// custom logic
	}

}
```