### PR TITLE
Check hasNext when when accessing sessionIds from UserDestinationResult

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/user/UserDestinationMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/user/UserDestinationMessageHandler.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.logging.Log;
@@ -276,8 +275,7 @@ public class UserDestinationMessageHandler implements MessageHandler, SmartLifec
 		}
 
 		public void send(UserDestinationResult destinationResult, Message<?> message) throws MessagingException {
-			Set<String> sessionIds = destinationResult.getSessionIds();
-			Iterator<String> itr = (sessionIds != null ? sessionIds.iterator() : null);
+			Iterator<String> itr = destinationResult.getSessionIds().iterator();
 
 			for (String target : destinationResult.getTargetDestinations()) {
 				String sessionId = (itr != null && itr.hasNext() ? itr.next() : null);

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/user/UserDestinationMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/user/UserDestinationMessageHandler.java
@@ -280,7 +280,7 @@ public class UserDestinationMessageHandler implements MessageHandler, SmartLifec
 			Iterator<String> itr = (sessionIds != null ? sessionIds.iterator() : null);
 
 			for (String target : destinationResult.getTargetDestinations()) {
-				String sessionId = (itr != null ? itr.next() : null);
+				String sessionId = (itr != null && itr.hasNext() ? itr.next() : null);
 				getTemplateToUse(sessionId).send(target, message);
 			}
 		}

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/user/UserDestinationResult.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/user/UserDestinationResult.java
@@ -113,7 +113,7 @@ public class UserDestinationResult {
 	/**
 	 * Return the session id for the targetDestination.
 	 */
-	public @Nullable Set<String> getSessionIds() {
+	public Set<String> getSessionIds() {
 		return this.sessionIds;
 	}
 

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/user/UserDestinationMessageHandlerTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/user/UserDestinationMessageHandlerTests.java
@@ -17,6 +17,7 @@
 package org.springframework.messaging.simp.user;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Set;
 
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
@@ -89,6 +90,26 @@ class UserDestinationMessageHandlerTests {
 		given(this.registry.getUser("joe")).willReturn(simpUser);
 		given(this.brokerChannel.send(Mockito.any(Message.class))).willReturn(true);
 		this.handler.handleMessage(createWith(SimpMessageType.MESSAGE, "joe", "123", "/user/joe/queue/foo"));
+
+		ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
+		Mockito.verify(this.brokerChannel).send(captor.capture());
+
+		SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.wrap(captor.getValue());
+		assertThat(accessor.getDestination()).isEqualTo("/queue/foo-user123");
+		assertThat(accessor.getFirstNativeHeader(ORIGINAL_DESTINATION)).isEqualTo("/user/queue/foo");
+	}
+
+	@Test
+	@SuppressWarnings("rawtypes")
+	void handleMessageWithoutSessionIds() {
+		UserDestinationResolver resolver = mock();
+		Message message = createWith(SimpMessageType.MESSAGE, "joe", null, "/user/joe/queue/foo");
+		UserDestinationResult result = new UserDestinationResult("/queue/foo-user123", Set.of("/queue/foo-user123"), "/user/queue/foo", "joe");
+		given(resolver.resolveDestination(message)).willReturn(result);
+
+		given(this.brokerChannel.send(Mockito.any(Message.class))).willReturn(true);
+		UserDestinationMessageHandler handler = new UserDestinationMessageHandler(new StubMessageChannel(), this.brokerChannel, resolver);
+		handler.handleMessage(message);
 
 		ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
 		Mockito.verify(this.brokerChannel).send(captor.capture());


### PR DESCRIPTION
Found a bug in `UserDestinationMessageHandler.SendHelper#send` that occurs when the `UserDestinationResult` was created by the pre-6.1.x constructor. Bug was introduced with https://github.com/spring-projects/spring-framework/commit/3277b0d6ac6075135308ac6f8412376cb4b61b83

Ideally this fix will target 6.1+ and should be compatible. Not sure if there's a special way to call that out as a first-time contributor.

### Changes

- Add a test that reproduces the error and subsequently covers the fix
- Check if the iterator has a next value before accessing it and use the default condition if it does not
  - Using the default seems to be the original intent and was just missing this initial check

### Bug Details

The `UserDestinationMessageHandler` unsafely [retrieves](https://github.com/spring-projects/spring-framework/blob/f5b5f9a639311cf9614395a3f899c866869e0adb/spring-messaging/src/main/java/org/springframework/messaging/simp/user/UserDestinationMessageHandler.java#L283) values from an iterator of `sessionId` strings to lookup ordered messages.

This happens when the `UserDestinationResult` used to route the message was created with the pre-6.1.x [constructor](https://github.com/spring-projects/spring-framework/blob/f5b5f9a639311cf9614395a3f899c866869e0adb/spring-messaging/src/main/java/org/springframework/messaging/simp/user/UserDestinationResult.java#L47) this retrieval throws a `NoSuchElementException`.

This is because the older constructor passes a `null` to the newer [constructor](https://github.com/spring-projects/spring-framework/blob/f5b5f9a639311cf9614395a3f899c866869e0adb/spring-messaging/src/main/java/org/springframework/messaging/simp/user/UserDestinationResult.java#L57) for the `sessionIds` constructor arg. The class attempts to safe handle this `null` arg by creating an [EmptySet](https://github.com/openjdk/jdk/blob/98a93e115137a305aed6b7dbf1d4a7d5906fe77c/src/java.base/share/classes/java/util/Collections.java#L4679) that eventually provides an [EmptyIterator],(https://github.com/openjdk/jdk/blob/98a93e115137a305aed6b7dbf1d4a7d5906fe77c/src/java.base/share/classes/java/util/Collections.java#L4559) which then throws for `Set#next`.

This bug seems to only happen for custom implementations of `UserDestinationResolver` as the `DefaultUserDestinationResolver` always provides a populated set to the new constructor.