### PR TITLE
Stop assuming that AspectJ Advice has JoinPoint as the first argument

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/AbstractAspectJAdvice.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/AbstractAspectJAdvice.java
@@ -272,14 +272,16 @@ public abstract class AbstractAspectJAdvice implements Advice, AspectJPrecedence
 		}
 		if (this.aspectJAdviceMethod.getParameterCount() == this.argumentNames.length + 1) {
 			// May need to add implicit join point arg name...
-			Class<?> firstArgType = this.aspectJAdviceMethod.getParameterTypes()[0];
-			if (firstArgType == JoinPoint.class ||
-					firstArgType == ProceedingJoinPoint.class ||
-					firstArgType == JoinPoint.StaticPart.class) {
-				@Nullable String[] oldNames = this.argumentNames;
-				this.argumentNames = new String[oldNames.length + 1];
-				this.argumentNames[0] = "THIS_JOIN_POINT";
-				System.arraycopy(oldNames, 0, this.argumentNames, 1, oldNames.length);
+			for (int i = 0; i < this.aspectJAdviceMethod.getParameterCount(); i++) {
+				Class<?> argType = this.aspectJAdviceMethod.getParameterTypes()[i];
+				if (argType == JoinPoint.class ||
+						argType == ProceedingJoinPoint.class ||
+						argType == JoinPoint.StaticPart.class) {
+					@Nullable String[] oldNames = this.argumentNames;
+					this.argumentNames = new String[oldNames.length + 1];
+					this.argumentNames[0] = "THIS_JOIN_POINT";
+					System.arraycopy(oldNames, 0, this.argumentNames, 1, oldNames.length);
+				}
 			}
 		}
 	}

--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/AbstractAspectJAdvice.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/AbstractAspectJAdvice.java
@@ -279,8 +279,9 @@ public abstract class AbstractAspectJAdvice implements Advice, AspectJPrecedence
 						argType == JoinPoint.StaticPart.class) {
 					@Nullable String[] oldNames = this.argumentNames;
 					this.argumentNames = new String[oldNames.length + 1];
-					this.argumentNames[0] = "THIS_JOIN_POINT";
-					System.arraycopy(oldNames, 0, this.argumentNames, 1, oldNames.length);
+					System.arraycopy(oldNames, 0, this.argumentNames, 0, i);
+					this.argumentNames[i] = "THIS_JOIN_POINT";
+					System.arraycopy(oldNames, i, this.argumentNames, i + 1, oldNames.length - i);
 					break;
 				}
 			}

--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/AbstractAspectJAdvice.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/AbstractAspectJAdvice.java
@@ -281,6 +281,7 @@ public abstract class AbstractAspectJAdvice implements Advice, AspectJPrecedence
 					this.argumentNames = new String[oldNames.length + 1];
 					this.argumentNames[0] = "THIS_JOIN_POINT";
 					System.arraycopy(oldNames, 0, this.argumentNames, 1, oldNames.length);
+					break;
 				}
 			}
 		}

