### PR TITLE
Sync `checkstyle` on `buildSrc`

### DIFF
--- a/buildSrc/config/checkstyle/checkstyle.xml
+++ b/buildSrc/config/checkstyle/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
-<module name="com.puppycrawl.tools.checkstyle.Checker">
+<module name="Checker">
 
 	<!-- Root Checks -->
 	<module name="io.spring.javaformat.checkstyle.check.SpringHeaderCheck">
@@ -12,13 +12,12 @@
 	<module name="com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck"/>
 
 	<!-- TreeWalker Checks -->
-	<module name="com.puppycrawl.tools.checkstyle.TreeWalker">
+	<module name="TreeWalker">
 
 		<!-- Imports -->
-		<module name="com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck">
-			<property name="processJavadoc" value="true"/>
-		</module>
-
+		<module name="AvoidStarImport"/>
+		<module name="UnusedImports"/>
+		<module name="RedundantImport"/>
 		<!-- Modifiers -->
 		<module name="com.puppycrawl.tools.checkstyle.checks.modifier.ModifierOrderCheck"/>
 

--- a/buildSrc/src/main/java/org/springframework/build/architecture/ArchitectureCheck.java
+++ b/buildSrc/src/main/java/org/springframework/build/architecture/ArchitectureCheck.java
@@ -44,7 +44,12 @@ import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.SkipWhenEmpty;
 import org.gradle.api.tasks.TaskAction;
 
-import static org.springframework.build.architecture.ArchitectureRules.*;
+import static org.springframework.build.architecture.ArchitectureRules.allPackagesShouldBeFreeOfTangles;
+import static org.springframework.build.architecture.ArchitectureRules.classesShouldNotImportForbiddenTypes;
+import static org.springframework.build.architecture.ArchitectureRules.javaClassesShouldNotImportKotlinAnnotations;
+import static org.springframework.build.architecture.ArchitectureRules.noClassesShouldCallStringToLowerCaseWithoutLocale;
+import static org.springframework.build.architecture.ArchitectureRules.noClassesShouldCallStringToUpperCaseWithoutLocale;
+import static org.springframework.build.architecture.ArchitectureRules.packageInfoShouldBeNullMarked;
 
 /**
  * {@link Task} that checks for architecture problems.

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
-<module name="com.puppycrawl.tools.checkstyle.Checker">
+<module name="Checker">
 
 	<!-- Suppressions -->
 	<module name="SuppressionFilter">
@@ -18,7 +18,7 @@
 	<module name="JavadocPackage" /><!-- package-info.java -->
 
 	<!-- TreeWalker Checks -->
-	<module name="com.puppycrawl.tools.checkstyle.TreeWalker">
+	<module name="TreeWalker">
 
 		<!-- Annotations -->
 		<module name="com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck">
@@ -89,11 +89,9 @@
 		<module name="com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck"/>
 
 		<!-- Imports -->
-		<module name="com.puppycrawl.tools.checkstyle.checks.imports.AvoidStarImportCheck"/>
-		<module name="com.puppycrawl.tools.checkstyle.checks.imports.RedundantImportCheck"/>
-		<module name="com.puppycrawl.tools.checkstyle.checks.imports.UnusedImportsCheck">
-			<property name="processJavadoc" value="true"/>
-		</module>
+		<module name="AvoidStarImport"/>
+		<module name="UnusedImports"/>
+		<module name="RedundantImport"/>
 		<module name="com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck">
 			<property name="groups" value="java,javax,*,org.springframework"/>
 			<property name="ordered" value="true"/>


### PR DESCRIPTION
I was wondering why the only existing wildcard import was not flagged by Checkstyle. It turned out that the configuration was out of sync.

Considering the example documentation from Checkstyle itself, the default setup appears to work out of the box without requiring a fully qualified import.  

This can likely be reverted—I just wanted to point this out, as I’ve been using it the same way on other projects as in the example, and it worked effortlessly and identically.

- https://checkstyle.sourceforge.io/checks/imports/illegalimport.html#Example1-config
- https://checkstyle.sourceforge.io/checks/imports