### PR TITLE
Multiple batch updates in NamedParameterJdbcOperations

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcOperations.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcOperations.java
@@ -16,6 +16,7 @@
 
 package org.springframework.jdbc.core.namedparam;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -585,5 +586,17 @@ public interface NamedParameterJdbcOperations {
 	 */
 	int[] batchUpdate(String sql, SqlParameterSource[] batchArgs, KeyHolder generatedKeyHolder,
 			String[] keyColumnNames);
+
+	/**
+	 * Executes the specified SQL update statement in multiple batches using the provided batch arguments.
+	 * @param sql the SQL statement to execute
+	 * @param batchArgs the collection of {@link SqlParameterSource} containing arguments for the query
+	 * @param batchSize batch size
+	 * @return a two-dimensional array containing results for each batch execution.
+	 * (may also contain special JDBC-defined negative values for affected rows such as
+	 * {@link java.sql.Statement#SUCCESS_NO_INFO}/{@link java.sql.Statement#EXECUTE_FAILED})
+	 * @throws DataAccessException if there is any problem issuing the update
+	 */
+	int[][] batchUpdate(String sql, Collection<SqlParameterSource> batchArgs, int batchSize);
 
 }

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplate.java
@@ -18,6 +18,7 @@ package org.springframework.jdbc.core.namedparam;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -423,6 +424,21 @@ public class NamedParameterJdbcTemplate implements NamedParameterJdbcOperations 
 		}, generatedKeyHolder);
 	}
 
+	@Override
+	public int[][] batchUpdate(String sql, Collection<SqlParameterSource> batchArgs, int batchSize) {
+		if (batchArgs.isEmpty() || batchSize <= 0) {
+			return new int[0][0];
+		}
+
+		ParsedSql parsedSql = getParsedSql(sql);
+		SqlParameterSource sqlParameterSource = batchArgs.iterator().next();
+		PreparedStatementCreatorFactory pscf = getPreparedStatementCreatorFactory(parsedSql, sqlParameterSource);
+
+		return getJdbcOperations().batchUpdate(pscf.getSql(), batchArgs, batchSize, (ps, argument) -> {
+			@Nullable Object[] values = NamedParameterUtils.buildValueArray(parsedSql, argument, null);
+			pscf.newPreparedStatementSetter(values).setValues(ps);
+		});
+	}
 
 	/**
 	 * Build a {@link PreparedStatementCreator} based on the given SQL and named parameters.


### PR DESCRIPTION
Feature request: Support for multiple batch updates in ``NamedParameterJdbcOperations``, similar to the existing support in ``JdbcOperations``.
Motivation: In my work, ``NamedParameterJdbcOperations`` is often used because of readability. I've come across cases where there is a big collection that needs to be executed in multiple batches. For that I see people doing one of the following:
- Use classic template, ``JdbcOperations.batchUpdate(String sql, Collection<T> batchArgs, int batchSize, ParameterizedPreparedStatementSetter<T> pss)``. It works great, but for many parameters, it can get complex from readability point of view due to many ``?``.
- Collection gets manually split into chunks and ``NamedParameterJdbcOperations.batchUpdate(String sql, SqlParameterSource[] batchArgs)`` is used. The splitting of the collection can be error prone, and is always done in different ways, for loops, streams. The operation gets cluttered with if / else and loops for the sake of parameter names in the query.

It would be nice to have a multiple batch support in NamedParameterJdbcOperations. So we can replace (example):
``` java
        List<SqlParameterSource> newCars = getNewCars();
        String sql = "INSERT INTO CARS VALUES(:year, :brand, :model)";
        int batchSize = 1000;
        List<List<SqlParameterSource>> batches = new ArrayList<>();
        for (int i = 0; i < newCars.size(); i++) {
            if (i % batchSize == 0) {
                batches.add(new ArrayList<>());
            }
            List<SqlParameterSource> currentBatch = batches.getLast();
            currentBatch.add(newCars.get(i));
        }
        for (List<SqlParameterSource> batch : batches) {
            namedParameterJdbcTemplate.batchUpdate(sql, batch.toArray(SqlParameterSource[]::new));
        }
```

With:
``` java
        List<SqlParameterSource> newCars = getNewCars();
        String sql = "INSERT INTO CARS VALUES(:year, :brand, :model)";
        int batchSize = 1000;
        int[][] results = namedParameterJdbcTemplate.batchUpdate(sql, newCars, batchSize);
```