### PR TITLE
Keep the - of header on init parameter names, otherwise the nested path will not work.

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ExtendedServletRequestDataBinder.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ExtendedServletRequestDataBinder.java
@@ -124,7 +124,7 @@ public class ExtendedServletRequestDataBinder extends ServletRequestDataBinder {
 				String name = names.nextElement();
 				Object value = getHeaderValue(httpRequest, name);
 				if (value != null) {
-					name = StringUtils.uncapitalize(name.replace("-", ""));
+					name = transformedHeaderName(name);
 					addValueIfNotPresent(mpvs, "Header", name, value);
 				}
 			}
@@ -145,6 +145,10 @@ public class ExtendedServletRequestDataBinder extends ServletRequestDataBinder {
 		else {
 			mpvs.addPropertyValue(name, value);
 		}
+	}
+
+	private static String transformedHeaderName(String headerName) {
+		return StringUtils.uncapitalize(headerName.replace("-", ""));
 	}
 
 	private @Nullable Object getHeaderValue(HttpServletRequest request, String name) {
@@ -206,7 +210,7 @@ public class ExtendedServletRequestDataBinder extends ServletRequestDataBinder {
 				Enumeration<String> enumeration = httpServletRequest.getHeaderNames();
 				while (enumeration.hasMoreElements()) {
 					String headerName = enumeration.nextElement();
-					set.add(headerName.replaceAll("-", ""));
+					set.add(headerName);
 				}
 			}
 			return set;

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ExtendedServletRequestDataBinderTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ExtendedServletRequestDataBinderTests.java
@@ -89,6 +89,30 @@ class ExtendedServletRequestDataBinderTests {
 	}
 
 	@Test
+	void createBinderViaConstructorNested() {
+		request.addHeader("Nested-Test-Bean.Some-Int-Array", "1");
+		request.addHeader("Nested-Test-Bean.Some-Int-Array", "2");
+
+		ServletRequestDataBinder binder = new ExtendedServletRequestDataBinder(null);
+		binder.setTargetType(ResolvableType.forClass(SimpleBean.class));
+		binder.setNameResolver(new BindParamNameResolver());
+		binder.construct(request);
+
+		SimpleBean bean = (SimpleBean) binder.getTarget();
+
+		assertThat(bean.nestedTestBean()).isNotNull();
+		assertThat(bean.nestedTestBean().someIntArray()).containsExactly(1, 2);
+	}
+
+	private record SimpleBean(@BindParam("Nested-Test-Bean") NestedTestBean nestedTestBean) {
+
+	}
+
+	private record NestedTestBean(@BindParam("Some-Int-Array") Integer[] someIntArray) {
+
+	}
+
+	@Test
 	void uriVarsAndHeadersAddedConditionally() {
 		request.addParameter("name", "John");
 		request.addParameter("age", "25");


### PR DESCRIPTION
Keep the `-` of header names when init parameter names, otherwise the nested path will not work.



~~@rstoyanchev Hi, for **property name** and **parameter name**, I think they should use the same transformed header name using "camelCase".~~

~~For example, A http request with headers:~~
- `User-Agent`: `something`
- `WWW-Authenticate`: `something`

~~Before this PR,  the method `ExtendedServletRequestValueResolver#initParameterNames` will return a name set:~~
- `UserAgent`,  `WWWAuthenticate`

~~After this PR, the method will return a name set:~~
- `userAgent`, `wWWAuthenticate`
