### PR TITLE
Introduce `@BeanAlias` to support adding bean aliases declaratively outside of bean definitions

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/BeanAlias.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/BeanAlias.java
@@ -1,0 +1,42 @@
+package org.springframework.context.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation that declares a single bean alias.
+ *
+ * <p>This annotation can be used on a configuration class to declare an alias for a specific bean.
+ * It is processed by the {@link BeanAliasRegistrar} which registers the specified alias with the
+ * application context. Multiple aliases can be declared using the {@link BeanAliases} container
+ * annotation.
+ *
+ * @author Tiger Zhao
+ * @since 7.0.0
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+@Repeatable(BeanAliases.class)
+@Documented
+@Import(BeanAliasRegistrar.class)
+public @interface BeanAlias {
+
+	/**
+	 * The name of the bean for which this alias is being declared.
+	 *
+	 * @return the name of the bean
+	 */
+	String name();
+
+	/**
+	 * An array of alias names for the specified bean.
+	 *
+	 * @return an array of alias names
+	 */
+	String[] alias();
+}

--- a/spring-context/src/main/java/org/springframework/context/annotation/BeanAliasRegistrar.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/BeanAliasRegistrar.java
@@ -1,0 +1,62 @@
+package org.springframework.context.annotation;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.util.Assert;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * A registrar for handling {@code @BeanAliases} and {@code @BeanAlias} annotations.
+ * This class registers aliases for beans defined via these annotations.
+ *
+ * <p>This class implements the {@link ImportBeanDefinitionRegistrar} interface to allow
+ * custom processing of bean definitions during the import phase.
+ *
+ * @author Tiger Zhao
+ * @since 7.0.0
+ */
+public class BeanAliasRegistrar implements ImportBeanDefinitionRegistrar {
+
+	private static final Log logger = LogFactory.getLog(AnnotationBeanNameGenerator.class);
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void registerBeanDefinitions(AnnotationMetadata metadata, BeanDefinitionRegistry registry) {
+		// Register aliases from @BeanAliases annotation
+		Map<String, Object> aliasesAttr = metadata.getAnnotationAttributes(BeanAliases.class.getName());
+		if (null != aliasesAttr) {
+			aliasesAttr.values().stream().flatMap(v -> Stream.of((Map<String, Object>[]) v)).forEach(attr -> registerAlias(registry, attr));
+		}
+
+		// Register alias from @BeanAlias annotation
+		Map<String, Object> aliasAttr = metadata.getAnnotationAttributes(BeanAlias.class.getName());
+		if (null != aliasAttr) {
+			registerAlias(registry, aliasAttr);
+		}
+	}
+
+	/**
+	 * Registers an alias for a bean based on the provided attributes.
+	 *
+	 * @param registry   the bean definition registry to register the alias in
+	 * @param attributes the attributes from the {@code @BeanAlias} or {@code @BeanAliases} annotation
+	 */
+	protected void registerAlias(BeanDefinitionRegistry registry, Map<String, Object> attributes) {
+		String name = (String) attributes.get("name");
+		Assert.hasLength(name, "name must not be empty");
+		String[] aliases = (String[]) attributes.get("alias");
+		Assert.notEmpty(aliases, "alias must not be empty");
+
+		for (String alias : aliases) {
+			if (logger.isDebugEnabled()) {
+				logger.debug(String.format("register bean alias for '%s': %s", name, alias));
+			}
+			registry.registerAlias(name, alias);
+		}
+	}
+
+}

--- a/spring-context/src/main/java/org/springframework/context/annotation/BeanAliases.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/BeanAliases.java
@@ -1,0 +1,32 @@
+package org.springframework.context.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation that aggregates multiple {@link BeanAlias} declarations.
+ *
+ * <p>This annotation can be used on a configuration class to declare multiple bean aliases
+ * in a single place. It is processed by the {@link BeanAliasRegistrar} which registers the
+ * specified aliases with the application context.
+ *
+ * @author Tiger Zhao
+ * @since 7.0.0
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+@Documented
+@Import(BeanAliasRegistrar.class)
+public @interface BeanAliases {
+
+	/**
+	 * Returns an array of {@link BeanAlias} declarations.
+	 *
+	 * @return an array of {@code @BeanAlias} annotations
+	 */
+	BeanAlias[] value();
+}

