### PR TITLE
Clarify that @Primary and @Fallback doesn't affect the sorting of beans

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/Fallback.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/Fallback.java
@@ -32,7 +32,8 @@ import java.lang.annotation.Target;
  * <p>Just like primary beans, fallback beans only have an effect when
  * finding multiple candidates for single injection points.
  * All type-matching beans are included when autowiring arrays,
- * collections, maps, or ObjectProvider streams.
+ * collections, maps, or ObjectProvider streams, this annotation
+ * doesn't affect the sorting of beans.
  *
  * @author Juergen Hoeller
  * @since 6.2

--- a/spring-context/src/main/java/org/springframework/context/annotation/Primary.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/Primary.java
@@ -29,7 +29,8 @@ import java.lang.annotation.Target;
  *
  * <p>Primary beans only have an effect when finding multiple candidates
  * for single injection points. All type-matching beans are included when
- * autowiring arrays, collections, maps, or ObjectProvider streams.
+ * autowiring arrays, collections, maps, or ObjectProvider streams,
+ * this annotation doesn't affect the sorting of beans.
  *
  * <p>This annotation is semantically equivalent to the {@code <bean>} element's
  * {@code primary} attribute in Spring XML.


### PR DESCRIPTION
Users may misunderstand that `@Primary` will be the first and `@Fallback` will be the last.