### PR TITLE
Add CONNECT constant to HttpMethod

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpMethod.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpMethod.java
@@ -72,6 +72,12 @@ public final class HttpMethod implements Comparable<HttpMethod>, Serializable {
 	public static final HttpMethod DELETE = new HttpMethod("DELETE");
 
 	/**
+	 * The HTTP method {@code CONNECT}.
+	 * @see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.6">RFC 9110, section 9.3.6</a>
+	 */
+	public static final HttpMethod CONNECT = new HttpMethod("CONNECT");
+
+	/**
 	 * The HTTP method {@code OPTIONS}.
 	 * @see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.7">RFC 9110, section 9.3.7</a>
 	 */
@@ -83,7 +89,7 @@ public final class HttpMethod implements Comparable<HttpMethod>, Serializable {
 	 */
 	public static final HttpMethod TRACE = new HttpMethod("TRACE");
 
-	private static final HttpMethod[] values = new HttpMethod[] { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE };
+	private static final HttpMethod[] values = new HttpMethod[] { GET, HEAD, POST, PUT, PATCH, DELETE, CONNECT, OPTIONS, TRACE };
 
 
 	private final String name;
@@ -97,7 +103,7 @@ public final class HttpMethod implements Comparable<HttpMethod>, Serializable {
 	 * Returns an array containing the standard HTTP methods. Specifically,
 	 * this method returns an array containing {@link #GET}, {@link #HEAD},
 	 * {@link #POST}, {@link #PUT}, {@link #PATCH}, {@link #DELETE},
-	 * {@link #OPTIONS}, and {@link #TRACE}.
+	 * {@link #CONNECT}, {@link #OPTIONS}, and {@link #TRACE}.
 	 *
 	 * <p>Note that the returned value does not include any HTTP methods defined
 	 * in WebDav.
@@ -122,6 +128,7 @@ public final class HttpMethod implements Comparable<HttpMethod>, Serializable {
 			case "PUT" -> PUT;
 			case "PATCH" -> PATCH;
 			case "DELETE" -> DELETE;
+			case "CONNECT" -> CONNECT;
 			case "OPTIONS" -> OPTIONS;
 			case "TRACE" -> TRACE;
 			default -> new HttpMethod(method);

--- a/spring-web/src/main/java/org/springframework/http/HttpMethod.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpMethod.java
@@ -37,25 +37,25 @@ public final class HttpMethod implements Comparable<HttpMethod>, Serializable {
 
 	/**
 	 * The HTTP method {@code GET}.
-	 * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.3">HTTP 1.1, section 9.3</a>
+	 * @see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.1">RFC 9110, section 9.3.1</a>
 	 */
 	public static final HttpMethod GET = new HttpMethod("GET");
 
 	/**
 	 * The HTTP method {@code HEAD}.
-	 * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.4">HTTP 1.1, section 9.4</a>
+	 * @see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2">RFC 9110, section 9.3.2</a>
 	 */
 	public static final HttpMethod HEAD = new HttpMethod("HEAD");
 
 	/**
 	 * The HTTP method {@code POST}.
-	 * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5">HTTP 1.1, section 9.5</a>
+	 * @see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.3">RFC 9110, section 9.3.3</a>
 	 */
 	public static final HttpMethod POST = new HttpMethod("POST");
 
 	/**
 	 * The HTTP method {@code PUT}.
-	 * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.6">HTTP 1.1, section 9.6</a>
+	 * @see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.4">RFC 9110, section 9.3.4</a>
 	 */
 	public static final HttpMethod PUT = new HttpMethod("PUT");
 
@@ -67,19 +67,19 @@ public final class HttpMethod implements Comparable<HttpMethod>, Serializable {
 
 	/**
 	 * The HTTP method {@code DELETE}.
-	 * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.7">HTTP 1.1, section 9.7</a>
+	 * @see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.5">RFC 9110, section 9.3.5</a>
 	 */
 	public static final HttpMethod DELETE = new HttpMethod("DELETE");
 
 	/**
 	 * The HTTP method {@code OPTIONS}.
-	 * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.2">HTTP 1.1, section 9.2</a>
+	 * @see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.7">RFC 9110, section 9.3.7</a>
 	 */
 	public static final HttpMethod OPTIONS = new HttpMethod("OPTIONS");
 
 	/**
 	 * The HTTP method {@code TRACE}.
-	 * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.8">HTTP 1.1, section 9.8</a>
+	 * @see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.8">RFC 9110, section 9.3.8</a>
 	 */
 	public static final HttpMethod TRACE = new HttpMethod("TRACE");
 

--- a/spring-web/src/main/java/org/springframework/http/HttpMethod.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpMethod.java
@@ -37,25 +37,25 @@ public final class HttpMethod implements Comparable<HttpMethod>, Serializable {
 
 	/**
 	 * The HTTP method {@code GET}.
-	 * @see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.1">RFC 9110, section 9.3.1</a>
+	 * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.3">HTTP 1.1, section 9.3</a>
 	 */
 	public static final HttpMethod GET = new HttpMethod("GET");
 
 	/**
 	 * The HTTP method {@code HEAD}.
-	 * @see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.2">RFC 9110, section 9.3.2</a>
+	 * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.4">HTTP 1.1, section 9.4</a>
 	 */
 	public static final HttpMethod HEAD = new HttpMethod("HEAD");
 
 	/**
 	 * The HTTP method {@code POST}.
-	 * @see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.3">RFC 9110, section 9.3.3</a>
+	 * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.5">HTTP 1.1, section 9.5</a>
 	 */
 	public static final HttpMethod POST = new HttpMethod("POST");
 
 	/**
 	 * The HTTP method {@code PUT}.
-	 * @see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.4">RFC 9110, section 9.3.4</a>
+	 * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.6">HTTP 1.1, section 9.6</a>
 	 */
 	public static final HttpMethod PUT = new HttpMethod("PUT");
 
@@ -67,7 +67,7 @@ public final class HttpMethod implements Comparable<HttpMethod>, Serializable {
 
 	/**
 	 * The HTTP method {@code DELETE}.
-	 * @see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.5">RFC 9110, section 9.3.5</a>
+	 * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.7">HTTP 1.1, section 9.7</a>
 	 */
 	public static final HttpMethod DELETE = new HttpMethod("DELETE");
 
@@ -79,13 +79,13 @@ public final class HttpMethod implements Comparable<HttpMethod>, Serializable {
 
 	/**
 	 * The HTTP method {@code OPTIONS}.
-	 * @see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.7">RFC 9110, section 9.3.7</a>
+	 * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.2">HTTP 1.1, section 9.2</a>
 	 */
 	public static final HttpMethod OPTIONS = new HttpMethod("OPTIONS");
 
 	/**
 	 * The HTTP method {@code TRACE}.
-	 * @see <a href="https://www.rfc-editor.org/rfc/rfc9110.html#section-9.3.8">RFC 9110, section 9.3.8</a>
+	 * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.8">HTTP 1.1, section 9.8</a>
 	 */
 	public static final HttpMethod TRACE = new HttpMethod("TRACE");
 

--- a/spring-web/src/test/java/org/springframework/http/HttpMethodTests.java
+++ b/spring-web/src/test/java/org/springframework/http/HttpMethodTests.java
@@ -44,12 +44,12 @@ class HttpMethodTests {
 	void values() {
 		HttpMethod[] values = HttpMethod.values();
 		assertThat(values).containsExactly(HttpMethod.GET, HttpMethod.HEAD, HttpMethod.POST, HttpMethod.PUT,
-				HttpMethod.PATCH, HttpMethod.DELETE, HttpMethod.OPTIONS, HttpMethod.TRACE);
+				HttpMethod.PATCH, HttpMethod.DELETE, HttpMethod.CONNECT, HttpMethod.OPTIONS, HttpMethod.TRACE);
 
 		// check defensive copy
 		values[0] = HttpMethod.POST;
 		assertThat(HttpMethod.values()).containsExactly(HttpMethod.GET, HttpMethod.HEAD, HttpMethod.POST, HttpMethod.PUT,
-				HttpMethod.PATCH, HttpMethod.DELETE, HttpMethod.OPTIONS, HttpMethod.TRACE);
+				HttpMethod.PATCH, HttpMethod.DELETE, HttpMethod.CONNECT, HttpMethod.OPTIONS, HttpMethod.TRACE);
 	}
 
 	@Test

--- a/spring-web/src/test/java/org/springframework/http/client/reactive/ClientHttpConnectorTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/reactive/ClientHttpConnectorTests.java
@@ -271,6 +271,9 @@ class ClientHttpConnectorTests {
 		List<Arguments> result = new ArrayList<>();
 		for (Named<ClientHttpConnector> connector : connectors()) {
 			for (HttpMethod method : HttpMethod.values()) {
+				if (HttpMethod.CONNECT.equals(method) && List.of("HttpComponents", "Jdk").contains(connector.getName())) {
+					continue;
+				}
 				result.add(Arguments.of(connector, method));
 			}
 		}

--- a/spring-web/src/test/java/org/springframework/web/bind/annotation/RequestMethodTests.java
+++ b/spring-web/src/test/java/org/springframework/web/bind/annotation/RequestMethodTests.java
@@ -41,6 +41,10 @@ class RequestMethodTests {
 	@Test
 	void resolveHttpMethod() {
 		for (HttpMethod httpMethod : HttpMethod.values()) {
+			if (HttpMethod.CONNECT.equals(httpMethod)) {
+				assertThat(RequestMethod.resolve(httpMethod)).isNull();
+				continue;
+			}
 			RequestMethod requestMethod = RequestMethod.resolve(httpMethod);
 			assertThat(requestMethod).isNotNull();
 			assertThat(requestMethod.name()).isEqualTo(httpMethod.name());

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMapping.java
@@ -517,7 +517,7 @@ public abstract class RequestMappingInfoHandlerMapping extends AbstractHandlerMe
 			Set<HttpMethod> result = CollectionUtils.newLinkedHashSet(declaredMethods.size());
 			if (declaredMethods.isEmpty()) {
 				for (HttpMethod method : HttpMethod.values()) {
-					if (method != HttpMethod.TRACE) {
+					if (method != HttpMethod.TRACE && method != HttpMethod.CONNECT) {
 						result.add(method);
 					}
 				}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/support/WebContentGenerator.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/support/WebContentGenerator.java
@@ -146,7 +146,7 @@ public abstract class WebContentGenerator extends WebApplicationObjectSupport {
 		if (this.supportedMethods == null) {
 			allowedMethods = new ArrayList<>(HttpMethod.values().length - 1);
 			for (HttpMethod method : HttpMethod.values()) {
-				if (method != HttpMethod.TRACE) {
+				if (method != HttpMethod.TRACE && method != HttpMethod.CONNECT) {
 					allowedMethods.add(method.name());
 				}
 			}


### PR DESCRIPTION
While reviewing issue #34044, I noticed that the HttpMethod class does not include a constant for the HTTP method CONNECT, which was introduced in RFC 7231. This PR adds the CONNECT constant to the HttpMethod class and updates the test class HttpMethodTests.

Changes in other files:

- CONNECT method excluded in initAllowedHttpMethods of RequestMappingInfoHandlerMapping and in initAllowHeader of WebContentGenerator.

- CONNECT method is not supported by HttpComponentsClientHttpConnector and JdkClientHttpConnector, so ClientHttpConnectorTests was updated to dynamically skip CONNECT for these connectors.

- CONNECT method is primarily used for establishing tunnels, so it is not relevant for RequestMethod class and was excluded from RequestMethodTests.

These changes prepare the repository for a follow-up PR addressing issue #34044, where a conditional check will be introduced for WebSocket handshakes: if the HTTP version is HTTP/2 the method must be CONNECT, as specified in RFC 8441, otherwise it should be GET.