### PR TITLE
Fix CRaC potential hangup after restoring

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/DefaultLifecycleProcessor.java
+++ b/spring-context/src/main/java/org/springframework/context/support/DefaultLifecycleProcessor.java
@@ -589,22 +589,20 @@ public class DefaultLifecycleProcessor implements LifecycleProcessor, BeanFactor
 	 */
 	private class CracResourceAdapter implements org.crac.Resource {
 
-		private @Nullable CyclicBarrier barrier;
+		private CyclicBarrier stepToRestore = new CyclicBarrier(2);
+		private CyclicBarrier finishRestore = new CyclicBarrier(2);
+
+		private void preventShutdown() {
+			waitBarrier(this.stepToRestore);
+			// Checkpoint happens here
+			waitBarrier(this.finishRestore);
+		}
 
 		@Override
 		public void beforeCheckpoint(org.crac.Context<? extends org.crac.Resource> context) {
-			// A non-daemon thread for preventing an accidental JVM shutdown before the checkpoint
-			this.barrier = new CyclicBarrier(2);
-
-			Thread thread = new Thread(() -> {
-				awaitPreventShutdownBarrier();
-				// Checkpoint happens here
-				awaitPreventShutdownBarrier();
-			}, "prevent-shutdown");
-
+			Thread thread = new Thread(this::preventShutdown, "prevent-shutdown");
 			thread.setDaemon(false);
 			thread.start();
-			awaitPreventShutdownBarrier();
 
 			logger.debug("Stopping Spring-managed lifecycle beans before JVM checkpoint");
 			stopForRestart();
@@ -612,11 +610,24 @@ public class DefaultLifecycleProcessor implements LifecycleProcessor, BeanFactor
 
 		@Override
 		public void afterRestore(org.crac.Context<? extends org.crac.Resource> context) {
+			// Unlock barrier for beforeCheckpoint
+			try {
+				this.stepToRestore.await();
+			}
+			catch (Exception ex) {
+				logger.trace("Exception from stepToRestore barrier", ex);
+			}
+
 			logger.info("Restarting Spring-managed lifecycle beans after JVM restore");
 			restartAfterStop();
 
-			// Barrier for prevent-shutdown thread not needed anymore
-			this.barrier = null;
+			// Unlock barrier for afterRestore to shutdown "prevent-shutdown" thread
+			try {
+				this.finishRestore.await();
+			}
+			catch (Exception ex) {
+				logger.trace("Exception from stepToRestore barrier", ex);
+			}
 
 			if (!checkpointOnRefresh) {
 				logger.info("Spring-managed lifecycle restart completed (restored JVM running for " +
@@ -624,11 +635,9 @@ public class DefaultLifecycleProcessor implements LifecycleProcessor, BeanFactor
 			}
 		}
 
-		private void awaitPreventShutdownBarrier() {
+		private void waitBarrier(CyclicBarrier barrier) {
 			try {
-				if (this.barrier != null) {
-					this.barrier.await();
-				}
+				barrier.await();
 			}
 			catch (Exception ex) {
 				logger.trace("Exception from prevent-shutdown barrier", ex);


### PR DESCRIPTION
I run following `ApplicationRunner` Spring Boot app and I obtained checkpoint by CRIU. The app did not finish after restoring.

```java
  @Override
  public void run(ApplicationArguments args) throws Exception {
    if(args.containsOption("checkpoint")){
      System.out.println("Ready to obtain checkpoint...");
      // Wait restoring...
      cpCoordinator.await();
    }
    System.out.println("from Spring Boot App");
  }
```

I obtained thread dump, then I got following stack trace. It shows `beforeCheckpoint` CRaC handler waits signal in `CyclicBarrier`.

```
"prevent-shutdown" #29 [1504] prio=5 os_prio=0 cpu=0.17ms elapsed=25.76s tid=0x00007feb1017db00 nid=1504 waiting on condition  [0x00007feb4e22b000]
   java.lang.Thread.State: WAITING (parking)
        at jdk.internal.misc.Unsafe.park(java.base@21.0.2/Native Method)
        - parking to wait for  <0x000000008a9279b0> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
        at java.util.concurrent.locks.LockSupport.park(java.base@21.0.2/LockSupport.java:371)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(java.base@21.0.2/AbstractQueuedSynchronizer.java:519)
        at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@21.0.2/ForkJoinPool.java:3780)
        at java.util.concurrent.ForkJoinPool.managedBlock(java.base@21.0.2/ForkJoinPool.java:3725)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@21.0.2/AbstractQueuedSynchronizer.java:1707)
        at java.util.concurrent.CyclicBarrier.dowait(java.base@21.0.2/CyclicBarrier.java:236)
        at java.util.concurrent.CyclicBarrier.await(java.base@21.0.2/CyclicBarrier.java:364)
        at org.springframework.context.support.DefaultLifecycleProcessor$CracResourceAdapter.awaitPreventShutdownBarrier(DefaultLifecycleProcessor.java:634)
        at org.springframework.context.support.DefaultLifecycleProcessor$CracResourceAdapter.lambda$beforeCheckpoint$0(DefaultLifecycleProcessor.java:606)
        at org.springframework.context.support.DefaultLifecycleProcessor$CracResourceAdapter$$Lambda/0x00007feb501c37c0.run(Unknown Source)
        at java.lang.Thread.runWith(java.base@21.0.2/Thread.java:1596)
        at java.lang.Thread.run(java.base@21.0.2/Thread.java:1583)
```

I investigated `CracResourceAdapter`, `prevent-shutdown` thread might through the second `awaitPreventShutdownBarrier()` call if that thread runs before `awaitPreventShutdownBarrier()` at `beforeCheckpoint()`.

We need to separate barriers for `beforeCheckpoint` / `afterRestore` to work as expected.