### PR TITLE
Improve consistency in StandardMultipartFile implementation

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/multipart/support/StandardMultipartHttpServletRequest.java
+++ b/spring-web/src/main/java/org/springframework/web/multipart/support/StandardMultipartHttpServletRequest.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/spring-web/src/main/java/org/springframework/web/multipart/support/StandardMultipartHttpServletRequest.java
+++ b/spring-web/src/main/java/org/springframework/web/multipart/support/StandardMultipartHttpServletRequest.java
@@ -242,7 +242,7 @@ public class StandardMultipartHttpServletRequest extends AbstractMultipartHttpSe
 
 		@Override
 		public boolean isEmpty() {
-			return (this.part.getSize() == 0);
+			return (getSize() == 0);
 		}
 
 		@Override
@@ -252,7 +252,7 @@ public class StandardMultipartHttpServletRequest extends AbstractMultipartHttpSe
 
 		@Override
 		public byte[] getBytes() throws IOException {
-			return FileCopyUtils.copyToByteArray(this.part.getInputStream());
+			return FileCopyUtils.copyToByteArray(getInputStream());
 		}
 
 		@Override
@@ -270,13 +270,8 @@ public class StandardMultipartHttpServletRequest extends AbstractMultipartHttpSe
 				// At least we offloaded the file from memory storage; it'll get deleted
 				// from the temp dir eventually in any case. And for our user's purposes,
 				// we can manually copy it to the requested location as a fallback.
-				FileCopyUtils.copy(this.part.getInputStream(), Files.newOutputStream(dest.toPath()));
+				FileCopyUtils.copy(getInputStream(), Files.newOutputStream(dest.toPath()));
 			}
-		}
-
-		@Override
-		public void transferTo(Path dest) throws IOException, IllegalStateException {
-			FileCopyUtils.copy(this.part.getInputStream(), Files.newOutputStream(dest));
 		}
 	}
 


### PR DESCRIPTION
This PR refactors the **StandardMultipartFile** class to enhance consistency

**Changes include:**

1. Removed the `transferTo(Path dest)` method from **StandardMultipartFile**, as it is already provided as a default method in the **MultipartFile** interface.
2. Updated the `transferTo(File dest)` method to use `getInputStream()` for consistency with the **MultipartFile** interface's default `transferTo(Path dest)` implementation.
3. Modified the `isEmpty` and `getBytes` methods to also utilize internal methods (`getSize()` and `getInputStream()` respectively) for better code consistency.