### PR TITLE
Add form fields to MockMvc Kotlin DSL

### DIFF
--- a/spring-test/src/main/kotlin/org/springframework/test/web/servlet/MockHttpServletRequestDsl.kt
+++ b/spring-test/src/main/kotlin/org/springframework/test/web/servlet/MockHttpServletRequestDsl.kt
@@ -130,6 +130,18 @@ open class MockHttpServletRequestDsl(private val builder: AbstractMockHttpServle
 	var queryParams: MultiValueMap<String, String>? = null
 
 	/**
+	 * @see [MockHttpServletRequestBuilder.formField]
+	 */
+	fun formField(name: String, vararg values: String) {
+		builder.formField(name, *values)
+	}
+
+	/**
+	 * @see [MockHttpServletRequestBuilder.formFields]
+	 */
+	var formFields: MultiValueMap<String, String>? = null
+
+	/**
 	 * @see [MockHttpServletRequestBuilder.cookie]
 	 */
 	fun cookie(vararg cookies: Cookie) {
@@ -215,6 +227,7 @@ open class MockHttpServletRequestDsl(private val builder: AbstractMockHttpServle
 		contentType?.also { builder.contentType(it) }
 		params?.also { builder.params(it) }
 		queryParams?.also { builder.queryParams(it) }
+		formFields?.also { builder.formFields(it) }
 		sessionAttrs?.also { builder.sessionAttrs(it) }
 		flashAttrs?.also { builder.flashAttrs(it) }
 		session?.also { builder.session(it) }

--- a/spring-test/src/test/kotlin/org/springframework/test/web/servlet/MockMvcExtensionsTests.kt
+++ b/spring-test/src/test/kotlin/org/springframework/test/web/servlet/MockMvcExtensionsTests.kt
@@ -23,6 +23,7 @@ import org.hamcrest.CoreMatchers
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED_VALUE
 import org.springframework.http.MediaType.APPLICATION_ATOM_XML
 import org.springframework.http.MediaType.APPLICATION_JSON
 import org.springframework.http.MediaType.APPLICATION_XML
@@ -230,6 +231,15 @@ class MockMvcExtensionsTests {
 		assertThat(result.request.queryString).isEqualTo("foo=bar&foo=baz")
 	}
 
+	@Test
+	fun formField() {
+		val result = mockMvc.post("/person") {
+			formField("name", "foo")
+			formField("someDouble", "1.23")
+		}.andReturn()
+		assertThat(result.request.contentType).startsWith(APPLICATION_FORM_URLENCODED_VALUE)
+		assertThat(result.request.contentAsString).isEqualTo("name=foo&someDouble=1.23")
+	}
 
 	@RestController
 	private class PersonController {


### PR DESCRIPTION
Form fields are available on `MockHttpServletRequestBuilder` but do not exist in `MockHttpServletRequestDsl`. This is a form equivalent of #32371 