### PR TITLE
ContentDisposition should match attributes in a case-insensitive fashion

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
+++ b/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
@@ -252,7 +252,7 @@ public final class ContentDisposition {
 			String part = parts.get(i);
 			int eqIndex = part.indexOf('=');
 			if (eqIndex != -1) {
-				String attribute = part.substring(0, eqIndex);
+				String attribute = part.substring(0, eqIndex).toLowerCase();
 				String value = (part.startsWith("\"", eqIndex + 1) && part.endsWith("\"") ?
 						part.substring(eqIndex + 2, part.length() - 1) :
 						part.substring(eqIndex + 1));

--- a/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
+++ b/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
@@ -181,6 +181,14 @@ class ContentDispositionTests {
 	}
 
 	@Test
+	void parseAttributesCaseIgnore() {
+		ContentDisposition cd = ContentDisposition.parse("form-data; Name=\"foo\"; FileName=\"bar.txt\"");
+		assertThat(cd.getName()).isEqualTo("foo");
+		assertThat(cd.getFilename()).isEqualTo("bar.txt");
+		assertThat(cd.toString()).isEqualTo("form-data; name=\"foo\"; filename=\"bar.txt\"");
+	}
+
+	@Test
 	void parseEmpty() {
 		assertThatIllegalArgumentException().isThrownBy(() -> parse(""));
 	}

--- a/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
+++ b/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
@@ -181,7 +181,7 @@ class ContentDispositionTests {
 	}
 
 	@Test
-	void parseAttributesCaseIgnore() {
+	void parseAttributesCaseInsensitively() {
 		ContentDisposition cd = ContentDisposition.parse("form-data; Name=\"foo\"; FileName=\"bar.txt\"");
 		assertThat(cd.getName()).isEqualTo("foo");
 		assertThat(cd.getFilename()).isEqualTo("bar.txt");


### PR DESCRIPTION
File name is null bug. HTTP clients may send a file with a "FileName" attribute in the Content-Disposition header.

RFC 6266: 'The parameters "filename" and "filename*", to be matched case-insensitively, provide information on how to construct a filename for storing the message payload.'

Signed-off-by: Andras Dobrosi <dobrosi@gmail.com>