### PR TITLE
Support RFC 8441 WebSocket upgrade with HTTP/2 CONNECT

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/socket/server/support/HandshakeWebSocketService.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/socket/server/support/HandshakeWebSocketService.java
@@ -205,23 +205,25 @@ public class HandshakeWebSocketService implements WebSocketService, Lifecycle {
 		HttpMethod method = request.getMethod();
 		HttpHeaders headers = request.getHeaders();
 
-		if (HttpMethod.GET != method && CONNECT_METHOD != method) {
+		if (HttpMethod.GET != method && !CONNECT_METHOD.equals(method)) {
 			return Mono.error(new MethodNotAllowedException(
 					request.getMethod(), Set.of(HttpMethod.GET, CONNECT_METHOD)));
 		}
 
-		if (!"WebSocket".equalsIgnoreCase(headers.getUpgrade())) {
-			return handleBadRequest(exchange, "Invalid 'Upgrade' header: " + headers);
-		}
+		if (HttpMethod.GET == method) {
+			if (!"WebSocket".equalsIgnoreCase(headers.getUpgrade())) {
+				return handleBadRequest(exchange, "Invalid 'Upgrade' header: " + headers);
+			}
 
-		List<String> connectionValue = headers.getConnection();
-		if (!connectionValue.contains("Upgrade") && !connectionValue.contains("upgrade")) {
-			return handleBadRequest(exchange, "Invalid 'Connection' header: " + headers);
-		}
+			List<String> connectionValue = headers.getConnection();
+			if (!connectionValue.contains("Upgrade") && !connectionValue.contains("upgrade")) {
+				return handleBadRequest(exchange, "Invalid 'Connection' header: " + headers);
+			}
 
-		String key = headers.getFirst(SEC_WEBSOCKET_KEY);
-		if (key == null) {
-			return handleBadRequest(exchange, "Missing \"Sec-WebSocket-Key\" header");
+			String key = headers.getFirst(SEC_WEBSOCKET_KEY);
+			if (key == null) {
+				return handleBadRequest(exchange, "Missing \"Sec-WebSocket-Key\" header");
+			}
 		}
 
 		String protocol = selectProtocol(headers, handler);

--- a/spring-websocket/src/main/java/org/springframework/web/socket/WebSocketHttpHeaders.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/WebSocketHttpHeaders.java
@@ -151,7 +151,7 @@ public class WebSocketHttpHeaders extends HttpHeaders {
 	}
 
 	/**
-	 * Returns the value of the {@code Sec-WebSocket-Key} header.
+	 * Returns the value of the {@code Sec-WebSocket-Protocol} header.
 	 * @return the value of the header
 	 */
 	public List<String> getSecWebSocketProtocol() {

--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/RequestUpgradeStrategy.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/RequestUpgradeStrategy.java
@@ -17,9 +17,12 @@
 package org.springframework.web.socket.server;
 
 import java.security.Principal;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import org.springframework.http.HttpMethod;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.lang.Nullable;
@@ -34,6 +37,25 @@ import org.springframework.web.socket.WebSocketHandler;
  * @see org.springframework.web.socket.server.standard.StandardWebSocketUpgradeStrategy
  */
 public interface RequestUpgradeStrategy {
+
+	enum OpeningHandshake {
+		RFC6455(HttpMethod.GET),
+		RFC8441(HttpMethod.valueOf("CONNECT"));
+
+		private final HttpMethod method;
+
+		OpeningHandshake(HttpMethod method) {
+			this.method = method;
+		}
+
+		public HttpMethod getMethod() {
+			return method;
+		}
+	}
+
+	default Set<OpeningHandshake> getSupportedOpeningHandshake() {
+		return EnumSet.of(OpeningHandshake.RFC6455);
+	}
 
 	/**
 	 * Return the supported WebSocket protocol versions.

--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/jetty/JettyRequestUpgradeStrategy.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/jetty/JettyRequestUpgradeStrategy.java
@@ -19,8 +19,10 @@ package org.springframework.web.socket.server.jetty;
 import java.lang.reflect.UndeclaredThrowableException;
 import java.security.Principal;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import jakarta.servlet.ServletContext;
@@ -58,6 +60,11 @@ public class JettyRequestUpgradeStrategy implements RequestUpgradeStrategy, Serv
 	@Nullable
 	private Consumer<Configurable> webSocketConfigurer;
 
+
+	@Override
+	public Set<OpeningHandshake> getSupportedOpeningHandshake() {
+		return EnumSet.of(OpeningHandshake.RFC6455, OpeningHandshake.RFC8441);
+	}
 
 	@Override
 	public String[] getSupportedVersions() {

--- a/spring-websocket/src/main/java/org/springframework/web/socket/server/support/AbstractHandshakeHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/server/support/AbstractHandshakeHandler.java
@@ -215,7 +215,7 @@ public abstract class AbstractHandshakeHandler implements HandshakeHandler, Life
 		}
 		try {
 			HttpMethod httpMethod = request.getMethod();
-			if (HttpMethod.GET != httpMethod && CONNECT_METHOD != httpMethod) {
+			if (HttpMethod.GET != httpMethod && !CONNECT_METHOD.equals(httpMethod)) {
 				response.setStatusCode(HttpStatus.METHOD_NOT_ALLOWED);
 				response.getHeaders().setAllow(Set.of(HttpMethod.GET, CONNECT_METHOD));
 				if (logger.isErrorEnabled()) {
@@ -223,13 +223,15 @@ public abstract class AbstractHandshakeHandler implements HandshakeHandler, Life
 				}
 				return false;
 			}
-			if (!"WebSocket".equalsIgnoreCase(headers.getUpgrade())) {
-				handleInvalidUpgradeHeader(request, response);
-				return false;
-			}
-			if (!headers.getConnection().contains("Upgrade") && !headers.getConnection().contains("upgrade")) {
-				handleInvalidConnectHeader(request, response);
-				return false;
+			if (HttpMethod.GET == httpMethod) {
+				if (!"WebSocket".equalsIgnoreCase(headers.getUpgrade())) {
+					handleInvalidUpgradeHeader(request, response);
+					return false;
+				}
+				if (!headers.getConnection().contains("Upgrade") && !headers.getConnection().contains("upgrade")) {
+					handleInvalidConnectHeader(request, response);
+					return false;
+				}
 			}
 			if (!isWebSocketVersionSupported(headers)) {
 				handleWebSocketVersionNotSupported(request, response);
@@ -239,13 +241,15 @@ public abstract class AbstractHandshakeHandler implements HandshakeHandler, Life
 				response.setStatusCode(HttpStatus.FORBIDDEN);
 				return false;
 			}
-			String wsKey = headers.getSecWebSocketKey();
-			if (wsKey == null) {
-				if (logger.isErrorEnabled()) {
-					logger.error("Missing \"Sec-WebSocket-Key\" header");
+			if (HttpMethod.GET == httpMethod) {
+				String wsKey = headers.getSecWebSocketKey();
+				if (wsKey == null) {
+					if (logger.isErrorEnabled()) {
+						logger.error("Missing \"Sec-WebSocket-Key\" header");
+					}
+					response.setStatusCode(HttpStatus.BAD_REQUEST);
+					return false;
 				}
-				response.setStatusCode(HttpStatus.BAD_REQUEST);
-				return false;
 			}
 		}
 		catch (IOException ex) {


### PR DESCRIPTION
f477c1653d2d8198bede242f4ea4d4a599727bcc which closed #34044 was an incomplete fix. Further changes are necessary to support HTTP/2 CONNECT WebSocket upgrades (RFC 8441).

I have manually tested this PR and the CONNECT WebSocket upgrade works as expected using Jetty 12 EE10.

Link to RFC:
https://datatracker.ietf.org/doc/html/rfc8441

The RFC explicitly says that the `Sec-WebSocket-Key` header is not required:

> Implementations using this extended CONNECT to bootstrap WebSockets
   do not do the processing of the Sec-WebSocket-Key and Sec-WebSocket-
   Accept header fields of [[RFC6455](https://datatracker.ietf.org/doc/html/rfc6455)] as that functionality has been
   superseded by the :protocol pseudo-header field.

The RFC explicitly says that the `Connection ` and `Upgrade`  headers are not required:

>  [RFC6455] requires the use of Connection and Upgrade header fields
   that are not part of HTTP/2.  They MUST NOT be included in the
   CONNECT request defined here.

## TODO
- Look into if we need to verify that we are using HTTP/2 and verify the `:protocol` pseudo-header
- Fix WebFlux implementation also