### PR TITLE
Improve readability in SpringServletContainerInitializer with method extraction

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/SpringServletContainerInitializer.java
+++ b/spring-web/src/main/java/org/springframework/web/SpringServletContainerInitializer.java
@@ -147,8 +147,7 @@ public class SpringServletContainerInitializer implements ServletContainerInitia
 			for (Class<?> waiClass : webAppInitializerClasses) {
 				// Be defensive: Some servlet containers provide us with invalid classes,
 				// no matter what @HandlesTypes says...
-				if (!waiClass.isInterface() && !Modifier.isAbstract(waiClass.getModifiers()) &&
-						WebApplicationInitializer.class.isAssignableFrom(waiClass)) {
+				if (isWebAppInitializerImplementation(waiClass)) {
 					try {
 						initializers.add((WebApplicationInitializer)
 								ReflectionUtils.accessibleConstructor(waiClass).newInstance());
@@ -170,6 +169,11 @@ public class SpringServletContainerInitializer implements ServletContainerInitia
 		for (WebApplicationInitializer initializer : initializers) {
 			initializer.onStartup(servletContext);
 		}
+	}
+
+	private boolean isWebAppInitializerImplementation(Class<?> waiClass) {
+		return !waiClass.isInterface() && !Modifier.isAbstract(waiClass.getModifiers()) &&
+				WebApplicationInitializer.class.isAssignableFrom(waiClass);
 	}
 
 }


### PR DESCRIPTION
While studying servlet containers, I explored how this is implemented in Spring. I realized that extracting this part into a separate method could enhance readability, so I have made this modification.