### PR TITLE
Extend HTTP status assertions

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/http/HttpStatusAssert.java
+++ b/spring-test/src/main/java/org/springframework/test/http/HttpStatusAssert.java
@@ -1,0 +1,310 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.http;
+
+import org.assertj.core.api.AbstractObjectAssert;
+import org.assertj.core.api.Assert;
+import org.assertj.core.api.Assertions;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatus.Series;
+
+/**
+ * AssertJ {@link Assert assertions} that can be applied to
+ * {@link HttpStatus}.
+ *
+ * @author Christian Morbach
+ */
+public class HttpStatusAssert extends AbstractObjectAssert<HttpStatusAssert, HttpStatus> {
+
+	public HttpStatusAssert(int statusCode) {
+		this(HttpStatus.valueOf(statusCode));
+	}
+
+	HttpStatusAssert(HttpStatus httpStatus) {
+		super(httpStatus, HttpStatusAssert.class);
+		as("HTTP status code");
+	}
+
+	public HttpStatusAssert isEqualTo(int httpStatus) {
+		return isEqualTo(HttpStatus.resolve(httpStatus));
+	}
+
+	public HttpStatusAssert is1xxInformational() {
+		return hasSeries(Series.INFORMATIONAL);
+	}
+
+	public HttpStatusAssert is2xxSuccessful() {
+		return hasSeries(Series.SUCCESSFUL);
+	}
+
+	public HttpStatusAssert is3xxRedirection() {
+		return hasSeries(Series.REDIRECTION);
+	}
+
+	public HttpStatusAssert is4xxClientError() {
+		return hasSeries(Series.CLIENT_ERROR);
+	}
+
+	public HttpStatusAssert is5xxServerError() {
+		return hasSeries(Series.SERVER_ERROR);
+	}
+
+	public HttpStatusAssert isContinue() {
+		return isEqualTo(HttpStatus.CONTINUE);
+	}
+
+	public HttpStatusAssert isSwitchingProtocols() {
+		return isEqualTo(HttpStatus.SWITCHING_PROTOCOLS);
+	}
+
+	public HttpStatusAssert isProcessing() {
+		return isEqualTo(HttpStatus.PROCESSING);
+	}
+
+	public HttpStatusAssert isEarlyHints() {
+		return isEqualTo(HttpStatus.EARLY_HINTS);
+	}
+
+	public HttpStatusAssert isOk() {
+		return isEqualTo(HttpStatus.OK);
+	}
+
+	public HttpStatusAssert isCreated() {
+		return isEqualTo(HttpStatus.CREATED);
+	}
+
+	public HttpStatusAssert isAccepted() {
+		return isEqualTo(HttpStatus.ACCEPTED);
+	}
+
+	public HttpStatusAssert isNonAuthoritativeInformation() {
+		return isEqualTo(HttpStatus.NON_AUTHORITATIVE_INFORMATION);
+	}
+
+	public HttpStatusAssert isNoContent() {
+		return isEqualTo(HttpStatus.NO_CONTENT);
+	}
+
+	public HttpStatusAssert isResetContent() {
+		return isEqualTo(HttpStatus.RESET_CONTENT);
+	}
+
+	public HttpStatusAssert isPartialContent() {
+		return isEqualTo(HttpStatus.PARTIAL_CONTENT);
+	}
+
+	public HttpStatusAssert isMultiStatus() {
+		return isEqualTo(HttpStatus.MULTI_STATUS);
+	}
+
+	public HttpStatusAssert isAlreadyReported() {
+		return isEqualTo(HttpStatus.ALREADY_REPORTED);
+	}
+
+	public HttpStatusAssert isIMUsed() {
+		return isEqualTo(HttpStatus.IM_USED);
+	}
+
+	public HttpStatusAssert isMultipleChoices() {
+		return isEqualTo(HttpStatus.MULTIPLE_CHOICES);
+	}
+
+	public HttpStatusAssert isMovedPermanently() {
+		return isEqualTo(HttpStatus.MOVED_PERMANENTLY);
+	}
+
+	public HttpStatusAssert isFound() {
+		return isEqualTo(HttpStatus.FOUND);
+	}
+
+	public HttpStatusAssert isSeeOther() {
+		return isEqualTo(HttpStatus.SEE_OTHER);
+	}
+
+	public HttpStatusAssert isNotModified() {
+		return isEqualTo(HttpStatus.NOT_MODIFIED);
+	}
+
+	public HttpStatusAssert isTemporaryRedirect() {
+		return isEqualTo(HttpStatus.TEMPORARY_REDIRECT);
+	}
+
+	public HttpStatusAssert isPermanentRedirect() {
+		return isEqualTo(HttpStatus.PERMANENT_REDIRECT);
+	}
+
+	public HttpStatusAssert isBadRequest() {
+		return isEqualTo(HttpStatus.BAD_REQUEST);
+	}
+
+	public HttpStatusAssert isUnauthorized() {
+		return isEqualTo(HttpStatus.UNAUTHORIZED);
+	}
+
+	public HttpStatusAssert isPaymentRequired() {
+		return isEqualTo(HttpStatus.PAYMENT_REQUIRED);
+	}
+
+	public HttpStatusAssert isForbidden() {
+		return isEqualTo(HttpStatus.FORBIDDEN);
+	}
+
+	public HttpStatusAssert isNotFound() {
+		return isEqualTo(HttpStatus.NOT_FOUND);
+	}
+
+	public HttpStatusAssert isMethodNotAllowed() {
+		return isEqualTo(HttpStatus.METHOD_NOT_ALLOWED);
+	}
+
+	public HttpStatusAssert isNotAcceptable() {
+		return isEqualTo(HttpStatus.NOT_ACCEPTABLE);
+	}
+
+	public HttpStatusAssert isProxyAuthenticationRequired() {
+		return isEqualTo(HttpStatus.PROXY_AUTHENTICATION_REQUIRED);
+	}
+
+	public HttpStatusAssert isRequestTimeout() {
+		return isEqualTo(HttpStatus.REQUEST_TIMEOUT);
+	}
+
+	public HttpStatusAssert isConflict() {
+		return isEqualTo(HttpStatus.CONFLICT);
+	}
+
+	public HttpStatusAssert isGone() {
+		return isEqualTo(HttpStatus.GONE);
+	}
+
+	public HttpStatusAssert isLengthRequired() {
+		return isEqualTo(HttpStatus.LENGTH_REQUIRED);
+	}
+
+	public HttpStatusAssert isPreconditionFailed() {
+		return isEqualTo(HttpStatus.PRECONDITION_FAILED);
+	}
+
+	public HttpStatusAssert isPayloadTooLarge() {
+		return isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE);
+	}
+
+	public HttpStatusAssert isURITooLong() {
+		return isEqualTo(HttpStatus.URI_TOO_LONG);
+	}
+
+	public HttpStatusAssert isUnsupportedMediaType() {
+		return isEqualTo(HttpStatus.UNSUPPORTED_MEDIA_TYPE);
+	}
+
+	public HttpStatusAssert isRequestedRangeNotSatisfiable() {
+		return isEqualTo(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE);
+	}
+
+	public HttpStatusAssert isExpectationFailed() {
+		return isEqualTo(HttpStatus.EXPECTATION_FAILED);
+	}
+
+	public HttpStatusAssert isUnprocessableEntity() {
+		return isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+	}
+
+	public HttpStatusAssert isLocked() {
+		return isEqualTo(HttpStatus.LOCKED);
+	}
+
+	public HttpStatusAssert isFailedDependency() {
+		return isEqualTo(HttpStatus.FAILED_DEPENDENCY);
+	}
+
+	public HttpStatusAssert isTooEarly() {
+		return isEqualTo(HttpStatus.TOO_EARLY);
+	}
+
+	public HttpStatusAssert isUpgradeRequired() {
+		return isEqualTo(HttpStatus.UPGRADE_REQUIRED);
+	}
+
+	public HttpStatusAssert isPreconditionRequired() {
+		return isEqualTo(HttpStatus.PRECONDITION_REQUIRED);
+	}
+
+	public HttpStatusAssert isTooManyRequests() {
+		return isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+	}
+
+	public HttpStatusAssert isRequestHeaderFieldsTooLarge() {
+		return isEqualTo(HttpStatus.REQUEST_HEADER_FIELDS_TOO_LARGE);
+	}
+
+	public HttpStatusAssert isUnavailableForLegalReasons() {
+		return isEqualTo(HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS);
+	}
+
+	public HttpStatusAssert isInternalServerError() {
+		return isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+
+	public HttpStatusAssert isNotImplemented() {
+		return isEqualTo(HttpStatus.NOT_IMPLEMENTED);
+	}
+
+	public HttpStatusAssert isBadGateway() {
+		return isEqualTo(HttpStatus.BAD_GATEWAY);
+	}
+
+	public HttpStatusAssert isServiceUnavailable() {
+		return isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+	}
+
+	public HttpStatusAssert isGatewayTimeout() {
+		return isEqualTo(HttpStatus.GATEWAY_TIMEOUT);
+	}
+
+	public HttpStatusAssert isHttpVersionNotSupported() {
+		return isEqualTo(HttpStatus.HTTP_VERSION_NOT_SUPPORTED);
+	}
+
+	public HttpStatusAssert isVariantAlsoNegotiates() {
+		return isEqualTo(HttpStatus.VARIANT_ALSO_NEGOTIATES);
+	}
+
+	public HttpStatusAssert isInsufficientStorage() {
+		return isEqualTo(HttpStatus.INSUFFICIENT_STORAGE);
+	}
+
+	public HttpStatusAssert isLoopDetected() {
+		return isEqualTo(HttpStatus.LOOP_DETECTED);
+	}
+
+	public HttpStatusAssert isBandwidthLimitExceeded() {
+		return isEqualTo(HttpStatus.BANDWIDTH_LIMIT_EXCEEDED);
+	}
+
+	public HttpStatusAssert isNotExtended() {
+		return isEqualTo(HttpStatus.NOT_EXTENDED);
+	}
+
+	public HttpStatusAssert isNetworkAuthenticationRequired() {
+		return isEqualTo(HttpStatus.NETWORK_AUTHENTICATION_REQUIRED);
+	}
+
+	private HttpStatusAssert hasSeries(Series series) {
+		Assertions.assertThat(Series.resolve(this.actual.value())).isEqualTo(series);
+		return this.myself;
+	}
+}

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/assertj/AbstractHttpServletResponseAssert.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/assertj/AbstractHttpServletResponseAssert.java
@@ -30,6 +30,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatus.Series;
 import org.springframework.http.MediaType;
 import org.springframework.test.http.HttpHeadersAssert;
