### PR TITLE
Fix broken link to Code of Conduct in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ First off, thank you for taking the time to contribute! :+1: :tada:
 
 ### Code of Conduct
 
-This project is governed by the [Spring Code of Conduct](CODE_OF_CONDUCT.adoc).
+This project is governed by the [Spring Code of Conduct](https://github.com/spring-projects/spring-framework/?tab=coc-ov-file#contributor-code-of-conduct).
 By participating you are expected to uphold this code.
 Please report unacceptable behavior to spring-code-of-conduct@spring.io.
 


### PR DESCRIPTION
While reviewing project documentation I found that the Spring Code of Conduct link in CONTRIBUTING.md referred to a non-existent file (CODE_OF_CONDUCT.adoc). This file appears to have been removed earlier. I updated the link to match the correct one used in README.md.

<img width="1208" alt="Screenshot 2024-12-30 at 21 39 39" src="https://github.com/user-attachments/assets/73e72936-6cc4-4eb2-a808-fb33f901e51b" />
