### PR TITLE
remove `UnusedLocalVariable`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,10 +1,16 @@
 root = true
 
-[*.{adoc,bat,groovy,html,java,js,jsp,kt,kts,md,properties,py,rb,sh,sql,svg,txt,xml,xsd}]
+[*]
 charset = utf-8
+end_of_line = lf
+# indent_style = tab todo: verify
+insert_final_newline = true
 
 [*.{groovy,java,kt,kts,xml,xsd}]
 indent_style = tab
 indent_size = 4
-continuation_indent_size = 8
-end_of_line = lf
+ij_continuation_indent_size = 8
+
+[*.java]
+ij_java_class_count_to_use_import_on_demand = 999
+ij_java_names_count_to_use_import_on_demand = 999

--- a/buildSrc/config/checkstyle/checkstyle.xml
+++ b/buildSrc/config/checkstyle/checkstyle.xml
@@ -21,6 +21,9 @@
 		<!-- Modifiers -->
 		<module name="com.puppycrawl.tools.checkstyle.checks.modifier.ModifierOrderCheck"/>
 
+		<!-- Best Practice -->
+		<module name="EmptyStatement"/>
+		<module name="UnusedLocalVariable"/>
+		<module name="VariableDeclarationUsageDistance"/>
 	</module>
-
 </module>

--- a/integration-tests/src/test/java/org/springframework/aot/test/ReflectionInvocationsTests.java
+++ b/integration-tests/src/test/java/org/springframework/aot/test/ReflectionInvocationsTests.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.test.agent.EnabledIfRuntimeHintsAgent;
-import org.springframework.aot.test.agent.RuntimeHintsInvocations;
+import org.springframework.aot.test.agent.RuntimeHintsRecorder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,11 +34,10 @@ class ReflectionInvocationsTests {
 		RuntimeHints hints = new RuntimeHints();
 		hints.reflection().registerType(String.class);
 
-		RuntimeHintsInvocations invocations = org.springframework.aot.test.agent.RuntimeHintsRecorder.record(() -> {
+		assertThat(RuntimeHintsRecorder.record(() -> {
 			SampleReflection sample = new SampleReflection();
-			sample.sample(); // does Method[] methods = String.class.getMethods();
-		});
-		assertThat(invocations).match(hints);
+			sample.sample(); // String.class.getMethods();
+		})).match(hints);
 	}
 
 	@Test
@@ -46,11 +45,11 @@ class ReflectionInvocationsTests {
 		RuntimeHints hints = new RuntimeHints();
 		hints.reflection().registerType(String.class);
 		hints.reflection().registerType(Integer.class);
-		RuntimeHintsInvocations invocations = org.springframework.aot.test.agent.RuntimeHintsRecorder.record(() -> {
+
+		assertThat(RuntimeHintsRecorder.record(() -> {
 			SampleReflection sample = new SampleReflection();
-			sample.multipleCalls(); // does Method[] methods = String.class.getMethods(); methods = Integer.class.getMethods();
-		});
-		assertThat(invocations).match(hints);
+			sample.multipleCalls(); // String.class.getMethods(); Integer.class.getMethods();
+		})).match(hints);
 	}
 
 }

--- a/integration-tests/src/test/java/org/springframework/aot/test/SampleReflection.java
+++ b/integration-tests/src/test/java/org/springframework/aot/test/SampleReflection.java
@@ -16,25 +16,19 @@
 
 package org.springframework.aot.test;
 
-import java.lang.reflect.Method;
-
 /**
  * @author Brian Clozel
  * @since 6.0
  */
 public class SampleReflection {
 
-	@SuppressWarnings("unused")
 	public void sample() {
-		String value = "Sample";
-		Method[] methods = String.class.getMethods();
+		String.class.getMethods();
 	}
 
-	@SuppressWarnings("unused")
 	public void multipleCalls() {
-		String value = "Sample";
-		Method[] methods = String.class.getMethods();
-		methods = Integer.class.getMethods();
+		String.class.getMethods();
+		Integer.class.getMethods();
 	}
 
 }

--- a/spring-beans/src/test/java/org/springframework/beans/factory/config/ServiceLocatorFactoryBeanTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/config/ServiceLocatorFactoryBeanTests.java
@@ -123,16 +123,11 @@ class ServiceLocatorFactoryBeanTests {
 				.addPropertyValue("serviceLocatorInterface", TestServiceLocator2.class)
 				.getBeanDefinition());
 
