### PR TITLE
Apply checkstyle rule `UnusedImports`

### DIFF
--- a/buildSrc/config/checkstyle/checkstyle.xml
+++ b/buildSrc/config/checkstyle/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
+<!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+		"https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
-
 	<!-- Root Checks -->
 	<module name="io.spring.javaformat.checkstyle.check.SpringHeaderCheck">
 		<property name="fileExtensions" value="java"/>
@@ -10,17 +10,16 @@
 		<property name="packageInfoHeaderType" value="none"/>
 	</module>
 	<module name="com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck"/>
-
 	<!-- TreeWalker Checks -->
 	<module name="TreeWalker">
-
 		<!-- Imports -->
 		<module name="AvoidStarImport"/>
 		<module name="UnusedImports"/>
 		<module name="RedundantImport"/>
 		<!-- Modifiers -->
 		<module name="com.puppycrawl.tools.checkstyle.checks.modifier.ModifierOrderCheck"/>
-
+		<!-- Best Practices -->
+		<module name="UnusedLocalVariable"/>
+		<module name="VariableDeclarationUsageDistance"/>
 	</module>
-
 </module>

--- a/framework-docs/src/main/java/org/springframework/docs/testing/mockmvc/assertj/mockmvctesterrequests/HotelControllerTests.java
+++ b/framework-docs/src/main/java/org/springframework/docs/testing/mockmvc/assertj/mockmvctesterrequests/HotelControllerTests.java
@@ -21,7 +21,6 @@ import org.springframework.test.web.servlet.assertj.MockMvcTester;
 import org.springframework.test.web.servlet.assertj.MvcTestResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 /**
  * @author Stephane Nicoll

--- a/framework-docs/src/main/java/org/springframework/docs/web/websocket/stomp/websocketstompconfigurationperformance/MessageSizeLimitWebSocketConfiguration.java
+++ b/framework-docs/src/main/java/org/springframework/docs/web/websocket/stomp/websocketstompconfigurationperformance/MessageSizeLimitWebSocketConfiguration.java
@@ -17,7 +17,9 @@
 package org.springframework.docs.web.websocket.stomp.websocketstompconfigurationperformance;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
 

--- a/framework-docs/src/main/java/org/springframework/docs/web/websocket/stomp/websocketstompconfigurationperformance/MessageSizeLimitWebSocketConfiguration.java
+++ b/framework-docs/src/main/java/org/springframework/docs/web/websocket/stomp/websocketstompconfigurationperformance/MessageSizeLimitWebSocketConfiguration.java
@@ -17,9 +17,7 @@
 package org.springframework.docs.web.websocket.stomp.websocketstompconfigurationperformance;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
-import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
 

--- a/framework-docs/src/main/java/org/springframework/docs/web/websocket/stomp/websocketstompconfigurationperformance/WebSocketConfiguration.java
+++ b/framework-docs/src/main/java/org/springframework/docs/web/websocket/stomp/websocketstompconfigurationperformance/WebSocketConfiguration.java
@@ -17,9 +17,7 @@
 package org.springframework.docs.web.websocket.stomp.websocketstompconfigurationperformance;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
-import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 import org.springframework.web.socket.config.annotation.WebSocketTransportRegistration;
 

--- a/framework-docs/src/main/java/org/springframework/docs/web/websocket/stomp/websocketstomphandlesimplebroker/WebSocketConfiguration.java
+++ b/framework-docs/src/main/java/org/springframework/docs/web/websocket/stomp/websocketstomphandlesimplebroker/WebSocketConfiguration.java
@@ -22,7 +22,6 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
-import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 // tag::snippet[]

--- a/framework-docs/src/main/java/org/springframework/docs/web/websocket/stomp/websocketstompmessageflow/GreetingController.java
+++ b/framework-docs/src/main/java/org/springframework/docs/web/websocket/stomp/websocketstompmessageflow/GreetingController.java
@@ -19,13 +19,8 @@ package org.springframework.docs.web.websocket.stomp.websocketstompmessageflow;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
-import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
-import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 // tag::snippet[]
 @Controller

--- a/framework-docs/src/main/java/org/springframework/docs/web/websocket/stomp/websocketstomporderedmessages/ReceiveOrderWebSocketConfiguration.java
+++ b/framework-docs/src/main/java/org/springframework/docs/web/websocket/stomp/websocketstomporderedmessages/ReceiveOrderWebSocketConfiguration.java
@@ -17,7 +17,6 @@
 package org.springframework.docs.web.websocket.stomp.websocketstomporderedmessages;
 
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN" "https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
-
 	<!-- Suppressions -->
 	<module name="SuppressionFilter">
 		<property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
 	</module>
-
 	<!-- Root Checks -->
 	<module name="io.spring.javaformat.checkstyle.check.SpringHeaderCheck">
 		<property name="fileExtensions" value="java"/>
@@ -16,10 +14,8 @@
 	</module>
 	<module name="com.puppycrawl.tools.checkstyle.checks.NewlineAtEndOfFileCheck"/>
 	<module name="JavadocPackage" /><!-- package-info.java -->
-
 	<!-- TreeWalker Checks -->
 	<module name="TreeWalker">
-
 		<!-- Annotations -->
 		<module name="com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck">
 			<property name="elementStyle" value="compact"/>
@@ -27,7 +23,6 @@
 		<module name="com.puppycrawl.tools.checkstyle.checks.annotation.MissingOverrideCheck"/>
 		<module name="com.puppycrawl.tools.checkstyle.checks.annotation.PackageAnnotationCheck"/>
 		<module name="com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck"/>
-
 		<!-- Block Checks -->
 		<module name="com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck">
 			<property name="option" value="text"/>
@@ -38,7 +33,6 @@
 		</module>
 		<module name="com.puppycrawl.tools.checkstyle.checks.blocks.NeedBracesCheck"/>
 		<module name="com.puppycrawl.tools.checkstyle.checks.blocks.AvoidNestedBlocksCheck"/>
-
 		<!-- Class Design -->
 		<module name="com.puppycrawl.tools.checkstyle.checks.design.FinalClassCheck"/>
 		<module name="com.puppycrawl.tools.checkstyle.checks.design.InterfaceIsTypeCheck"/>
@@ -48,7 +42,6 @@
 		</module>
 		<module name="com.puppycrawl.tools.checkstyle.checks.design.InnerTypeLastCheck"/>
 		<module name="com.puppycrawl.tools.checkstyle.checks.design.OneTopLevelClassCheck"/>
-
 		<!-- Type Names -->
 		<module name="TypeName">
 			<property name="format" value="^[A-Z][a-zA-Z0-9_$]*(?&lt;!Test)$"/>
@@ -56,7 +49,6 @@
 			<message key="name.invalidPattern"
 				value="Class name ''{0}'' must not end with ''Test'' (checked pattern ''{1}'')."/>
 		</module>
-
 		<!-- Coding -->
 		<module name="com.puppycrawl.tools.checkstyle.checks.coding.CovariantEqualsCheck"/>
 		<module name="com.puppycrawl.tools.checkstyle.checks.coding.EmptyStatementCheck"/>
@@ -74,7 +66,6 @@
 			<property name="max" value="3"/>
 		</module>
 		<module name="com.puppycrawl.tools.checkstyle.checks.coding.MultipleVariableDeclarationsCheck"/>
-
 		<module name="io.spring.javaformat.checkstyle.filter.RequiresOuterThisFilter"/>
 		<module name="io.spring.javaformat.checkstyle.filter.IdentCheckFilter">
 			<property name="names" value="logger"/>
@@ -87,7 +78,6 @@
 			<property name="names" value="logger"/>
 		</module>
 		<module name="com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck"/>
-
 		<!-- Imports -->
 		<module name="AvoidStarImport"/>
 		<module name="UnusedImports"/>
@@ -131,7 +121,6 @@
 			<property name="regexp" value="true"/>
 			<property name="illegalClasses" value="^org\.hamcrest\..+"/>
 		</module>
-
 		<!-- Javadoc Comments -->
 		<module name="com.puppycrawl.tools.checkstyle.checks.javadoc.JavadocTypeCheck">
 			<property name="scope" value="package"/>
@@ -159,14 +148,11 @@
 			<property name="target" value="METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
 			<property name="tagOrder" value="@param, @return, @throws, @since, @see, @deprecated"/>
 		</module>
-
 		<!-- Modifiers -->
 		<module name="com.puppycrawl.tools.checkstyle.checks.modifier.ModifierOrderCheck"/>
-
 		<!-- Whitespace -->
 		<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.MethodParamPadCheck"/>
 		<module name="com.puppycrawl.tools.checkstyle.checks.whitespace.SingleSpaceSeparatorCheck"/>
-
 		<!-- Miscellaneous -->
 		<module name="com.puppycrawl.tools.checkstyle.checks.indentation.CommentsIndentationCheck">
 			<property name="tokens" value="BLOCK_COMMENT_BEGIN"/>
@@ -175,7 +161,6 @@
 		<module name="com.puppycrawl.tools.checkstyle.checks.ArrayTypeStyleCheck"/>
 		<module name="com.puppycrawl.tools.checkstyle.checks.OuterTypeFilenameCheck"/>
 		<module name="UnnecessarySemicolonInEnumeration"/>
-
 		<!-- Regexp -->
 		<module name="com.puppycrawl.tools.checkstyle.checks.regexp.RegexpSinglelineJavaCheck">
 			<property name="format" value="^\t* +\t*\S"/>
@@ -256,7 +241,6 @@
 			<property name="message" value="Please use AssertJ assertions."/>
 			<property name="ignoreComments" value="true"/>
 		</module>
-
 		<!-- Spring Conventions -->
 		<module name="io.spring.javaformat.checkstyle.check.SpringLambdaCheck">
 			<property name="singleArgumentParentheses" value="false"/>
@@ -264,7 +248,9 @@
 		<module name="io.spring.javaformat.checkstyle.check.SpringCatchCheck"/>
 		<module name="io.spring.javaformat.checkstyle.check.SpringJavadocCheck"/>
 		<module name="io.spring.javaformat.checkstyle.check.SpringJUnit5Check"/>
-
+		<!-- Best Practices -->
+		<!-- <module name="UnusedLocalVariable"/> fix with https://docs.openrewrite.org/recipes/staticanalysis/removeunusedprivatefields#usage -->
+		<!-- <module name="UnusedLocalMethod"/> wait for https://github.com/checkstyle/checkstyle/issues/16375 -->
+		<!-- <module name="VariableDeclarationUsageDistance"/> wait for https://github.com/openrewrite/rewrite-static-analysis/issues/469 -->
 	</module>
-
 </module>

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -79,9 +79,6 @@
 		</module>
 		<module name="com.puppycrawl.tools.checkstyle.checks.coding.OneStatementPerLineCheck"/>
 		<!-- Imports -->
-		<module name="AvoidStarImport"/>
-		<module name="UnusedImports"/>
-		<module name="RedundantImport"/>
 		<module name="com.puppycrawl.tools.checkstyle.checks.imports.ImportOrderCheck">
 			<property name="groups" value="java,javax,*,org.springframework"/>
 			<property name="ordered" value="true"/>

--- a/src/nohttp/checkstyle.xml
+++ b/src/nohttp/checkstyle.xml
@@ -3,7 +3,6 @@
 <module name="Checker">
 	<property name="charset" value="UTF-8"/>
 	<property name="fileExtensions" value=""/>
-
 	<!-- nohttp workaround, see https://github.com/spring-io/nohttp/issues/55 -->
 	<module name="io.spring.nohttp.checkstyle.check.NoHttpCheck">
 		<property name="allowlistFileName" value="${config_loc}/allowlist.lines" default=""/>
@@ -13,4 +12,14 @@
 		<property name="optional" value="true"/>
 	</module>
 	<module name="SuppressWithPlainTextCommentFilter"/>
+	<!-- TreeWalker Checks -->
+	<module name="TreeWalker">
+		<!-- Imports -->
+		<module name="AvoidStarImport"/>
+		<module name="UnusedImports"/>
+		<module name="RedundantImport"/>
+		<!-- Best Practices -->
+		<!-- <module name="UnusedLocalVariable"/> fix https://docs.openrewrite.org/recipes/staticanalysis/removeunusedprivatefields#usage-->
+		<!-- <module name="VariableDeclarationUsageDistance"/> wait for fix https://github.com/openrewrite/rewrite-static-analysis/issues/469-->
+	</module>
 </module>

--- a/src/nohttp/checkstyle.xml
+++ b/src/nohttp/checkstyle.xml
@@ -15,9 +15,9 @@
 	<!-- TreeWalker Checks -->
 	<module name="TreeWalker">
 		<!-- Imports -->
-		<module name="AvoidStarImport"/>
-		<module name="UnusedImports"/>
-		<module name="RedundantImport"/>
+		<!--		<module name="AvoidStarImport"/>-->
+		<!--		<module name="UnusedImports"/>-->
+		<!--		<module name="RedundantImport"/>-->
 		<!-- Best Practices -->
 		<!-- <module name="UnusedLocalVariable"/> fix https://docs.openrewrite.org/recipes/staticanalysis/removeunusedprivatefields#usage-->
 		<!-- <module name="VariableDeclarationUsageDistance"/> wait for fix https://github.com/openrewrite/rewrite-static-analysis/issues/469-->

--- a/src/nohttp/checkstyle.xml
+++ b/src/nohttp/checkstyle.xml
@@ -16,7 +16,7 @@
 	<module name="TreeWalker">
 		<!-- Imports -->
 		<!--		<module name="AvoidStarImport"/>-->
-		<!--		<module name="UnusedImports"/>-->
+		<module name="UnusedImports"/>
 		<!--		<module name="RedundantImport"/>-->
 		<!-- Best Practices -->
 		<!-- <module name="UnusedLocalVariable"/> fix https://docs.openrewrite.org/recipes/staticanalysis/removeunusedprivatefields#usage-->


### PR DESCRIPTION
I saw the rules are not fully aligned. Assuming the minimum approach will be shared, such as avoiding used ballast as already approached.

- Sync checkstyle rules  
- Apply `UnusedImports`  

_PS: This is just a suggestion to serve as a basis for discussion—no need to merge this all at once in a big bang. I can also split it up according to priorities (separation of concerns)._  
