### PR TITLE
Remove the catch of NPE because this issue had resolved at Jetty 12.0.2.

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/adapter/jetty/JettyWebSocketSession.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/adapter/jetty/JettyWebSocketSession.java
@@ -183,13 +183,7 @@ public class JettyWebSocketSession extends AbstractWebSocketSession<Session> {
 		this.extensions = getExtensions(session);
 
 		if (this.user == null) {
-			try {
-				this.user = session.getUpgradeRequest().getUserPrincipal();
-			}
-			catch (NullPointerException ex) {
-				// Necessary until https://github.com/eclipse/jetty.project/issues/10498 is resolved
-				logger.error("Failure from UpgradeRequest while getting Principal", ex);
-			}
+			this.user = session.getUpgradeRequest().getUserPrincipal();
 		}
 	}
 


### PR DESCRIPTION
https://github.com/eclipse/jetty.project/issues/10498 had resolved