### PR TITLE
Adding Null Check for validateIfNoneMatch() method

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/context/request/ServletWebRequest.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/ServletWebRequest.java
@@ -236,6 +236,9 @@ public class ServletWebRequest extends ServletRequestAttributes implements Nativ
 
 	private boolean validateIfNoneMatch(@Nullable String etag) {
 		Enumeration<String> ifNoneMatchHeaders = getRequest().getHeaders(HttpHeaders.IF_NONE_MATCH);
+		if(ifNoneMatchHeaders==null){
+			return false;
+		}
 		if (!ifNoneMatchHeaders.hasMoreElements()) {
 			return false;
 		}


### PR DESCRIPTION
Basic Null Check to avoid Null pointer exception if the header is not sent