### PR TITLE
Add support for multidimensional arrays

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
@@ -893,16 +893,7 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 	private Object newValue(Class<?> type, @Nullable TypeDescriptor desc, String name) {
 		try {
 			if (type.isArray()) {
-				Class<?> componentType = type.componentType();
-				// TODO - only handles 2-dimensional arrays
-				if (componentType.isArray()) {
-					Object array = Array.newInstance(componentType, 1);
-					Array.set(array, 0, Array.newInstance(componentType.componentType(), 0));
-					return array;
-				}
-				else {
-					return Array.newInstance(componentType, 0);
-				}
+				return createArray(type);
 			}
 			else if (Collection.class.isAssignableFrom(type)) {
 				TypeDescriptor elementDesc = (desc != null ? desc.getElementTypeDescriptor() : null);
@@ -923,6 +914,28 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 		catch (Throwable ex) {
 			throw new NullValueInNestedPathException(getRootClass(), this.nestedPath + name,
 					"Could not instantiate property type [" + type.getName() + "] to auto-grow nested property path", ex);
+		}
+	}
+
+	/**
+	 * Create the array for the given array type.
+	 *
+	 * @param arrayType the desired type of the target array
+	 * @return a new array instance
+	 */
+	private Object createArray(Class<?> arrayType) {
+		Assert.notNull(arrayType, "Array type must not be null");
+		if (arrayType.isArray()) {
+			Class<?> componentType = arrayType.componentType();
+			if (componentType.isArray()) {
+				Object array = Array.newInstance(componentType, 1);
+				Array.set(array, 0, createArray(componentType));
+				return array;
+			} else {
+				return Array.newInstance(componentType, 0);
+			}
+		} else {
+			throw new IllegalArgumentException("Unsupported Array type: " + arrayType.getName());
 		}
 	}
 

--- a/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/AbstractNestablePropertyAccessor.java
@@ -919,7 +919,6 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 
 	/**
 	 * Create the array for the given array type.
-	 *
 	 * @param arrayType the desired type of the target array
 	 * @return a new array instance
 	 */
@@ -931,10 +930,12 @@ public abstract class AbstractNestablePropertyAccessor extends AbstractPropertyA
 				Object array = Array.newInstance(componentType, 1);
 				Array.set(array, 0, createArray(componentType));
 				return array;
-			} else {
+			}
+			else {
 				return Array.newInstance(componentType, 0);
 			}
-		} else {
+		}
+		else {
 			throw new IllegalArgumentException("Unsupported Array type: " + arrayType.getName());
 		}
 	}

--- a/spring-beans/src/test/java/org/springframework/beans/BeanWrapperAutoGrowingTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanWrapperAutoGrowingTests.java
@@ -104,6 +104,27 @@ class BeanWrapperAutoGrowingTests {
 	}
 
 	@Test
+	void getPropertyValueAutoGrow3dArrayList() {
+		assertThat(wrapper.getPropertyValue("threeDimensionalArrayList[1][2][3][4]")).isNotNull();
+		assertThat(bean.getThreeDimensionalArrayList()).hasSize(2);
+		assertThat(bean.getThreeDimensionalArrayList().get(1)).hasNumberOfRows(3);
+		assertThat(bean.getThreeDimensionalArrayList().get(1)[2]).hasNumberOfRows(4);
+		assertThat(bean.getThreeDimensionalArrayList().get(1)[2][3]).hasSize(5);
+		assertThat(bean.getThreeDimensionalArrayList().get(1)[2][3][4]).isInstanceOf(Bean.class);
+	}
+
+	@Test
+	void getPropertyValueAutoGrow3dArrayListForDefault3dArray() {
+		assertThat(wrapper.getPropertyValue("threeDimensionalArrayList[0]")).isNotNull();
+		assertThat(bean.getThreeDimensionalArrayList()).hasSize(1);
+
+		// Default 3-dimensional array should be [[[]]]
+		assertThat(bean.getThreeDimensionalArrayList().get(0)).hasNumberOfRows(1);
+		assertThat(bean.getThreeDimensionalArrayList().get(0)[0]).hasNumberOfRows(1);
+		assertThat(bean.getThreeDimensionalArrayList().get(0)[0][0]).isEmpty();
+	}
+
+	@Test
 	void setPropertyValueAutoGrow2dArray() {
 		Bean newBean = new Bean();
 		newBean.setProp("enigma");
@@ -121,6 +142,16 @@ class BeanWrapperAutoGrowingTests {
 		assertThat(bean.getThreeDimensionalArray()[2][3][4])
 			.isInstanceOf(Bean.class)
 			.extracting(Bean::getProp).isEqualTo("enigma");
+	}
+
+	@Test
+	void setPropertyValueAutoGrow3dArrayList() {
+		Bean newBean = new Bean();
+		newBean.setProp("enigma");
+		wrapper.setPropertyValue("threeDimensionalArrayList[0][1][2][3]", newBean);
+		assertThat(bean.getThreeDimensionalArrayList().get(0)[1][2][3])
+				.isInstanceOf(Bean.class)
+				.extracting(Bean::getProp).isEqualTo("enigma");
 	}
 
 	@Test
@@ -215,6 +246,8 @@ class BeanWrapperAutoGrowingTests {
 
 		private Bean[][][] threeDimensionalArray;
 
+		private List<Bean[][][]> threeDimensionalArrayList;
+
 		private List<Bean> list;
 
 		private List<List<Bean>> nestedList;
@@ -267,6 +300,14 @@ class BeanWrapperAutoGrowingTests {
 
 		public void setThreeDimensionalArray(Bean[][][] threeDimensionalArray) {
 			this.threeDimensionalArray = threeDimensionalArray;
+		}
+
+		public List<Bean[][][]> getThreeDimensionalArrayList() {
+			return threeDimensionalArrayList;
+		}
+
+		public void setThreeDimensionalArrayList(List<Bean[][][]> threeDimensionalArrayList) {
+			this.threeDimensionalArrayList = threeDimensionalArrayList;
 		}
 
 		public List<Bean> getList() {


### PR DESCRIPTION
Resolve TODO: `TODO - only handles 2-dimensional arrays`.

For method `org.springframework.beans.AbstractNestablePropertyAccessor#newValue`:
- When arg `type` is `Integer[][][].class`, it will return a 2-dimensional array instance like`[[]]`.

After this PR, this method support handling multidimensional arrays:
- When arg `type` is `Integer[][][].class`, it will return a 3-dimensional array instance like `[[[]]]`.



But actually, **this final behavior is correct before this PR**. For example: 
- Test case `org.springframework.beans.BeanWrapperAutoGrowingTests#getPropertyValueAutoGrow3dArray`  had passed.

So I just fix this method `newValue`.

