### PR TITLE
Broken syntax in xml sample of "Reference to Other Beans" section

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/beans/dependencies/factory-properties-detailed.adoc
+++ b/framework-docs/modules/ROOT/pages/core/beans/dependencies/factory-properties-detailed.adoc
@@ -169,7 +169,8 @@ listings shows how to use the `parent` attribute:
 [source,xml,indent=0,subs="verbatim,quotes"]
 ----
 	<!-- in the child (descendant) context -->
-	<bean id="accountService" <!-- bean name is the same as the parent bean -->
+	<!-- bean name is the same as the parent bean -->
+	<bean id="accountService" 
 		class="org.springframework.aop.framework.ProxyFactoryBean">
 		<property name="target">
 			<ref parent="accountService"/> <!-- notice how we refer to the parent bean -->


### PR DESCRIPTION
Reading through [the docs](https://docs.spring.io/spring-framework/reference/core/beans/dependencies/factory-properties-detailed.html#beans-ref-element) and came across a syntax highlighting error in one of the XML code samples. Moved the comment to the line above to make the sample valid XML.

