### PR TITLE
Polish org.springframework.scheduling.support.CronExpression#isValidExpression

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/support/CronExpression.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/support/CronExpression.java
@@ -206,9 +206,6 @@ public final class CronExpression {
 	 * @since 5.3.8
 	 */
 	public static boolean isValidExpression(@Nullable String expression) {
-		if (expression == null) {
-			return false;
-		}
 		try {
 			parse(expression);
 			return true;


### PR DESCRIPTION
The ‘parse’ method called by the ‘isValidExpression’ method already uses ‘Assert.hasLength’ first to check if the input of the parameter being checked is empty or null, so it is not necessary to make the null judgement first in ‘isValidExpression’.