+import org.springframework.test.http.HttpStatusAssert;
 import org.springframework.test.http.MediaTypeAssert;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -54,6 +55,8 @@ public abstract class AbstractHttpServletResponseAssert<R extends HttpServletRes
 
 	private final Supplier<HttpHeadersAssert> headersAssertSupplier;
 
+	private final Supplier<HttpStatusAssert> statusAssertSupplier;
+
 	private final Supplier<AbstractIntegerAssert<?>> statusAssert;
 
 
@@ -62,6 +65,7 @@ public abstract class AbstractHttpServletResponseAssert<R extends HttpServletRes
 		this.contentTypeAssertSupplier = SingletonSupplier.of(() -> new MediaTypeAssert(getResponse().getContentType()));
 		this.headersAssertSupplier = SingletonSupplier.of(() -> new HttpHeadersAssert(getHttpHeaders(getResponse())));
 		this.statusAssert = SingletonSupplier.of(() -> Assertions.assertThat(getResponse().getStatus()).as("HTTP status code"));
+		this.statusAssertSupplier = SingletonSupplier.of(() -> new HttpStatusAssert(getResponse().getStatus()));
 	}
 
 	private static HttpHeaders getHttpHeaders(HttpServletResponse response) {
@@ -101,6 +105,10 @@ public abstract class AbstractHttpServletResponseAssert<R extends HttpServletRes
 	 */
 	public HttpHeadersAssert headers() {
 		return this.headersAssertSupplier.get();
+	}
+
+	public HttpStatusAssert httpStatus() {
+		return this.statusAssertSupplier.get();
 	}
 
 	// Content-type shortcuts

--- a/spring-test/src/test/java/org/springframework/test/http/HttpStatusAssertTests.java
+++ b/spring-test/src/test/java/org/springframework/test/http/HttpStatusAssertTests.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2002-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.http;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.lang.NonNull;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+/**
+ * Tests for {@link HttpStatusAssert}.
+ *
+ * @author Christian Morbach
+ */
+class HttpStatusAssertTests {
+
+	@Test
+	void isEqualWhenExpectedIsNullShouldFail() {
+		assertThatExceptionOfType(AssertionError.class)
+				.isThrownBy(() -> assertThat(HttpStatus.OK).isEqualTo(null))
+				.withMessageContaining("HTTP status code");
+	}
+
+	@ParameterizedTest
+	@MethodSource
+	void isStatusCodeWithSameStatusCodeShouldPass(HttpStatus status, String methodName) throws Exception {
+		var function = HttpStatusAssert.class.getMethod(methodName);
+		assertThatNoException().isThrownBy(() -> function.invoke(assertThat(status)));
+	}
+
+	private static Stream<Arguments> isStatusCodeWithSameStatusCodeShouldPass() {
+		return Stream.of(
+				Arguments.of(HttpStatus.CONTINUE, "isContinue"),
+				Arguments.of(HttpStatus.SWITCHING_PROTOCOLS, "isSwitchingProtocols"),
+				Arguments.of(HttpStatus.PROCESSING, "isProcessing"),
+				Arguments.of(HttpStatus.EARLY_HINTS, "isEarlyHints"),
+				Arguments.of(HttpStatus.OK, "isOk"),
+				Arguments.of(HttpStatus.CREATED, "isCreated"),
+				Arguments.of(HttpStatus.ACCEPTED, "isAccepted"),
+				Arguments.of(HttpStatus.NON_AUTHORITATIVE_INFORMATION, "isNonAuthoritativeInformation"),
+				Arguments.of(HttpStatus.NO_CONTENT, "isNoContent"),
+				Arguments.of(HttpStatus.RESET_CONTENT, "isResetContent"),
+				Arguments.of(HttpStatus.PARTIAL_CONTENT, "isPartialContent"),
+				Arguments.of(HttpStatus.MULTI_STATUS, "isMultiStatus"),
+				Arguments.of(HttpStatus.ALREADY_REPORTED, "isAlreadyReported"),
+				Arguments.of(HttpStatus.IM_USED, "isIMUsed"),
+				Arguments.of(HttpStatus.MULTIPLE_CHOICES, "isMultipleChoices"),
+				Arguments.of(HttpStatus.FOUND, "isFound"),
+				Arguments.of(HttpStatus.SEE_OTHER, "isSeeOther"),
+				Arguments.of(HttpStatus.NOT_MODIFIED, "isNotModified"),
+				Arguments.of(HttpStatus.TEMPORARY_REDIRECT, "isTemporaryRedirect"),
+				Arguments.of(HttpStatus.PERMANENT_REDIRECT, "isPermanentRedirect"),
+				Arguments.of(HttpStatus.BAD_REQUEST, "isBadRequest"),
+				Arguments.of(HttpStatus.UNAUTHORIZED, "isUnauthorized"),
+				Arguments.of(HttpStatus.PAYMENT_REQUIRED, "isPaymentRequired"),
+				Arguments.of(HttpStatus.FORBIDDEN, "isForbidden"),
+				Arguments.of(HttpStatus.NOT_FOUND, "isNotFound"),
+				Arguments.of(HttpStatus.METHOD_NOT_ALLOWED, "isMethodNotAllowed"),
+				Arguments.of(HttpStatus.NOT_ACCEPTABLE, "isNotAcceptable"),
+				Arguments.of(HttpStatus.PROXY_AUTHENTICATION_REQUIRED, "isProxyAuthenticationRequired"),
+				Arguments.of(HttpStatus.REQUEST_TIMEOUT, "isRequestTimeout"),
+				Arguments.of(HttpStatus.CONFLICT, "isConflict"),
+				Arguments.of(HttpStatus.GONE, "isGone"),
+				Arguments.of(HttpStatus.LENGTH_REQUIRED, "isLengthRequired"),
+				Arguments.of(HttpStatus.PRECONDITION_FAILED, "isPreconditionFailed"),
+				Arguments.of(HttpStatus.PAYLOAD_TOO_LARGE, "isPayloadTooLarge"),
+				Arguments.of(HttpStatus.URI_TOO_LONG, "isURITooLong"),
+				Arguments.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "isUnsupportedMediaType"),
+				Arguments.of(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE, "isRequestedRangeNotSatisfiable"),
+				Arguments.of(HttpStatus.EXPECTATION_FAILED, "isExpectationFailed"),
+				Arguments.of(HttpStatus.UNPROCESSABLE_ENTITY, "isUnprocessableEntity"),
+				Arguments.of(HttpStatus.LOCKED, "isLocked"),
+				Arguments.of(HttpStatus.FAILED_DEPENDENCY, "isFailedDependency"),
+				Arguments.of(HttpStatus.TOO_EARLY, "isTooEarly"),
+				Arguments.of(HttpStatus.UPGRADE_REQUIRED, "isUpgradeRequired"),
+				Arguments.of(HttpStatus.PRECONDITION_REQUIRED, "isPreconditionRequired"),
+				Arguments.of(HttpStatus.TOO_MANY_REQUESTS, "isTooManyRequests"),
+				Arguments.of(HttpStatus.REQUEST_HEADER_FIELDS_TOO_LARGE, "isRequestHeaderFieldsTooLarge"),
+				Arguments.of(HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS, "isUnavailableForLegalReasons"),
+				Arguments.of(HttpStatus.INTERNAL_SERVER_ERROR, "isInternalServerError"),
+				Arguments.of(HttpStatus.NOT_IMPLEMENTED, "isNotImplemented"),
+				Arguments.of(HttpStatus.BAD_GATEWAY, "isBadGateway"),
+				Arguments.of(HttpStatus.SERVICE_UNAVAILABLE, "isServiceUnavailable"),
+				Arguments.of(HttpStatus.GATEWAY_TIMEOUT, "isGatewayTimeout"),
+				Arguments.of(HttpStatus.HTTP_VERSION_NOT_SUPPORTED, "isHttpVersionNotSupported"),
+				Arguments.of(HttpStatus.VARIANT_ALSO_NEGOTIATES, "isVariantAlsoNegotiates"),
+				Arguments.of(HttpStatus.INSUFFICIENT_STORAGE, "isInsufficientStorage"),
+				Arguments.of(HttpStatus.LOOP_DETECTED, "isLoopDetected"),
+				Arguments.of(HttpStatus.BANDWIDTH_LIMIT_EXCEEDED, "isBandwidthLimitExceeded"),
+				Arguments.of(HttpStatus.NOT_EXTENDED, "isNotExtended"),
+				Arguments.of(HttpStatus.NETWORK_AUTHENTICATION_REQUIRED, "isNetworkAuthenticationRequired")
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource
+	void isSeriesShouldPassOnSameSeries(HttpStatus status, String methodName) throws Exception {
+		var function = HttpStatusAssert.class.getMethod(methodName);
+		assertThatNoException().isThrownBy(() -> function.invoke(assertThat(status)));
+	}
+
+	private static Stream<Arguments> isSeriesShouldPassOnSameSeries() {
+		return Stream.of(
+				Arguments.of(HttpStatus.CONTINUE, "is1xxInformational"),
+				Arguments.of(HttpStatus.SWITCHING_PROTOCOLS, "is1xxInformational"),
+				Arguments.of(HttpStatus.PROCESSING, "is1xxInformational"),
+				Arguments.of(HttpStatus.EARLY_HINTS, "is1xxInformational"),
+				Arguments.of(HttpStatus.OK, "is2xxSuccessful"),
+				Arguments.of(HttpStatus.CREATED, "is2xxSuccessful"),
+				Arguments.of(HttpStatus.ACCEPTED, "is2xxSuccessful"),
+				Arguments.of(HttpStatus.NON_AUTHORITATIVE_INFORMATION, "is2xxSuccessful"),
+				Arguments.of(HttpStatus.NO_CONTENT, "is2xxSuccessful"),
+				Arguments.of(HttpStatus.RESET_CONTENT, "is2xxSuccessful"),
+				Arguments.of(HttpStatus.PARTIAL_CONTENT, "is2xxSuccessful"),
+				Arguments.of(HttpStatus.MULTI_STATUS, "is2xxSuccessful"),
+				Arguments.of(HttpStatus.ALREADY_REPORTED, "is2xxSuccessful"),
+				Arguments.of(HttpStatus.IM_USED, "is2xxSuccessful"),
+				Arguments.of(HttpStatus.MULTIPLE_CHOICES, "is3xxRedirection"),
+				Arguments.of(HttpStatus.FOUND, "is3xxRedirection"),
+				Arguments.of(HttpStatus.SEE_OTHER, "is3xxRedirection"),
+				Arguments.of(HttpStatus.NOT_MODIFIED, "is3xxRedirection"),
+				Arguments.of(HttpStatus.TEMPORARY_REDIRECT, "is3xxRedirection"),
+				Arguments.of(HttpStatus.PERMANENT_REDIRECT, "is3xxRedirection"),
+				Arguments.of(HttpStatus.BAD_REQUEST, "is4xxClientError"),
+				Arguments.of(HttpStatus.UNAUTHORIZED, "is4xxClientError"),
+				Arguments.of(HttpStatus.PAYMENT_REQUIRED, "is4xxClientError"),
+				Arguments.of(HttpStatus.FORBIDDEN, "is4xxClientError"),
+				Arguments.of(HttpStatus.NOT_FOUND, "is4xxClientError"),
+				Arguments.of(HttpStatus.METHOD_NOT_ALLOWED, "is4xxClientError"),
+				Arguments.of(HttpStatus.NOT_ACCEPTABLE, "is4xxClientError"),
+				Arguments.of(HttpStatus.PROXY_AUTHENTICATION_REQUIRED, "is4xxClientError"),
+				Arguments.of(HttpStatus.REQUEST_TIMEOUT, "is4xxClientError"),
+				Arguments.of(HttpStatus.CONFLICT, "is4xxClientError"),
+				Arguments.of(HttpStatus.GONE, "is4xxClientError"),
+				Arguments.of(HttpStatus.LENGTH_REQUIRED, "is4xxClientError"),
+				Arguments.of(HttpStatus.PRECONDITION_FAILED, "is4xxClientError"),
+				Arguments.of(HttpStatus.PAYLOAD_TOO_LARGE, "is4xxClientError"),
+				Arguments.of(HttpStatus.URI_TOO_LONG, "is4xxClientError"),
+				Arguments.of(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "is4xxClientError"),
+				Arguments.of(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE, "is4xxClientError"),
+				Arguments.of(HttpStatus.EXPECTATION_FAILED, "is4xxClientError"),
+				Arguments.of(HttpStatus.UNPROCESSABLE_ENTITY, "is4xxClientError"),
+				Arguments.of(HttpStatus.LOCKED, "is4xxClientError"),
+				Arguments.of(HttpStatus.FAILED_DEPENDENCY, "is4xxClientError"),
+				Arguments.of(HttpStatus.TOO_EARLY, "is4xxClientError"),
+				Arguments.of(HttpStatus.UPGRADE_REQUIRED, "is4xxClientError"),
+				Arguments.of(HttpStatus.PRECONDITION_REQUIRED, "is4xxClientError"),
+				Arguments.of(HttpStatus.TOO_MANY_REQUESTS, "is4xxClientError"),
+				Arguments.of(HttpStatus.REQUEST_HEADER_FIELDS_TOO_LARGE, "is4xxClientError"),
+				Arguments.of(HttpStatus.UNAVAILABLE_FOR_LEGAL_REASONS, "is4xxClientError"),
+				Arguments.of(HttpStatus.INTERNAL_SERVER_ERROR, "is5xxServerError"),
+				Arguments.of(HttpStatus.NOT_IMPLEMENTED, "is5xxServerError"),
+				Arguments.of(HttpStatus.BAD_GATEWAY, "is5xxServerError"),
+				Arguments.of(HttpStatus.SERVICE_UNAVAILABLE, "is5xxServerError"),
+				Arguments.of(HttpStatus.GATEWAY_TIMEOUT, "is5xxServerError"),
+				Arguments.of(HttpStatus.HTTP_VERSION_NOT_SUPPORTED, "is5xxServerError"),
+				Arguments.of(HttpStatus.VARIANT_ALSO_NEGOTIATES, "is5xxServerError"),
+				Arguments.of(HttpStatus.INSUFFICIENT_STORAGE, "is5xxServerError"),
+				Arguments.of(HttpStatus.LOOP_DETECTED, "is5xxServerError"),
+				Arguments.of(HttpStatus.BANDWIDTH_LIMIT_EXCEEDED, "is5xxServerError"),
+				Arguments.of(HttpStatus.NOT_EXTENDED, "is5xxServerError"),
+				Arguments.of(HttpStatus.NETWORK_AUTHENTICATION_REQUIRED, "is5xxServerError")
+		);
+	}
+
+	private static HttpStatusAssert assertThat(@NonNull HttpStatus httpStatus) {
+		return new HttpStatusAssert(httpStatus);
+	}
+}

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/assertj/AbstractHttpServletResponseAssertTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/assertj/AbstractHttpServletResponseAssertTests.java
@@ -175,6 +175,51 @@ class AbstractHttpServletResponseAssertTests {
 		}
 	}
 
+	@Nested
+	class HttpStatusTests {
+
+		@Test
+		void testStatusOk() {
+			assertThat(createResponse(200))
+					.httpStatus()
+					.isOk();
+		}
+
+		@Test
+		void testStatusBadRequest() {
+			assertThat(createResponse(400))
+					.httpStatus()
+					.isBadRequest();
+		}
+
+		@Test
+		void testStatusInternalServerError() {
+			assertThat(createResponse(500))
+					.httpStatus()
+					.isInternalServerError();
+		}
+
+		@Test
+		void testStatusFamilyRedirect() {
+			assertThat(createResponse(302))
+					.httpStatus()
+					.is3xxRedirection();
+		}
+
+		@Test
+		void testStatusFamilyClientError() {
+			assertThat(createResponse(401))
+					.httpStatus()
+					.is4xxClientError();
+		}
+
+		private MockHttpServletResponse createResponse(int status) {
+			MockHttpServletResponse response = new MockHttpServletResponse();
+			response.setStatus(status);
+			return response;
+		}
+	}
+
 
 	private static ResponseAssert assertThat(HttpServletResponse response) {
 		return new ResponseAssert(response);


### PR DESCRIPTION
This is an extension for HTTP status assertions in the `AbstractHttpServletResponseAssert`, which was introduced in version 6.2. With this extension, it is possible to write test assertions like this

```java
MvcTestResult result = mockMvcTester.get().uri("/example").exchange();
assertThat(result).httpStatus().isUnauthorized();
```

which is inspired by the "old" `MockMvc` status assertions:

```java
mockMvc.perform(get("/example"))
    .andExpect(status().isUnauthorized());
```

No breaking changes introduced.