### PR TITLE
Document order values for `TestExecutionListener` implementations

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/event/ApplicationEventsTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/event/ApplicationEventsTestExecutionListener.java
@@ -61,7 +61,12 @@ public class ApplicationEventsTestExecutionListener extends AbstractTestExecutio
 
 
 	/**
-	 * Returns {@code 1800}.
+	 * Returns {@code 1800}, which ensures that the {@code ApplicationEventsTestExecutionListener}
+	 * is ordered after the
+	 * {@link org.springframework.test.context.support.DirtiesContextBeforeModesTestExecutionListener
+	 * DirtiesContextBeforeModesTestExecutionListener} and just before the
+	 * {@link org.springframework.test.context.bean.override.BeanOverrideTestExecutionListener
+	 * BeanOverrideTestExecutionListener}.
 	 */
 	@Override
 	public final int getOrder() {

--- a/spring-test/src/main/java/org/springframework/test/context/event/EventPublishingTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/event/EventPublishingTestExecutionListener.java
@@ -101,7 +101,7 @@ public class EventPublishingTestExecutionListener extends AbstractTestExecutionL
 	 * Returns {@code 10000}, which ensures that the {@code EventPublishingTestExecutionListener}
 	 * is ordered after the
 	 * {@link org.springframework.test.context.jdbc.SqlScriptsTestExecutionListener
-	 * SqlScriptsTestExecutionListener}
+	 * SqlScriptsTestExecutionListener}.
 	 */
 	@Override
 	public final int getOrder() {

--- a/spring-test/src/main/java/org/springframework/test/context/event/EventPublishingTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/event/EventPublishingTestExecutionListener.java
@@ -98,7 +98,10 @@ import org.springframework.test.context.support.AbstractTestExecutionListener;
 public class EventPublishingTestExecutionListener extends AbstractTestExecutionListener {
 
 	/**
-	 * Returns {@code 10000}.
+	 * Returns {@code 10000}, which ensures that the {@code EventPublishingTestExecutionListener}
+	 * is ordered after the
+	 * {@link org.springframework.test.context.jdbc.SqlScriptsTestExecutionListener
+	 * SqlScriptsTestExecutionListener}
 	 */
 	@Override
 	public final int getOrder() {

--- a/spring-test/src/main/java/org/springframework/test/context/jdbc/SqlScriptsTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/jdbc/SqlScriptsTestExecutionListener.java
@@ -126,7 +126,12 @@ public class SqlScriptsTestExecutionListener extends AbstractTestExecutionListen
 
 
 	/**
-	 * Returns {@code 5000}.
+	 * Returns {@code 5000}, which ensures that the {@code SqlScriptsTestExecutionListener}
+	 * is ordered after the
+	 * {@link org.springframework.test.context.transaction.TransactionalTestExecutionListener
+	 * TransactionalTestExecutionListener} and just before the
+	 * {@link org.springframework.test.context.event.EventPublishingTestExecutionListener
+	 * EventPublishingTestExecutionListener}.
 	 */
 	@Override
 	public final int getOrder() {

--- a/spring-test/src/main/java/org/springframework/test/context/observation/MicrometerObservationRegistryTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/observation/MicrometerObservationRegistryTestExecutionListener.java
@@ -106,7 +106,12 @@ class MicrometerObservationRegistryTestExecutionListener extends AbstractTestExe
 
 
 	/**
-	 * Returns {@code 2500}.
+	 * Returns {@code 2500}, which ensures that the {@code MicrometerObservationRegistryTestExecutionListener}
+	 * is ordered after the
+	 * {@link org.springframework.test.context.support.DependencyInjectionTestExecutionListener
+	 * DependencyInjectionTestExecutionListener} and just before the
+	 * {@link org.springframework.test.context.support.DirtiesContextTestExecutionListener
+	 * DirtiesContextTestExecutionListener}.
 	 */
 	@Override
 	public final int getOrder() {

--- a/spring-test/src/main/java/org/springframework/test/context/support/CommonCachesTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/CommonCachesTestExecutionListener.java
@@ -36,7 +36,12 @@ import org.springframework.test.context.TestContext;
 public class CommonCachesTestExecutionListener extends AbstractTestExecutionListener {
 
 	/**
-	 * Returns {@code 3005}.
+	 * Returns {@code 3005}, which ensures that the {@code CommonCachesTestExecutionListener}
+	 * is ordered after the
+	 * {@link org.springframework.test.context.support.DirtiesContextTestExecutionListener
+	 * DirtiesContextTestExecutionListener} and just before the
+	 * {@link org.springframework.test.context.transaction.TransactionalTestExecutionListener
+	 * TransactionalTestExecutionListener}.
 	 */
 	@Override
 	public final int getOrder() {

--- a/spring-test/src/main/java/org/springframework/test/context/support/DependencyInjectionTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/DependencyInjectionTestExecutionListener.java
@@ -63,7 +63,12 @@ public class DependencyInjectionTestExecutionListener extends AbstractTestExecut
 
 
 	/**
-	 * Returns {@code 2000}.
+	 * Returns {@code 2000}, which ensures that the {@code ApplicationEventsTestExecutionListener}
+	 * is ordered after the
+	 * {@link org.springframework.test.context.bean.override.BeanOverrideTestExecutionListener
+	 * BeanOverrideTestExecutionListener} and just before the
+	 * {@link org.springframework.test.context.support.DirtiesContextTestExecutionListener
+	 * DirtiesContextTestExecutionListener}.
 	 */
 	@Override
 	public final int getOrder() {

--- a/spring-test/src/main/java/org/springframework/test/context/support/DirtiesContextBeforeModesTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/DirtiesContextBeforeModesTestExecutionListener.java
@@ -55,7 +55,12 @@ import static org.springframework.test.annotation.DirtiesContext.MethodMode.BEFO
 public class DirtiesContextBeforeModesTestExecutionListener extends AbstractDirtiesContextTestExecutionListener {
 
 	/**
-	 * Returns {@code 1500}.
+	 * Returns {@code 1500}, which ensures that the {@code DirtiesContextBeforeModesTestExecutionListener}
+	 * is ordered after the
+	 * {@link org.springframework.test.context.web.ServletTestExecutionListener
+	 * ServletTestExecutionListener} and just before the
+	 * {@link org.springframework.test.context.bean.override.BeanOverrideTestExecutionListener
+	 * BeanOverrideTestExecutionListener}.
 	 */
 	@Override
 	public final int getOrder() {

--- a/spring-test/src/main/java/org/springframework/test/context/support/DirtiesContextTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/support/DirtiesContextTestExecutionListener.java
@@ -55,7 +55,12 @@ import static org.springframework.test.annotation.DirtiesContext.MethodMode.AFTE
 public class DirtiesContextTestExecutionListener extends AbstractDirtiesContextTestExecutionListener {
 
 	/**
-	 * Returns {@code 3000}.
+	 * Returns {@code 3000}, which ensures that the {@code DirtiesContextTestExecutionListener}
+	 * is ordered after the
+	 * {@link org.springframework.test.context.support.DependencyInjectionTestExecutionListener
+	 * DependencyInjectionTestExecutionListener} and just before the
+	 * {@link org.springframework.test.context.support.CommonCachesTestExecutionListener
+	 * CommonCachesTestExecutionListener}.
 	 */
 	@Override
 	public final int getOrder() {

--- a/spring-test/src/main/java/org/springframework/test/context/transaction/TransactionalTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/transaction/TransactionalTestExecutionListener.java
@@ -175,7 +175,12 @@ public class TransactionalTestExecutionListener extends AbstractTestExecutionLis
 
 
 	/**
-	 * Returns {@code 4000}.
+	 * Returns {@code 4000}, which ensures that the {@code TransactionalTestExecutionListener}
+	 * is ordered after the
+	 * {@link org.springframework.test.context.support.CommonCachesTestExecutionListener
+	 * CommonCachesTestExecutionListener} and just before the
+	 * {@link org.springframework.test.context.jdbc.SqlScriptsTestExecutionListener
+	 * SqlScriptsTestExecutionListener}.
 	 */
 	@Override
 	public final int getOrder() {

--- a/spring-test/src/main/java/org/springframework/test/context/web/ServletTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/web/ServletTestExecutionListener.java
@@ -110,7 +110,10 @@ public class ServletTestExecutionListener extends AbstractTestExecutionListener 
 
 
 	/**
-	 * Returns {@code 1000}.
+	 * Returns {@code 1000}, which ensures that the {@code ServletTestExecutionListener}
+	 * is ordered before the
+	 * {@link org.springframework.test.context.support.DirtiesContextBeforeModesTestExecutionListener
+	 * DirtiesContextBeforeModesTestExecutionListener}.
 	 */
 	@Override
 	public final int getOrder() {


### PR DESCRIPTION
Issue: #34225 

JUST add the comment of order for `TestExecutionListener` subclasses.