-		// test string-arg getter with null id
-		TestServiceLocator2 factory = (TestServiceLocator2) bf.getBean("factory");
-
-		@SuppressWarnings("unused")
-		TestService testBean = factory.getTestService(null);
-		// now test with explicit id
-		testBean = factory.getTestService("testService");
-		// now verify failure on bad id
-		assertThatExceptionOfType(NoSuchBeanDefinitionException.class).isThrownBy(() ->
-				factory.getTestService("bogusTestService"));
+		final var factory = (TestServiceLocator2) bf.getBean("factory"); // test string-arg getter
+		factory.getTestService(null); // with null id
+		factory.getTestService("testService"); // test with explicit id
+		assertThatExceptionOfType(NoSuchBeanDefinitionException.class)
+				.isThrownBy(() -> factory.getTestService("bogusTestService")); // verify failure on bad id
 	}
 
 	@Disabled @Test // worked when using an ApplicationContext (see commented), fails when using BeanFactory
@@ -144,14 +139,6 @@ class ServiceLocatorFactoryBeanTests {
 				genericBeanDefinition(ServiceLocatorFactoryBean.class)
 				.addPropertyValue("serviceLocatorInterface", TestServiceLocator3.class)
 				.getBeanDefinition());
-
-//		StaticApplicationContext ctx = new StaticApplicationContext();
-//		ctx.registerPrototype("testService", TestService.class, new MutablePropertyValues());
-//		ctx.registerAlias("testService", "1");
-//		MutablePropertyValues mpv = new MutablePropertyValues();
-//		mpv.addPropertyValue("serviceLocatorInterface", TestServiceLocator3.class);
-//		ctx.registerSingleton("factory", ServiceLocatorFactoryBean.class, mpv);
-//		ctx.refresh();
 
 		TestServiceLocator3 factory = (TestServiceLocator3) bf.getBean("factory");
 		TestService testBean1 = factory.getTestService();
@@ -177,16 +164,6 @@ class ServiceLocatorFactoryBeanTests {
 				.addPropertyValue("serviceLocatorInterface", TestServiceLocator3.class)
 				.addPropertyValue("serviceMappings", "=testService1\n1=testService1\n2=testService2")
 				.getBeanDefinition());
-
-//		StaticApplicationContext ctx = new StaticApplicationContext();
-//		ctx.registerPrototype("testService1", TestService.class, new MutablePropertyValues());
-//		ctx.registerPrototype("testService2", ExtendedTestService.class, new MutablePropertyValues());
-//		MutablePropertyValues mpv = new MutablePropertyValues();
-//		mpv.addPropertyValue("serviceLocatorInterface", TestServiceLocator3.class);
-//		mpv.addPropertyValue("serviceMappings", "=testService1\n1=testService1\n2=testService2");
-//		ctx.registerSingleton("factory", ServiceLocatorFactoryBean.class, mpv);
-//		ctx.refresh();
-
 		TestServiceLocator3 factory = (TestServiceLocator3) bf.getBean("factory");
 		TestService testBean1 = factory.getTestService();
 		TestService testBean2 = factory.getTestService("testService1");
