### PR TITLE
Missing Partitioned cookie support in reactive HTTP clients

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpResponse.java
@@ -134,6 +134,7 @@ class ReactorClientHttpResponse implements ClientHttpResponse {
 								.secure(cookie.isSecure())
 								.httpOnly(cookie.isHttpOnly())
 								.sameSite(getSameSite(cookie))
+								.partitioned(getPartitioned(cookie))
 								.build()));
 		return CollectionUtils.unmodifiableMultiValueMap(result);
 	}
@@ -143,6 +144,13 @@ class ReactorClientHttpResponse implements ClientHttpResponse {
 			return defaultCookie.sameSite().name();
 		}
 		return null;
+	}
+
+	private static boolean getPartitioned(Cookie cookie) {
+		if (cookie instanceof DefaultCookie defaultCookie) {
+			return defaultCookie.isPartitioned();
+		}
+		return false;
 	}
 
 	/**

--- a/spring-web/src/test/java/org/springframework/http/client/reactive/ReactorClientHttpResponseTest.java
+++ b/spring-web/src/test/java/org/springframework/http/client/reactive/ReactorClientHttpResponseTest.java
@@ -1,0 +1,54 @@
+package org.springframework.http.client.reactive;
+
+import io.netty.buffer.AdaptiveByteBufAllocator;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.cookie.Cookie;
+import io.netty.handler.codec.http.cookie.DefaultCookie;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.ResponseCookie;
+import reactor.netty.Connection;
+import reactor.netty.NettyOutbound;
+import reactor.netty.http.client.HttpClientResponse;
+
+import java.util.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+class ReactorClientHttpResponseTest {
+	private final HttpClientResponse mockResponse = mock();
+
+	private final DefaultHttpHeaders httpHeaders = mock();
+
+	private final Connection connection = mock();
+
+	private final NettyOutbound outbound = mock();
+
+	private ReactorClientHttpResponse reactorClientHttpResponse;
+
+
+	@BeforeEach
+	void configureMocks() {
+		given(mockResponse.responseHeaders()).willReturn(httpHeaders);
+		given(connection.outbound()).willReturn(outbound);
+		given(outbound.alloc()).willReturn(new AdaptiveByteBufAllocator());
+		reactorClientHttpResponse = new ReactorClientHttpResponse(mockResponse, connection);
+	}
+
+	@Test
+	void defaultCookies() {
+		Map<CharSequence, Set<Cookie>> mockCookieMap = new HashMap<>();
+		DefaultCookie cookie = new DefaultCookie("foo", "bar");
+		cookie.setPartitioned(true);
+		mockCookieMap.put("foo", Set.of(cookie));
+		given(mockResponse.cookies()).willReturn(mockCookieMap);
+
+		Assertions.assertTrue(reactorClientHttpResponse.getCookies().size() == 1 &&
+				reactorClientHttpResponse.getCookies().containsKey("foo"));
+		ResponseCookie foo = reactorClientHttpResponse.getCookies().getFirst("foo");
+		assertThat(foo.isPartitioned()).isSameAs(cookie.isPartitioned());
+	}
+}


### PR DESCRIPTION
While using org.springframework.cloud.gateway.test.BaseWebClientTests#testClient to check cookies, I found that the "partitioned" attribute was false, whereas the actual response showed it as true.
This commit aims to fix the "partitioned" attribute in DefaultCookie from ReactorClientHttpResponse.getCookies()

As this is my first contribution, I would appreciate any feedback.