### PR TITLE
Fix Non-transient non-serializable instance field in serializable class

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ProblemDetail.java
+++ b/spring-web/src/main/java/org/springframework/http/ProblemDetail.java
@@ -68,7 +68,7 @@ public class ProblemDetail implements Serializable {
 
 	private @Nullable URI instance;
 
-	private @Nullable Map<String, Object> properties;
+	private transient @Nullable Map<String, Object> properties;
 
 
 	/**


### PR DESCRIPTION
when execute org/springframework/test/web/UriAssertTests#isEqualToTemplate org/springframework/http/ProblemDetail#properties will throw Non-transient non-serializable instance field in serializable class