### PR TITLE
Fix StackOverflowError in ReflectionUtils

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ReflectionUtils.java
@@ -709,7 +709,11 @@ public abstract class ReflectionUtils {
 	public static void doWithFields(Class<?> clazz, FieldCallback fc, @Nullable FieldFilter ff) {
 		// Keep backing up the inheritance hierarchy.
 		Class<?> targetClass = clazz;
+		Set<Class<?>> visitedClasses = new HashSet<>();
 		do {
+			if (!visitedClasses.add(targetClass)) {
+				break; // Avoid infinite recursion
+			}
 			Field[] fields = getDeclaredFields(targetClass);
 			for (Field field : fields) {
 				if (ff != null && !ff.matches(field)) {


### PR DESCRIPTION
### Issue
This PR addresses a `StackOverflowError` in `ReflectionUtils` when processing fields with cyclic dependencies during AOT compilation.

### Fix
- Added defensive programming in `doWithFields` to track visited classes and prevent infinite recursion.

Fixes #34170 
