### PR TITLE
Fix reference to ApplicationContext#getAutowireCapableBeanFactory in reference documentation

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/beans/definition.adoc
+++ b/framework-docs/modules/ROOT/pages/core/beans/definition.adoc
@@ -57,7 +57,7 @@ The following table describes these properties:
 In addition to bean definitions that contain information on how to create a specific
 bean, the `ApplicationContext` implementations also permit the registration of existing
 objects that are created outside the container (by users). This is done by accessing the
-ApplicationContext's `BeanFactory` through the `getBeanFactory()` method, which returns
+ApplicationContext's `BeanFactory` through the `getAutowireCapableBeanFactory()` method, which returns
 the `DefaultListableBeanFactory` implementation. `DefaultListableBeanFactory` supports
 this registration through the `registerSingleton(..)` and `registerBeanDefinition(..)`
 methods. However, typical applications work solely with beans defined through regular


### PR DESCRIPTION
Adjust doc to start using `getAutowireCapableBeanFactory `ref, since `getBeanFactory `is not available on the `ApplicationContext `interface.