### PR TITLE
Use `ORDER` constant in `MockitoResetTestExecutionListener`

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/bean/override/mockito/MockitoResetTestExecutionListener.java
+++ b/spring-test/src/main/java/org/springframework/test/context/bean/override/mockito/MockitoResetTestExecutionListener.java
@@ -87,7 +87,7 @@ public class MockitoResetTestExecutionListener extends AbstractTestExecutionList
 	 */
 	@Override
 	public int getOrder() {
-		return Ordered.LOWEST_PRECEDENCE - 100;
+		return ORDER;
 	}
 
 	@Override


### PR DESCRIPTION
This PR changes to use the `ORDER` in the `MockitoResetTestExecutionListener.getOrder()` that seems to have been missed in 9797bc0acd11be924ce4501bb1f421939c31cc09.