### PR TITLE
Improve Javadoc for `SpringProperties.getFlag()`

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/SpringProperties.java
+++ b/spring-core/src/main/java/org/springframework/core/SpringProperties.java
@@ -122,7 +122,7 @@ public final class SpringProperties {
 	/**
 	 * Retrieve the flag for the given property key.
 	 * @param key the property key
-	 * @return {@code true} if the property is set to "true",
+	 * @return {@code true} if the property is not {@code null} and is equal, ignoring case, to the string "true",
 	 * {@code} false otherwise
 	 */
 	public static boolean getFlag(String key) {


### PR DESCRIPTION
`getFlag` return `true` when the property is equal, ignoring case, to the string "true", not just "true", "TrUe" also means `true`.

See more at `Boolean#parseBoolean`