--- a/spring-aop/src/test/java/org/springframework/aop/aspectj/AbstractAspectJAdviceTests.java
+++ b/spring-aop/src/test/java/org/springframework/aop/aspectj/AbstractAspectJAdviceTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.aop.aspectj;
+
+import java.io.Serial;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for {@link AbstractAspectJAdvice}.
+ *
+ * @author Joshua Chen
+ */
+class AbstractAspectJAdviceTests {
+
+	@Test
+	void setArgumentNamesFromStringArray_withJoinPointAsFirstParameter() {
+		AbstractAspectJAdvice advice = getAspectJAdvice("methodWithJoinPointAsFirstParameter");
+		assertArgumentNamesFromStringArray(advice);
+	}
+
+	@Test
+	void setArgumentNamesFromStringArray_withJoinPointAsLastParameter() {
+		AbstractAspectJAdvice advice = getAspectJAdvice("methodWithJoinPointAsLastParameter");
+		assertArgumentNamesFromStringArray(advice);
+	}
+
+	@Test
+	void setArgumentNamesFromStringArray_withJoinPointAsMiddleParameter() {
+		AbstractAspectJAdvice advice = getAspectJAdvice("methodWithJoinPointAsMiddleParameter");
+		assertArgumentNamesFromStringArray(advice);
+	}
+
+	@Test
+	void setArgumentNamesFromStringArray_withProceedingJoinPoint() {
+		AbstractAspectJAdvice advice = getAspectJAdvice("methodWithProceedingJoinPoint");
+		assertArgumentNamesFromStringArray(advice);
+	}
+
+	@Test
+	void setArgumentNamesFromStringArray_withStaticPart() {
+		AbstractAspectJAdvice advice = getAspectJAdvice("methodWithStaticPart");
+		assertArgumentNamesFromStringArray(advice);
+	}
+
+	private void assertArgumentNamesFromStringArray(AbstractAspectJAdvice advice) {
+		assertThat(getArgumentNames(advice)[0]).isEqualTo("THIS_JOIN_POINT");
+		assertThat(getArgumentNames(advice)[1]).isEqualTo("arg1");
+		assertThat(getArgumentNames(advice)[2]).isEqualTo("arg2");
+	}
+
+	private @NotNull AbstractAspectJAdvice getAspectJAdvice(final String methodName) {
+		AbstractAspectJAdvice advice = new TestAspectJAdvice(getMethod(methodName), mock(AspectJExpressionPointcut.class), mock(AspectInstanceFactory.class));
+		advice.setArgumentNamesFromStringArray("arg1", "arg2");
+		return advice;
+	}
+
+	private Method getMethod(final String name) {
+		return Arrays.stream(this.getClass().getDeclaredMethods()).filter(m -> m.getName().equals(name)).findFirst().orElseThrow();
+	}
+
+	private String[] getArgumentNames(final AbstractAspectJAdvice advice) {
+		try {
+			Field field = AbstractAspectJAdvice.class.getDeclaredField("argumentNames");
+			field.setAccessible(true);
+			return (String[]) field.get(advice);
+		}
+		catch (NoSuchFieldException | IllegalAccessException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	public static class TestAspectJAdvice extends AbstractAspectJAdvice {
+		@Serial private static final long serialVersionUID = 1L;
+
+		public TestAspectJAdvice(Method aspectJAdviceMethod, AspectJExpressionPointcut pointcut, AspectInstanceFactory aspectInstanceFactory) {
+			super(aspectJAdviceMethod, pointcut, aspectInstanceFactory);
+		}
+
+		@Override
+		public boolean isBeforeAdvice() {
+			return false;
+		}
+
+		@Override
+		public boolean isAfterAdvice() {
+			return false;
+		}
+	}
+
+	void methodWithJoinPointAsFirstParameter(JoinPoint joinPoint, String arg1, String arg2) {
+	}
+
+	void methodWithJoinPointAsLastParameter(String arg1, String arg2, JoinPoint joinPoint) {
+	}
+
+	void methodWithJoinPointAsMiddleParameter(String arg1, JoinPoint joinPoint, String arg2) {
+	}
+
+	void methodWithProceedingJoinPoint(ProceedingJoinPoint joinPoint, String arg1, String arg2) {
+	}
+
+	void methodWithStaticPart(JoinPoint.StaticPart staticPart, String arg1, String arg2) {
+	}
+}

--- a/spring-aop/src/test/java/org/springframework/aop/aspectj/AbstractAspectJAdviceTests.java
+++ b/spring-aop/src/test/java/org/springframework/aop/aspectj/AbstractAspectJAdviceTests.java
@@ -45,13 +45,17 @@ class AbstractAspectJAdviceTests {
 	@Test
 	void setArgumentNamesFromStringArray_withJoinPointAsLastParameter() {
 		AbstractAspectJAdvice advice = getAspectJAdvice("methodWithJoinPointAsLastParameter");
-		assertArgumentNamesFromStringArray(advice);
+		assertThat(getArgumentNames(advice)[0]).isEqualTo("arg1");
+		assertThat(getArgumentNames(advice)[1]).isEqualTo("arg2");
+		assertThat(getArgumentNames(advice)[2]).isEqualTo("THIS_JOIN_POINT");
 	}
 
 	@Test
 	void setArgumentNamesFromStringArray_withJoinPointAsMiddleParameter() {
 		AbstractAspectJAdvice advice = getAspectJAdvice("methodWithJoinPointAsMiddleParameter");
-		assertArgumentNamesFromStringArray(advice);
+		assertThat(getArgumentNames(advice)[0]).isEqualTo("arg1");
+		assertThat(getArgumentNames(advice)[1]).isEqualTo("THIS_JOIN_POINT");
+		assertThat(getArgumentNames(advice)[2]).isEqualTo("arg2");
 	}
 
 	@Test


### PR DESCRIPTION
After enabling `@EnableTransactionManagement(mode = AdviceMode.ASPECTJ, proxyTargetClass = true)`, an exception occurs.

```
java.lang.IllegalStateException: Expecting to find 3 arguments to bind by name in advice, but actually found 2 arguments
```

The issue seems to be that AspectJ has changed its logic, and the first element in `aspectJAdviceMethod.getParameterTypes()` no longer returns `JoinPoint`, causing the exception.

```
2025-01-24T22:15:06.825+08:00 DEBUG 85696 --- [           main] .s.a.a.a.ReflectiveAspectJAdvisorFactory : Found AspectJ method: public java.lang.Object org.springframework.transaction.aspectj.AbstractTransactionAspect.ajc$around$org_springframework_transaction_aspectj_AbstractTransactionAspect$1$2a73e96c(java.lang.Object,org.aspectj.runtime.internal.AroundClosure,org.aspectj.lang.JoinPoint$StaticPart)
2025-01-24T22:15:06.825+08:00 DEBUG 85696 --- [           main] .s.a.a.a.ReflectiveAspectJAdvisorFactory : Ignoring incompatible advice method: public java.lang.Object org.springframework.transaction.aspectj.AbstractTransactionAspect.ajc$around$org_springframework_transaction_aspectj_AbstractTransactionAspect$1$2a73e96c(java.lang.Object,org.aspectj.runtime.internal.AroundClosure,org.aspectj.lang.JoinPoint$StaticPart)

java.lang.IllegalStateException: Expecting to find 3 arguments to bind by name in advice, but actually found 2 arguments.
	at org.springframework.aop.aspectj.AbstractAspectJAdvice.bindExplicitArguments(AbstractAspectJAdvice.java:472) ~[spring-aop-6.2.1.jar:6.2.1]
	at org.springframework.aop.aspectj.AbstractAspectJAdvice.bindArgumentsByName(AbstractAspectJAdvice.java:438) ~[spring-aop-6.2.1.jar:6.2.1]
	at org.springframework.aop.aspectj.AbstractAspectJAdvice.calculateArgumentBindings(AbstractAspectJAdvice.java:389) ~[spring-aop-6.2.1.jar:6.2.1]
	at org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory.getAdvice(ReflectiveAspectJAdvisorFactory.java:314) ~[spring-aop-6.2.1.jar:6.2.1]
	at org.springframework.aop.aspectj.annotation.InstantiationModelAwarePointcutAdvisorImpl.instantiateAdvice(InstantiationModelAwarePointcutAdvisorImpl.java:152) ~[spring-aop-6.2.1.jar:6.2.1]
	at org.springframework.aop.aspectj.annotation.InstantiationModelAwarePointcutAdvisorImpl.<init>(InstantiationModelAwarePointcutAdvisorImpl.java:116) ~[spring-aop-6.2.1.jar:6.2.1]
	at org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory.getAdvisor(ReflectiveAspectJAdvisorFactory.java:217) ~[spring-aop-6.2.1.jar:6.2.1]
	at org.springframework.aop.aspectj.annotation.ReflectiveAspectJAdvisorFactory.getAdvisors(ReflectiveAspectJAdvisorFactory.java:146) ~[spring-aop-6.2.1.jar:6.2.1]
	at org.springframework.aop.aspectj.annotation.BeanFactoryAspectJAdvisorsBuilder.buildAspectJAdvisors(BeanFactoryAspectJAdvisorsBuilder.java:116) ~[spring-aop-6.2.1.jar:6.2.1]
	at org.springframework.aop.aspectj.annotation.AnnotationAwareAspectJAutoProxyCreator.findCandidateAdvisors(AnnotationAwareAspectJAutoProxyCreator.java:95) ~[spring-aop-6.2.1.jar:6.2.1]
	at org.springframework.aop.aspectj.autoproxy.AspectJAwareAdvisorAutoProxyCreator.shouldSkip(AspectJAwareAdvisorAutoProxyCreator.java:105) ~[spring-aop-6.2.1.jar:6.2.1]
	at org.springframework.aop.framework.autoproxy.AbstractAutoProxyCreator.postProcessBeforeInstantiation(AbstractAutoProxyCreator.java:280) ~[spring-aop-6.2.1.jar:6.2.1]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.applyBeanPostProcessorsBeforeInstantiation(AbstractAutowireCapableBeanFactory.java:1150) ~[spring-beans-6.2.1.jar:6.2.1]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.resolveBeforeInstantiation(AbstractAutowireCapableBeanFactory.java:1125) ~[spring-beans-6.2.1.jar:6.2.1]
	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:512) ~[spring-beans-6.2.1.jar:6.2.1]
	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:336) ~[spring-beans-6.2.1.jar:6.2.1]
	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:289) ~[spring-beans-6.2.1.jar:6.2.1]
	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:334) ~[spring-beans-6.2.1.jar:6.2.1]
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:204) ~[spring-beans-6.2.1.jar:6.2.1]
	at org.springframework.context.support.PostProcessorRegistrationDelegate.registerBeanPostProcessors(PostProcessorRegistrationDelegate.java:277) ~[spring-context-6.2.1.jar:6.2.1]
	at org.springframework.context.support.AbstractApplicationContext.registerBeanPostProcessors(AbstractApplicationContext.java:808) ~[spring-context-6.2.1.jar:6.2.1]
	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:611) ~[spring-context-6.2.1.jar:6.2.1]
	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:146) ~[spring-boot-3.4.1.jar:3.4.1]
	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:752) ~[spring-boot-3.4.1.jar:3.4.1]
	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:439) ~[spring-boot-3.4.1.jar:3.4.1]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:318) ~[spring-boot-3.4.1.jar:3.4.1]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1361) ~[spring-boot-3.4.1.jar:3.4.1]
	at org.springframework.boot.SpringApplication.run(SpringApplication.java:1350) ~[spring-boot-3.4.1.jar:3.4.1]
	at com.example.demo.DemoApplication.main(DemoApplication.java:17) ~[classes/:na]
```