### PR TITLE
Refactor Improve code readability by using isEmpty()

### DIFF
--- a/integration-tests/src/test/java/org/springframework/beans/factory/xml/ComponentFactoryBean.java
+++ b/integration-tests/src/test/java/org/springframework/beans/factory/xml/ComponentFactoryBean.java
@@ -35,7 +35,7 @@ public class ComponentFactoryBean implements FactoryBean<Component> {
 
 	@Override
 	public Component getObject() {
-		if (this.children != null && this.children.size() > 0) {
+		if (this.children != null && !this.children.isEmpty()) {
 			for (Component child : children) {
 				this.parent.addComponent(child);
 			}

--- a/spring-core/src/main/java/org/springframework/core/io/support/PropertySourceProcessor.java
+++ b/spring-core/src/main/java/org/springframework/core/io/support/PropertySourceProcessor.java
@@ -81,7 +81,7 @@ public class PropertySourceProcessor {
 		String name = descriptor.name();
 		String encoding = descriptor.encoding();
 		List<String> locations = descriptor.locations();
-		Assert.isTrue(locations.size() > 0, "At least one @PropertySource(value) location is required");
+		Assert.isTrue(!locations.isEmpty(), "At least one @PropertySource(value) location is required");
 		boolean ignoreResourceNotFound = descriptor.ignoreResourceNotFound();
 		PropertySourceFactory factory = (descriptor.propertySourceFactory() != null ?
 				instantiateClass(descriptor.propertySourceFactory()) : defaultPropertySourceFactory);

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/AbstractStompBrokerRelayIntegrationTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/AbstractStompBrokerRelayIntegrationTests.java
@@ -293,7 +293,7 @@ public abstract class AbstractStompBrokerRelayIntegrationTests {
 
 		public void expectMessages(MessageExchange... messageExchanges) throws InterruptedException {
 			List<MessageExchange> expectedMessages = new ArrayList<>(Arrays.asList(messageExchanges));
-			while (expectedMessages.size() > 0) {
+			while (!expectedMessages.isEmpty()) {
 				Message<?> message = this.queue.poll(10000, TimeUnit.MILLISECONDS);
 				assertThat(message).as("Timed out waiting for messages, expected [" + expectedMessages + "]").isNotNull();
 				MessageExchange match = findMatch(expectedMessages, message);

--- a/spring-web/src/main/java/org/springframework/web/util/pattern/PathPattern.java
+++ b/spring-web/src/main/java/org/springframework/web/util/pattern/PathPattern.java
@@ -522,7 +522,7 @@ public class PathPattern implements Comparable<PathPattern> {
 	 * @return {@code true} has more than zero elements
 	 */
 	private boolean hasLength(@Nullable PathContainer container) {
-		return container != null && container.elements().size() > 0;
+		return container != null && !container.elements().isEmpty();
 	}
 
 	private static int scoreByNormalizedLength(PathPattern pattern) {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractUrlHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractUrlHandlerMapping.java
@@ -372,7 +372,7 @@ public abstract class AbstractUrlHandlerMapping extends AbstractHandlerMapping i
 					uriTemplateVariables.putAll(decodedVars);
 				}
 			}
-			if (logger.isTraceEnabled() && uriTemplateVariables.size() > 0) {
+			if (logger.isTraceEnabled() && !uriTemplateVariables.isEmpty()) {
 				logger.trace("URI variables " + uriTemplateVariables);
 			}
 			return buildPathExposingHandler(handler, bestMatch, pathWithinMapping, uriTemplateVariables);


### PR DESCRIPTION
## Motivation:
- There are some codes using *.size() > 0 or *.size() == 0.

## Modifications:
- Replace a.size() > 0 with !a.isEmpty().
- Replace a.size() == 0 with a.isEmpty().

## Result:
- Improves code readability and consistency without introducing any functional changes.