### PR TITLE
Add Javadoc since for HandlerMethod(HandlerMethod, Object, boolean)

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/method/HandlerMethod.java
+++ b/spring-web/src/main/java/org/springframework/web/method/HandlerMethod.java
@@ -181,6 +181,7 @@ public class HandlerMethod extends AnnotatedMethod {
 	 * validation annotations.
 	 * <p>Subclasses can override this to ensure that a HandlerMethod is of the
 	 * same type if re-created.
+	 * @since 6.2.3
 	 */
 	protected HandlerMethod(HandlerMethod handlerMethod, @Nullable Object handler, boolean initValidateFlags) {
 		super(handlerMethod);


### PR DESCRIPTION
This PR adds a Javadoc `@since` tag for the `HandlerMethod(HandlerMethod, Object, boolean)`.

See 56c4d2d