### PR TITLE
HierarchicalUriComponents should format Collection URI var values in query param

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
+++ b/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -47,6 +48,7 @@ import org.springframework.util.StringUtils;
  * @author Rossen Stoyanchev
  * @author Phillip Webb
  * @author Sam Brannen
+ * @author Mengqi Xu
  * @since 3.1.3
  * @see <a href="https://tools.ietf.org/html/rfc3986#section-1.2.3">Hierarchical URIs</a>
  */
@@ -1089,6 +1091,9 @@ final class HierarchicalUriComponents extends UriComponents {
 			Object value = this.delegate.getValue(name);
 			if (ObjectUtils.isArray(value)) {
 				value = StringUtils.arrayToCommaDelimitedString(ObjectUtils.toObjectArray(value));
+			}
+			if (value instanceof Collection<?> coll) {
+				value = StringUtils.collectionToCommaDelimitedString(coll);
 			}
 			return value;
 		}

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsTests.java
@@ -23,6 +23,7 @@ import java.io.ObjectOutputStream;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -42,6 +43,7 @@ import static org.springframework.web.util.UriComponentsBuilder.fromUriString;
  * @author Arjen Poutsma
  * @author Phillip Webb
  * @author Rossen Stoyanchev
+ * @author Mengqi Xu
  */
 class UriComponentsTests {
 
@@ -151,6 +153,26 @@ class UriComponentsTests {
 				.expand("example.com", "foo", "bar");
 
 		assertThat(uri.toUriString()).isEqualTo("https://example.com/foo#bar");
+	}
+
+	@Test
+	void expandQueryParamWithArray() {
+		UriComponents uri = UriComponentsBuilder.fromPath("/hello")
+				.queryParam("name", "{name}")
+				.build();
+		uri = uri.expand(Collections.singletonMap("name", new String[]{"foo", "bar"}));
+
+		assertThat(uri.toString()).hasToString("/hello?name=foo,bar");
+	}
+
+	@Test
+	void expandQueryParamWithList() {
+		UriComponents uri = UriComponentsBuilder.fromPath("/hello")
+				.queryParam("name", "{name}")
+				.build();
+		uri = uri.expand(Collections.singletonMap("name", List.of("foo", "bar")));
+
+		assertThat(uri.toString()).hasToString("/hello?name=foo,bar");
 	}
 
 	@ParameterizedTest // SPR-12123


### PR DESCRIPTION
When expand `/hello?name={name}`:

1. with `uriVariables` map: 
- `name`: `new String[]{"foo", "bar"}`

We will get `/hello?name=foo,bar`.

2. with `uriVariables` map: 
- `name`: `List.of("foo", "bar")`
- Or other `Collection`.

We will get `/hello?name=[foo, bar]`.

This PR will keep the same behavior for array and collection when expanding query parameter.