### PR TITLE
Update Javadoc for `SimpleCommandLinePropertySource`

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/env/SimpleCommandLineArgsParser.java
+++ b/spring-core/src/main/java/org/springframework/core/env/SimpleCommandLineArgsParser.java
@@ -28,7 +28,8 @@ package org.springframework.core.env;
  * <p>That is, options must be prefixed with "{@code --}" and may or may not
  * specify a value. If a value is specified, the name and value must be separated
  * <em>without spaces</em> by an equals sign ("="). The value may optionally be
- * an empty string.
+ * an empty string. if the option is present and has multiple values (e. g. "--foo=bar --foo=baz"),
+* the values are parsed as a collection.
  *
  * <h4>Valid examples of option arguments</h4>
  * <pre class="code">
@@ -37,14 +38,14 @@ package org.springframework.core.env;
  * --foo=""
  * --foo=bar
  * --foo="bar then baz"
- * --foo=bar,baz,biz</pre>
+ * --foo=bar,baz,biz
+ * --foo=bar --foo=baz --foo=biz</pre>
  *
  * <h4>Invalid examples of option arguments</h4>
  * <pre class="code">
  * -foo
  * --foo bar
- * --foo = bar
- * --foo=bar --foo=baz --foo=biz</pre>
+ * --foo = bar</pre>
  *
  * <h3>End of option arguments</h3>
  * <p>This parser supports the POSIX "end of options" delimiter, meaning that any

--- a/spring-core/src/main/java/org/springframework/core/env/SimpleCommandLinePropertySource.java
+++ b/spring-core/src/main/java/org/springframework/core/env/SimpleCommandLinePropertySource.java
@@ -41,7 +41,8 @@ import org.springframework.util.StringUtils;
  * <p>That is, options must be prefixed with "{@code --}" and may or may not
  * specify a value. If a value is specified, the name and value must be separated
  * <em>without spaces</em> by an equals sign ("="). The value may optionally be
- * an empty string.
+ * an empty string. if the option is present and has multiple values (e. g. "--foo=bar --foo=baz"),
+ * the values are parsed as a collection.
  *
  * <h4>Valid examples of option arguments</h4>
  * <pre class="code">
@@ -50,14 +51,14 @@ import org.springframework.util.StringUtils;
  * --foo=""
  * --foo=bar
  * --foo="bar then baz"
- * --foo=bar,baz,biz</pre>
+ * --foo=bar,baz,biz
+ * --foo=bar --foo=baz --foo=biz</pre>
  *
  * <h4>Invalid examples of option arguments</h4>
  * <pre class="code">
  * -foo
  * --foo bar
- * --foo = bar
- * --foo=bar --foo=baz --foo=biz</pre>
+ * --foo = bar</pre>
  *
  * <h3>End of option arguments</h3>
  * <p>The underlying parser supports the POSIX "end of options" delimiter, meaning


### PR DESCRIPTION
For ComandLineArgs,  having multiple values in one option is valid and will be parsed into a collection.