### PR TITLE
Fix copyright end year in `ServerResponseResultHandler`

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/support/ServerResponseResultHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/support/ServerResponseResultHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This PR fixes a typo in the copyright end year in the `ServerResponseResultHandler`.

See https://github.com/spring-projects/spring-framework/commit/1cea1fe962cc95544fce7be8fd2f56419e89aaaf#diff-fa20069f0305b5aee07bf90a7f8d0502a6ee139892639b7dfe470b54c3a8574aL2-R2