--- a/spring-context/src/test/java/org/springframework/context/annotation/BeanAliasRegistrarTest.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/BeanAliasRegistrarTest.java
@@ -1,0 +1,58 @@
+package org.springframework.context.annotation;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+/**
+ * Tests for {@link BeanAliasRegistrar}.
+ *
+ * <p>This class contains unit tests to verify the functionality of the {@link BeanAliasRegistrar}
+ * class, ensuring that bean aliases are correctly registered based on the {@link BeanAlias} and
+ * {@link BeanAliases} annotations.
+ *
+ * @author Tiger Zhao
+ * @since 7.0.0
+ */
+class BeanAliasRegistrarTest {
+
+	@Test
+	public void test() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+		context.register(ConfigOfThisProject.class);
+		context.register(ConfigFromOtherProject.class);
+		context.refresh();
+
+		Object bean0 = context.getBean("bean0");
+		assertThat(bean0).isNotNull();
+		Object bean1 = context.getBean("bean1");
+		assertThat(bean1).isNotNull();
+		assertThat(bean1).isSameAs(bean0);
+		Object bean2 = context.getBean("bean2");
+		assertThat(bean2).isNotNull();
+		assertThat(bean2).isSameAs(bean0);
+		Object bean3 = context.getBean("bean3");
+		assertThat(bean3).isNotNull();
+		assertThat(bean3).isSameAs(bean0);
+	}
+
+	@BeanAlias(name = "bean0", alias = "bean1")
+	@BeanAliases({
+			@BeanAlias(name = "bean0", alias = "bean2"),
+			@BeanAlias(name = "bean0", alias = "bean3")
+	})
+	static class ConfigOfThisProject {
+
+	}
+
+	static class ConfigFromOtherProject {
+
+		@Bean
+		String bean0() {
+			return "";
+		}
+
+	}
+
+
+}

--- a/spring-context/src/test/java/org/springframework/context/annotation/BeanAliasRegistrarTest.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/BeanAliasRegistrarTest.java
@@ -1,6 +1,7 @@
 package org.springframework.context.annotation;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
@@ -23,33 +24,41 @@ class BeanAliasRegistrarTest {
 		context.register(ConfigFromOtherProject.class);
 		context.refresh();
 
-		Object bean0 = context.getBean("bean0");
-		assertThat(bean0).isNotNull();
+		Object beanCreateByOtherProject = context.getBean("beanCreateByOtherProject");
+		assertThat(beanCreateByOtherProject).isNotNull();
+		Object driver = context.getBean("driver");
+		assertThat(driver).isNotNull();
+		assertThat(driver).isSameAs(beanCreateByOtherProject);
 		Object bean1 = context.getBean("bean1");
 		assertThat(bean1).isNotNull();
-		assertThat(bean1).isSameAs(bean0);
+		assertThat(bean1).isSameAs(beanCreateByOtherProject);
 		Object bean2 = context.getBean("bean2");
 		assertThat(bean2).isNotNull();
-		assertThat(bean2).isSameAs(bean0);
-		Object bean3 = context.getBean("bean3");
-		assertThat(bean3).isNotNull();
-		assertThat(bean3).isSameAs(bean0);
+		assertThat(bean2).isSameAs(beanCreateByOtherProject);
+		Object beanCreateInThisProject = context.getBean("beanCreateInThisProject");
+		assertThat(beanCreateInThisProject).isNotNull();
+		assertThat(beanCreateInThisProject).isEqualTo("working with otherProjectDriver");
 	}
 
-	@BeanAlias(name = "bean0", alias = "bean1")
+	@BeanAlias(name = "beanCreateByOtherProject", alias = "driver")
 	@BeanAliases({
-			@BeanAlias(name = "bean0", alias = "bean2"),
-			@BeanAlias(name = "bean0", alias = "bean3")
+			@BeanAlias(name = "beanCreateByOtherProject", alias = "bean1"),
+			@BeanAlias(name = "beanCreateByOtherProject", alias = "bean2")
 	})
 	static class ConfigOfThisProject {
+
+		@Bean
+		String beanCreateInThisProject(@Qualifier("driver") String driver) {
+			return "working with " + driver;
+		}
 
 	}
 
 	static class ConfigFromOtherProject {
 
 		@Bean
-		String bean0() {
-			return "";
+		String beanCreateByOtherProject() {
+			return "otherProjectDriver";
 		}
 
 	}


### PR DESCRIPTION
Sometimes when you integrate with other projects, you want to use beans created in that project in other code, but you need to follow the naming convention. Or just use the beans you created in other modules to replace beans with the same functionality in another project.
Here I added a @BeanAlias ​​annotation so that simply declaring the bean alias in the configuration can achieve the effect.