### PR TITLE
Resolve deprecation warnings in RuntimeHintsAgentPlugin

### DIFF
--- a/buildSrc/src/main/java/org/springframework/build/hint/RuntimeHintsAgentPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/build/hint/RuntimeHintsAgentPlugin.java
@@ -64,7 +64,7 @@ public class RuntimeHintsAgentPlugin implements Plugin<Project> {
 				test.setClasspath(jvmTestSuite.getSources().getRuntimeClasspath());
 				test.getJvmArgumentProviders().add(createRuntimeHintsAgentArgumentProvider(project, agentExtension));
 			});
-			project.getTasks().getByName("check", task -> task.dependsOn(agentTest));
+			project.getTasks().named("check", task -> task.dependsOn(agentTest));
 			project.getDependencies().add(CONFIGURATION_NAME, project.project(":spring-core-test"));
 		});
 	}

--- a/buildSrc/src/main/java/org/springframework/build/hint/RuntimeHintsAgentPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/build/hint/RuntimeHintsAgentPlugin.java
@@ -27,6 +27,7 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.attributes.java.TargetJvmVersion;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.jvm.JvmTestSuite;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.testing.Test;
 import org.gradle.testing.base.TestingExtension;
 
@@ -52,7 +53,7 @@ public class RuntimeHintsAgentPlugin implements Plugin<Project> {
 			TestingExtension testing = project.getExtensions().getByType(TestingExtension.class);
 			JvmTestSuite jvmTestSuite = (JvmTestSuite) testing.getSuites().getByName("test");
 			RuntimeHintsAgentExtension agentExtension = createRuntimeHintsAgentExtension(project);
-			Test agentTest = project.getTasks().create(RUNTIMEHINTS_TEST_TASK, Test.class, test -> {
+			TaskProvider<Test> agentTest = project.getTasks().register(RUNTIMEHINTS_TEST_TASK, Test.class, test -> {
 				test.useJUnitPlatform(options -> {
 					options.includeTags("RuntimeHintsTests");
 				});


### PR DESCRIPTION
## Motivation
- This PR aims to resolve the deprecation warnings in `RuntimeHintsAgentPlugin.java`.  
Currently, the Gradle build shows the following warning with `-Xlint:deprecation`:
```
build/hint/RuntimeHintsAgentPlugin.java:55: warning: [deprecation] <T>create(String,Class<T>,Action<? super T>) in TaskContainer has been deprecated
 Test agentTest = project.getTasks().create(RUNTIMEHINTS_TEST_TASK, Test.class, test -> {
                                    ^
  where T is a type-variable:
    T extends Task declared in method <T>create(String,Class<T>,Action<? super T>)
```
## Modification
- Replaced `project.getTasks().create(...)` with `project.getTasks().register(...)` to avoid using the deprecated API.


## Result
Closes gh-34389