@@ -302,8 +279,6 @@ class ServiceLocatorFactoryBeanTests {
 
 
 	public interface ServiceLocatorInterfaceWithExtraNonCompliantMethod {
-
-		TestService2 getTestService();
 
 		TestService2 getTestService(String serviceName, String defaultNotAllowedParameter);
 	}

--- a/spring-expression/src/test/java/org/springframework/expression/spel/SpelCompilationCoverageTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/SpelCompilationCoverageTests.java
@@ -7145,8 +7145,7 @@ public class SpelCompilationCoverageTests extends AbstractExpressionTests {
 	static class HttpServlet3RequestFactory {
 
 		static Servlet3SecurityContextHolderAwareRequestWrapper getOne() {
-			HttpServlet3RequestFactory outer = new HttpServlet3RequestFactory();
-			return outer.new Servlet3SecurityContextHolderAwareRequestWrapper();
+			return new HttpServlet3RequestFactory().new Servlet3SecurityContextHolderAwareRequestWrapper();
 		}
 
 		// private class Servlet3SecurityContextHolderAwareRequestWrapper extends SecurityContextHolderAwareRequestWrapper

--- a/spring-test/src/test/java/org/springframework/test/web/client/samples/SampleTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/client/samples/SampleTests.java
@@ -70,10 +70,9 @@ public class SampleTests {
 		String responseBody = "{\"name\" : \"Ludwig van Beethoven\", \"someDouble\" : \"1.6035\"}";
 
 		this.mockServer.expect(requestTo("/composers/42")).andExpect(method(HttpMethod.GET))
-			.andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+				.andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
 
-		@SuppressWarnings("unused")
-		Person ludwig = this.restTemplate.getForObject("/composers/{id}", Person.class, 42);
+		this.restTemplate.getForObject("/composers/{id}", Person.class, 42);
 
 		// We are only validating the request. The response is mocked out.
 		// hotel.getId() == 42
@@ -90,8 +89,7 @@ public class SampleTests {
 		this.mockServer.expect(manyTimes(), requestTo("/composers/42")).andExpect(method(HttpMethod.GET))
 				.andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
 
-		@SuppressWarnings("unused")
-		Person ludwig = this.restTemplate.getForObject("/composers/{id}", Person.class, 42);
+		this.restTemplate.getForObject("/composers/{id}", Person.class, 42);
 
 		// We are only validating the request. The response is mocked out.
 		// hotel.getId() == 42
@@ -142,8 +140,7 @@ public class SampleTests {
 		this.mockServer.expect(requestTo("/composers/42")).andExpect(method(HttpMethod.GET))
 			.andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
 
-		@SuppressWarnings("unused")
-		Person ludwig = this.restTemplate.getForObject("/composers/{id}", Person.class, 42);
+		this.restTemplate.getForObject("/composers/{id}", Person.class, 42);
 
 		// hotel.getId() == 42
 		// hotel.getName().equals("Holiday Inn")
@@ -155,24 +152,19 @@ public class SampleTests {
 	public void verify() {
 
 		this.mockServer.expect(requestTo("/number")).andExpect(method(HttpMethod.GET))
-			.andRespond(withSuccess("1", MediaType.TEXT_PLAIN));
+				.andRespond(withSuccess("1", MediaType.TEXT_PLAIN));
 
 		this.mockServer.expect(requestTo("/number")).andExpect(method(HttpMethod.GET))
-			.andRespond(withSuccess("2", MediaType.TEXT_PLAIN));
+				.andRespond(withSuccess("2", MediaType.TEXT_PLAIN));
 
 		this.mockServer.expect(requestTo("/number")).andExpect(method(HttpMethod.GET))
-			.andRespond(withSuccess("4", MediaType.TEXT_PLAIN));
+				.andRespond(withSuccess("4", MediaType.TEXT_PLAIN));
 
 		this.mockServer.expect(requestTo("/number")).andExpect(method(HttpMethod.GET))
-			.andRespond(withSuccess("8", MediaType.TEXT_PLAIN));
+				.andRespond(withSuccess("8", MediaType.TEXT_PLAIN));
 
-		@SuppressWarnings("unused")
-		String result1 = this.restTemplate.getForObject("/number", String.class);
-		// result1 == "1"
-
-		@SuppressWarnings("unused")
-		String result2 = this.restTemplate.getForObject("/number", String.class);
-		// result == "2"
+		assertThat(this.restTemplate.getForObject("/number", String.class)).isEqualTo("1");
+		assertThat(this.restTemplate.getForObject("/number", String.class)).isEqualTo("2");
 
 		try {
 			this.mockServer.verify();
@@ -215,7 +207,7 @@ public class SampleTests {
 
 		@Override
 		public ClientHttpResponse intercept(HttpRequest request, byte[] body,
-				ClientHttpRequestExecution execution) throws IOException {
+											ClientHttpRequestExecution execution) throws IOException {
 
 			ClientHttpResponse response = execution.execute(request, body);
 			byte[] expected = FileCopyUtils.copyToByteArray(this.resource.getInputStream());

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/handler/HandlerMethodMappingTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/handler/HandlerMethodMappingTests.java
@@ -289,7 +289,7 @@ public class HandlerMethodMappingTests {
 
 		this.mapping.setApplicationContext(context);
 		this.mapping.registerMapping(key, beanName, this.method1);
-		HandlerMethod handlerMethod = this.mapping.getHandlerInternal(new MockHttpServletRequest("GET", key));
+		this.mapping.getHandlerInternal(new MockHttpServletRequest("GET", key));
 	}
 
 	@Test

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -265,6 +265,10 @@
 		<module name="io.spring.javaformat.checkstyle.check.SpringJavadocCheck"/>
 		<module name="io.spring.javaformat.checkstyle.check.SpringJUnit5Check"/>
 
+		<!-- Best Practice -->
+		<module name="EmptyStatement"/>
+		<module name="UnusedLocalVariable"/>
+		<!-- <module name="VariableDeclarationUsageDistance"/>--> <!-- wait for https://github.com/openrewrite/rewrite-static-analysis/issues/469 -->
 	</module>
 
 </module>

--- a/src/nohttp/checkstyle.xml
+++ b/src/nohttp/checkstyle.xml
@@ -13,4 +13,14 @@
 		<property name="optional" value="true"/>
 	</module>
 	<module name="SuppressWithPlainTextCommentFilter"/>
+	<!-- TreeWalker Checks -->
+	<module name="TreeWalker">
+		<!-- Imports -->
+		<module name="AvoidStarImport"/>
+		<module name="RedundantImport"/>
+		<!-- ignored as samples need some flexibility https://github.com/spring-projects/spring-framework/pull/34477 -->
+		<!-- <module name="UnusedImports"/>-->
+		<!-- <module name="UnusedLocalVariable"/>-->
+		<!-- <module name="VariableDeclarationUsageDistance"/>-->
+	</module>
 </module>


### PR DESCRIPTION
Encounter unused code with help of CS module `UnusedLocalVariable`.  

Wondering why the CS config needs to be duplicated. The rules seem not to be applied, some of the findings only emerge after adding the corresponding module again.  
