### PR TITLE
YamlPropertiesFactoryBean incorrect flatten nested map to properties

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlProcessor.java
@@ -56,6 +56,7 @@ import org.springframework.util.StringUtils;
  * @author Juergen Hoeller
  * @author Sam Brannen
  * @author Brian Clozel
+ * @author Mengqi Xu
  * @since 4.1
  */
 public abstract class YamlProcessor {
@@ -305,16 +306,19 @@ public abstract class YamlProcessor {
 	 */
 	protected final Map<String, Object> getFlattenedMap(Map<String, Object> source) {
 		Map<String, Object> result = new LinkedHashMap<>();
-		buildFlattenedMap(result, source, null);
+		buildFlattenedMap(result, source, null, false);
 		return result;
 	}
 
 	@SuppressWarnings({"rawtypes", "unchecked"})
-	private void buildFlattenedMap(Map<String, Object> result, Map<String, Object> source, @Nullable String path) {
+	private void buildFlattenedMap(Map<String, Object> result, Map<String, Object> source, @Nullable String path, boolean isIndexedKey) {
 		source.forEach((key, value) -> {
 			if (StringUtils.hasText(path)) {
-				if (key.startsWith("[")) {
+				if (isIndexedKey) {
 					key = path + key;
+				}
+				else if (key.startsWith("[") || key.endsWith("]")) {
+					key = path + '[' + key + ']';
 				}
 				else {
 					key = path + '.' + key;
@@ -325,7 +329,7 @@ public abstract class YamlProcessor {
 			}
 			else if (value instanceof Map map) {
 				// Need a compound key
-				buildFlattenedMap(result, map, key);
+				buildFlattenedMap(result, map, key, false);
 			}
 			else if (value instanceof Collection collection) {
 				// Need a compound key
@@ -336,7 +340,7 @@ public abstract class YamlProcessor {
 					int count = 0;
 					for (Object object : collection) {
 						buildFlattenedMap(result, Collections.singletonMap(
-								"[" + (count++) + "]", object), key);
+								"[" + (count++) + "]", object), key, true);
 					}
 				}
 			}

--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlProcessor.java
@@ -245,13 +245,7 @@ public abstract class YamlProcessor {
 			if (value instanceof Map) {
 				value = asMap(value);
 			}
-			if (key instanceof CharSequence) {
-				result.put(key.toString(), value);
-			}
-			else {
-				// It has to be a map key in this case
-				result.put("[" + key.toString() + "]", value);
-			}
+			result.put(key.toString(), value);
 		});
 		return result;
 	}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlMapFactoryBeanTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlMapFactoryBeanTests.java
@@ -128,4 +128,18 @@ class YamlMapFactoryBeanTests {
 				this.factory.getObject().get("mymap"));
 	}
 
+	@Test
+	void testMapWithIntegerKey() {
+		this.factory.setResources(new ByteArrayResource("foo:\n  1: bar".getBytes()));
+		Map<String, Object> map = this.factory.getObject();
+
+		assertThat(map).hasSize(1);
+		assertThat(map.containsKey("foo")).isTrue();
+		Object object = map.get("foo");
+		assertThat(object).isInstanceOf(LinkedHashMap.class);
+		@SuppressWarnings("unchecked")
+		Map<String, Object> sub = (Map<String, Object>) object;
+		assertThat(sub.containsKey("1")).isTrue();
+		assertThat(sub.get("1")).isEqualTo("bar");
+	}
 }

--- a/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlProcessorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlProcessorTests.java
@@ -99,7 +99,7 @@ class YamlProcessorTests {
 	void integerKeyBehaves() {
 		setYaml("foo: bar\n1: bar");
 		this.processor.process((properties, map) -> {
-			assertThat(properties.get("[1]")).isEqualTo("bar");
+			assertThat(properties.get("1")).isEqualTo("bar");
 			assertThat(properties).hasSize(2);
 		});
 	}
@@ -108,7 +108,7 @@ class YamlProcessorTests {
 	void integerDeepKeyBehaves() {
 		setYaml("foo:\n  1: bar");
 		this.processor.process((properties, map) -> {
-			assertThat(properties.get("foo[1]")).isEqualTo("bar");
+			assertThat(properties.get("foo.1")).isEqualTo("bar");
 			assertThat(properties).hasSize(1);
 		});
 	}

--- a/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlPropertiesFactoryBeanTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlPropertiesFactoryBeanTests.java
@@ -177,7 +177,7 @@ class YamlPropertiesFactoryBeanTests {
 		factory.setResources(
 				new ByteArrayResource(yaml.getBytes()),
 				new ByteArrayResource("indexed:\n  \"[0]\": foo\n  \"[1]\": bar".getBytes()),
-				new ByteArrayResource("indexed:\n  - \"[a]\": foo\n    \"[b]\": bar".getBytes()),
+				new ByteArrayResource("indexed2:\n  - \"[a]\": foo\n    \"[b]\": bar".getBytes()),
 				new ByteArrayResource("only-left-bracket:\n  \"[/key1/\": foo".getBytes()),
 				new ByteArrayResource("only-right-bracket:\n  \"/key1/]\": foo".getBytes()),
 				new ByteArrayResource("special-bracket:\n  \"][/key1/][\": foo".getBytes()));
@@ -188,8 +188,9 @@ class YamlPropertiesFactoryBeanTests {
 
 		assertThat(properties.getProperty("indexed[[0]]")).isEqualTo("foo");
 		assertThat(properties.getProperty("indexed[[1]]")).isEqualTo("bar");
-		assertThat(properties.getProperty("indexed[0][[a]]")).isEqualTo("foo");
-		assertThat(properties.getProperty("indexed[0][[b]]")).isEqualTo("bar");
+
+		assertThat(properties.getProperty("indexed2[0][[a]]")).isEqualTo("foo");
+		assertThat(properties.getProperty("indexed2[0][[b]]")).isEqualTo("bar");
 
 		assertThat(properties.getProperty("only-left-bracket[[/key1/]")).isEqualTo("foo");
 		assertThat(properties.getProperty("only-right-bracket[/key1/]]")).isEqualTo("foo");

--- a/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlPropertiesFactoryBeanTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlPropertiesFactoryBeanTests.java
@@ -165,6 +165,38 @@ class YamlPropertiesFactoryBeanTests {
 		assertThat(properties.getProperty("one")).isEqualTo("two");
 	}
 
+
+	@Test // gh-27020
+	void loadResourceWithEscapedKey() {
+		String yaml = "root:\n" +
+				"  webservices:\n" +
+				"    \"[domain.test:8080]\":\n" +
+				"      - username: foo\n" +
+				"        password: bar\n";
+		YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+		factory.setResources(
+				new ByteArrayResource(yaml.getBytes()),
+				new ByteArrayResource("indexed:\n  \"[0]\": foo\n  \"[1]\": bar".getBytes()),
+				new ByteArrayResource("indexed:\n  - \"[a]\": foo\n    \"[b]\": bar".getBytes()),
+				new ByteArrayResource("only-left-bracket:\n  \"[/key1/\": foo".getBytes()),
+				new ByteArrayResource("only-right-bracket:\n  \"/key1/]\": foo".getBytes()),
+				new ByteArrayResource("special-bracket:\n  \"][/key1/][\": foo".getBytes()));
+
+		Properties properties = factory.getObject();
+		assertThat(properties.getProperty("root.webservices[[domain.test:8080]][0].username")).isEqualTo("foo");
+		assertThat(properties.getProperty("root.webservices[[domain.test:8080]][0].password")).isEqualTo("bar");
+
+		assertThat(properties.getProperty("indexed[[0]]")).isEqualTo("foo");
+		assertThat(properties.getProperty("indexed[[1]]")).isEqualTo("bar");
+		assertThat(properties.getProperty("indexed[0][[a]]")).isEqualTo("foo");
+		assertThat(properties.getProperty("indexed[0][[b]]")).isEqualTo("bar");
+
+		assertThat(properties.getProperty("only-left-bracket[[/key1/]")).isEqualTo("foo");
+		assertThat(properties.getProperty("only-right-bracket[/key1/]]")).isEqualTo("foo");
+		assertThat(properties.getProperty("special-bracket.][/key1/][")).isEqualTo("foo");
+	}
+
+
 	@Test
 	void loadNonExistentResource() {
 		YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();

--- a/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlPropertiesFactoryBeanTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlPropertiesFactoryBeanTests.java
@@ -180,7 +180,8 @@ class YamlPropertiesFactoryBeanTests {
 				new ByteArrayResource("indexed2:\n  - \"[a]\": foo\n    \"[b]\": bar".getBytes()),
 				new ByteArrayResource("only-left-bracket:\n  \"[/key1/\": foo".getBytes()),
 				new ByteArrayResource("only-right-bracket:\n  \"/key1/]\": foo".getBytes()),
-				new ByteArrayResource("special-bracket:\n  \"][/key1/][\": foo".getBytes()));
+				new ByteArrayResource("special-bracket:\n  \"][/key1/][\": foo".getBytes()),
+				new ByteArrayResource("number-key:\n  1: foo".getBytes()));
 
 		Properties properties = factory.getObject();
 		assertThat(properties.getProperty("root.webservices[[domain.test:8080]][0].username")).isEqualTo("foo");
@@ -195,6 +196,8 @@ class YamlPropertiesFactoryBeanTests {
 		assertThat(properties.getProperty("only-left-bracket[[/key1/]")).isEqualTo("foo");
 		assertThat(properties.getProperty("only-right-bracket[/key1/]]")).isEqualTo("foo");
 		assertThat(properties.getProperty("special-bracket.][/key1/][")).isEqualTo("foo");
+
+		assertThat(properties.getProperty("number-key.1")).isEqualTo("foo");
 	}
 
 


### PR DESCRIPTION
To fix issue #27020.

For the method `org.springframework.beans.factory.config.YamlProcessor#getFlattenedMap` before this PR:
- When the key is start with `[`, will return `path + key` as map key.
- Otherwise, will return `path + '.' + key` as map key.
```java
if (key.startsWith("[")) {
	key = path + key;
}
else {
	key = path + '.' + key;
}
```

For the method `org.springframework.beans.factory.config.YamlProcessor#getFlattenedMap` after this PR:
- When the key is start with `[` or end with `]`, will return `path + '[' + key + ']'` as map key.
- Otherwise, will return `path + '.' + key` as map key.
- And when the key is indexed key at `Collection` like `[0]`, will return `path + key` as map key.

For the method `org.springframework.beans.factory.config.YamlProcessor#asMap` after this PR:
Change `result.put("[" + key.toString() + "]", value);` to `result.put(key.toString(), value);` on `asMap`.

And the test case you can see:
```yaml
root:
  webservices:
    "[domain.test:8080]":
      - username: foo
        password: bar
# Before this PR:
# root.webservices[domain.test:8080][0].username=foo
# root.webservices[domain.test:8080][0].password=bar
# After this PR:
# root.webservices[[domain.test:8080]][0].username=foo
# root.webservices[[domain.test:8080]][0].password=bar

indexed:
  "[0]": foo
  "[1]": bar
indexed2:
  - "[a]": foo
    "[b]": bar
# Before this PR:
# indexed[0]=foo
# indexed[1]=bar
# indexed2[0][a]=foo
# indexed2[0][b]=bar
# After this PR:
# indexed[[0]]=foo
# indexed[[1]]=bar
# indexed2[0][[a]]=foo
# indexed2[0][[b]]=bar

only-left-bracket:
  "[/key1/": foo
only-right-bracket:
  "/key1/]": foo
special-bracket:
  "][/key1/][": foo
# Before this PR:
# only-left-bracket[/key1/=foo
# only-right-bracket./key1/]=foo
# special-bracket.][/key1/][=foo
# After this PR:
# only-left-bracket[[/key1/]=foo
# only-right-bracket[/key1/]]=foo
# special-bracket.][/key1/][=foo


number-key:
  1: foo
# Before this PR:
# number-key[1]=bar
# After this PR:
# number-key.1=foo
```

By the way, `org.springframework.beans.factory.config.YamlMapFactoryBean#getObject` result is:
```
# Before this PR & After this PR:
# root={webservices={[domain.test:8080]=[{username=foo, password=bar}]}}
# indexed={[0]=foo, [1]=bar}
# indexed2=[{[a]=foo, [b]=bar}]
# only-left-bracket={[/key1/=foo}
# only-right-bracket={/key1/]=foo}
# special-bracket={][/key1/][=foo}

# Before this PR:
# number-key={[1]=foo}
# After this PR:
# number-key={1=foo}
```
