### PR TITLE
Replace hardcoded "Sec-WebSocket-Version" with constant

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/support/AbstractHandshakeHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/support/AbstractHandshakeHandler.java
@@ -255,7 +255,7 @@ public abstract class AbstractHandshakeHandler implements HandshakeHandler, Life
 
 	protected void handleWebSocketVersionNotSupported(ServerHttpRequest request, ServerHttpResponse response) {
 		if (logger.isErrorEnabled()) {
-			String version = request.getHeaders().getFirst("Sec-WebSocket-Version");
+			String version = request.getHeaders().getFirst(WebSocketHttpHeaders.SEC_WEBSOCKET_VERSION);
 			logger.error(LogFormatUtils.formatValue(
 					"Handshake failed due to unsupported WebSocket version: " + version +
 							". Supported versions: " + Arrays.toString(getSupportedVersions()), -1, true));


### PR DESCRIPTION
## Motivation
The current implementation uses a hardcoded string "Sec-WebSocket-Version" in the method, while also using the constant WebSocketHttpHeaders.SEC_WEBSOCKET_VERSION within the same method. This inconsistency could lead to potential errors during maintenance and reduces code readability.

## Modification
- Replaced the hardcoded string "Sec-WebSocket-Version" with the constant WebSocketHttpHeaders.SEC_WEBSOCKET_VERSION.
- Ensures consistent usage of constants throughout the method for better readability and maintainability.

## Result
This is a purely refactor-level change. No functional behavior has been altered, and existing functionality remains intact.