### PR TITLE
Optimize byte array reading

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/ByteArrayHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/ByteArrayHttpMessageConverter.java
@@ -54,8 +54,10 @@ public class ByteArrayHttpMessageConverter extends AbstractHttpMessageConverter<
 	@Override
 	public byte[] readInternal(Class<? extends byte[]> clazz, HttpInputMessage message) throws IOException {
 		long length = message.getHeaders().getContentLength();
-		return (length >= 0 && length < Integer.MAX_VALUE ?
-				message.getBody().readNBytes((int) length) : message.getBody().readAllBytes());
+		if (length > Integer.MAX_VALUE) {
+			throw new OutOfMemoryError("message size too large");
+		}
+		return message.getBody().readAllBytes()
 	}
 
 	@Override


### PR DESCRIPTION
if message length over Integer.MAX_VALUE, the message.getBody().readAllBytes() method will throw OutOfMemoryError. But we can throw this Error in advance. It can reduce message reading.

message.getBody().readAllBytes() method achieve: when reading bytes over  Integer.MAX_VALUE, it will throw OutOfMemoryError. Message is Required array size too large.