### PR TITLE
Make multiple slash sanitization optional in web util

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UrlPathHelper.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UrlPathHelper.java
@@ -79,6 +79,8 @@ public class UrlPathHelper {
 
 	private boolean removeSemicolonContent = true;
 
+	private boolean sanitizePath = true;
+
 	private String defaultEncoding = WebUtils.DEFAULT_CHARACTER_ENCODING;
 
 	private boolean readOnly = false;
@@ -143,6 +145,22 @@ public class UrlPathHelper {
 	 */
 	public boolean shouldRemoveSemicolonContent() {
 		return this.removeSemicolonContent;
+	}
+
+	/**
+	 * Set if double slashes to be replaced by single slash in the request URI.
+	 * <p>Default is "true".
+	 */
+	public void setSanitizePath(boolean sanitizePath) {
+		checkReadOnly();
+		this.sanitizePath = sanitizePath;
+	}
+
+	/**
+	 * Whether configured to replace double slashes with single slash from the request URI.
+	 */
+	public boolean shouldSanitizePath() {
+		return this.sanitizePath;
 	}
 
 	/**
@@ -392,12 +410,16 @@ public class UrlPathHelper {
 	}
 
 	/**
-	 * Sanitize the given path. Uses the following rules:
+	 * Sanitize the given path if {code shouldSanitizePath()} is true.
+	 * Uses the following rules:
 	 * <ul>
 	 * <li>replace all "//" by "/"</li>
 	 * </ul>
 	 */
-	private static String getSanitizedPath(final String path) {
+	private String getSanitizedPath(final String path) {
+		if (!shouldSanitizePath()) {
+			return path;
+		}
 		int start = path.indexOf("//");
 		if (start == -1) {
 			return path;

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -849,8 +849,20 @@ class UriComponentsBuilderTests {
 	}
 
 	@Test  // gh-26012
-	void verifyDoubleSlashReplacedWithSingleOne() {
+	void verifyDoubleSlashReplacedWithSingleDefault() {
 		String path = UriComponentsBuilder.fromPath("/home/").path("/path").build().getPath();
+		assertThat(path).isEqualTo("/home/path");
+	}
+
+	@Test  // gh-34076
+	void verifyDoubleSlashNotReplacedAsSingleSlash() {
+		String path = UriComponentsBuilder.fromPath("/home/").path("/path").build(true, false).getPath();
+		assertThat(path).isEqualTo("/home//path");
+	}
+
+	@Test  // gh-34076
+	void verifyDoubleSlashReplacedAsSingleSlashWithConfig() {
+		String path = UriComponentsBuilder.fromPath("/home/").path("/path").build(true, true).getPath();
 		assertThat(path).isEqualTo("/home/path");
 	}
 

--- a/spring-web/src/test/java/org/springframework/web/util/UrlPathHelperTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UrlPathHelperTests.java
@@ -110,6 +110,20 @@ class UrlPathHelperTests {
 		assertThat(helper.getRequestUri(request)).isEqualTo("/home/path");
 	}
 
+	@Test // gh-34076
+	void getRequestUriWithSanitizingDisabled() {
+		helper.setSanitizePath(false);
+		request.setRequestURI("/home/" + "/path");
+		assertThat(helper.getRequestUri(request)).isEqualTo("/home//path");
+	}
+
+	@Test // gh-34076
+	void getRequestUriWithSanitizingEnabled() {
+		helper.setSanitizePath(true);
+		request.setRequestURI("/home/" + "/path");
+		assertThat(helper.getRequestUri(request)).isEqualTo("/home/path");
+	}
+
 	@Test
 	void getRequestRemoveSemicolonContent() {
 		helper.setRemoveSemicolonContent(true);


### PR DESCRIPTION
Make multiple slash sanitization optional in UriComponentsBuilder and UrlPathHelper

No breaking changes introduced; users can continue using the default behavior without modification. 
Optional multi-slash sanitization is added to align with section 3.3 of [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt), which permits empty path segments.

Closes gh-34076
