### PR TITLE
Optimization by caching the map of `cache key` and `shouldSkip`

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/autoproxy/AspectJAwareAdvisorAutoProxyCreator.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/autoproxy/AspectJAwareAdvisorAutoProxyCreator.java
@@ -119,7 +119,7 @@ public class AspectJAwareAdvisorAutoProxyCreator extends AbstractAdvisorAutoProx
 			if (skip == null) {
 				skip = super.shouldSkip(beanClass, beanName);
 			}
-			this.skippedBeans.put(beanName, skip);
+			this.skippedBeans.put(cacheKey, skip);
 		}
 		return skip;
 	}


### PR DESCRIPTION
I add the cache for method `AspectJAwareAdvisorAutoProxyCreator#shouldSkip`:
- the key of cache: the cache key for the given class and name
- the value of cache:  Boolean value of should skip

And resolve `TODO: Consider optimization by caching the list of the aspect names`.