### PR TITLE
[POC] Optimize parallel context loading in the TestContext framework

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=7.0.0-SNAPSHOT
+version=7.0.0b-SNAPSHOT
 
 org.gradle.caching=true
 org.gradle.jvmargs=-Xmx2048m

--- a/spring-test/src/main/java/org/springframework/test/context/cache/ContextCache.java
+++ b/spring-test/src/main/java/org/springframework/test/context/cache/ContextCache.java
@@ -17,10 +17,12 @@
 package org.springframework.test.context.cache;
 
 import org.jspecify.annotations.Nullable;
-
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.annotation.DirtiesContext.HierarchyMode;
 import org.springframework.test.context.MergedContextConfiguration;
+
+import java.util.concurrent.Future;
+import java.util.function.Function;
 
 /**
  * {@code ContextCache} defines the SPI for caching Spring
@@ -96,7 +98,10 @@ public interface ContextCache {
 	 * if not found in the cache
 	 * @see #remove
 	 */
-	@Nullable ApplicationContext get(MergedContextConfiguration key);
+	@Nullable
+	ApplicationContext get(MergedContextConfiguration key);
+
+	Future<ApplicationContext> computeIfAbsent(MergedContextConfiguration key, Function<MergedContextConfiguration, ApplicationContext> mappingFunction);
 
 	/**
 	 * Explicitly add an {@code ApplicationContext} instance to the cache


### PR DESCRIPTION
Hi,

when I recently activated the junit thread parallelisation in my project I discovered that different tests are waiting each other even if they are creating different application contexts.
In fact a synchronised block inside `DefaultCacheAwareContextLoaderDelegate.loadContext` is preventing different threads to load also different contexts.
Waiting the context creation is essential to reuse the context when different tests are requesting the same context (context caching). But it is inefficient when the contexts are different.

So I replaced the synchronised block with a lazy creation of the context (using the combination of Map, Future and a separated thread pool). 

Now during the test execution the DefaultCacheAwareContextLoaderDelegate will put the context key and the lazy computation in the `contextMap` - and this operation is really fast. Then DefaultCacheAwareContextLoaderDelegate will wait the context creation during the `Future.get` invocation . If different tests are requesting the same context they will wait the same unique computation, preserving the caching feature. If they are requesting  different contexts the creation of them will be scheduled in parallel.

I prepared this poc to show you the idea. If you believe this is correct, please give me some guideline in order to prepare a better pull request.

I also created [this project](https://github.com/gnosly/sprint-test-load-test) that reproduce the bottleneck.

Just to give you an real example, with this change I reduce the testing time from 4 to 3 minutes for a project.

Please let me know,
Thank you