### PR TITLE
Fix typo in link

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/beans/dependencies/factory-dependson.adoc
+++ b/framework-docs/modules/ROOT/pages/core/beans/dependencies/factory-dependson.adoc
@@ -3,7 +3,7 @@
 
 If a bean is a dependency of another bean, that usually means that one bean is set as a
 property of another. Typically you accomplish this with the
-xref:core/beans/dependencies/factory-properties-detailed.adoc#beans-ref-element[`<ref/>` element>]
+xref:core/beans/dependencies/factory-properties-detailed.adoc#beans-ref-element[`<ref/>` element]
 in XML-based metadata or through xref:core/beans/dependencies/factory-autowire.adoc[autowiring].
 
 However, sometimes dependencies between beans are less direct. An example is when a static


### PR DESCRIPTION
[This page](https://docs.spring.io/spring-framework/reference/core/beans/dependencies/factory-dependson.html) contains what looks to be a type with one of embedded links. Just fixing that up.