### PR TITLE
Ensure that ConversionService.canConvert(Enum) no longer throws an exception

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/support/ConversionUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/ConversionUtils.java
@@ -22,7 +22,6 @@ import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.convert.converter.GenericConverter;
-import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
 /**
@@ -71,12 +70,17 @@ abstract class ConversionUtils {
 		return false;
 	}
 
-	public static Class<?> getEnumType(Class<?> targetType) {
+	/**
+	 * Resolve the enum type for the supplied target type.
+	 * @param targetType the target type for which to resolve the enum type
+	 * @return the resolved enum type, or {@code null} if the supplied target type
+	 * does not refer to an enum
+	 */
+	public static @Nullable Class<?> resolveEnumType(Class<?> targetType) {
 		Class<?> enumType = targetType;
 		while (enumType != null && !enumType.isEnum()) {
 			enumType = enumType.getSuperclass();
 		}
-		Assert.notNull(enumType, () -> "The target type " + targetType.getName() + " does not refer to an enum");
 		return enumType;
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/convert/support/IntegerToEnumConverterFactory.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/IntegerToEnumConverterFactory.java
@@ -31,7 +31,11 @@ final class IntegerToEnumConverterFactory implements ConverterFactory<Integer, E
 
 	@Override
 	public <T extends Enum> Converter<Integer, T> getConverter(Class<T> targetType) {
-		return new IntegerToEnum(ConversionUtils.getEnumType(targetType));
+		Class<?> enumType = ConversionUtils.getEnumType(targetType);
+		if (enumType == null) {
+			return new ConversionUtils.NonConvertableToEnum(targetType);
+		}
+		return new IntegerToEnum(enumType);
 	}
 
 

--- a/spring-core/src/main/java/org/springframework/core/convert/support/IntegerToEnumConverterFactory.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/IntegerToEnumConverterFactory.java
@@ -18,8 +18,11 @@ package org.springframework.core.convert.support;
 
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.ConditionalConverter;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.converter.ConverterFactory;
+import org.springframework.util.Assert;
 
 /**
  * Converts from an Integer to a {@link java.lang.Enum} by calling {@link Class#getEnumConstants()}.
@@ -29,11 +32,18 @@ import org.springframework.core.convert.converter.ConverterFactory;
  * @since 4.3
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-final class IntegerToEnumConverterFactory implements ConverterFactory<Integer, Enum> {
+final class IntegerToEnumConverterFactory implements ConverterFactory<Integer, Enum>, ConditionalConverter {
 
 	@Override
 	public <T extends Enum> Converter<Integer, @Nullable T> getConverter(Class<T> targetType) {
-		return new IntegerToEnum(ConversionUtils.getEnumType(targetType));
+		Class<?> enumType = ConversionUtils.resolveEnumType(targetType);
+		Assert.notNull(enumType, () -> "The target type " + targetType.getName() + " does not refer to an enum");
+		return new IntegerToEnum(enumType);
+	}
+
+	@Override
+	public boolean matches(TypeDescriptor sourceType, TypeDescriptor targetType) {
+		return (ConversionUtils.resolveEnumType(targetType.getType()) != null);
 	}
 
 

--- a/spring-core/src/main/java/org/springframework/core/convert/support/StringToEnumConverterFactory.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/StringToEnumConverterFactory.java
@@ -33,9 +33,12 @@ final class StringToEnumConverterFactory implements ConverterFactory<String, Enu
 
 	@Override
 	public <T extends Enum> Converter<String, T> getConverter(Class<T> targetType) {
-		return new StringToEnum(ConversionUtils.getEnumType(targetType));
+		Class<?> enumType = ConversionUtils.getEnumType(targetType);
+		if (enumType == null) {
+			return new ConversionUtils.NonConvertableToEnum(targetType);
+		}
+		return new StringToEnum(enumType);
 	}
-
 
 	private static class StringToEnum<T extends Enum> implements Converter<String, T> {
 

--- a/spring-core/src/main/java/org/springframework/core/convert/support/StringToEnumConverterFactory.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/StringToEnumConverterFactory.java
@@ -18,8 +18,11 @@ package org.springframework.core.convert.support;
 
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.core.convert.converter.ConditionalConverter;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.converter.ConverterFactory;
+import org.springframework.util.Assert;
 
 /**
  * Converts from a String to a {@link java.lang.Enum} by calling {@link Enum#valueOf(Class, String)}.
@@ -29,11 +32,18 @@ import org.springframework.core.convert.converter.ConverterFactory;
  * @since 3.0
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-final class StringToEnumConverterFactory implements ConverterFactory<String, Enum> {
+final class StringToEnumConverterFactory implements ConverterFactory<String, Enum>, ConditionalConverter {
 
 	@Override
 	public <T extends Enum> Converter<String, @Nullable T> getConverter(Class<T> targetType) {
-		return new StringToEnum(ConversionUtils.getEnumType(targetType));
+		Class<?> enumType = ConversionUtils.resolveEnumType(targetType);
+		Assert.notNull(enumType, () -> "The target type " + targetType.getName() + " does not refer to an enum");
+		return new StringToEnum(enumType);
+	}
+
+	@Override
+	public boolean matches(TypeDescriptor sourceType, TypeDescriptor targetType) {
+		return (ConversionUtils.resolveEnumType(targetType.getType()) != null);
 	}
 
 

--- a/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
@@ -504,6 +504,16 @@ class GenericConversionServiceTests {
 	}
 
 	@Test
+	void toEnumCanConvertShouldNotThrowException() {
+		conversionService.addConverterFactory(new IntegerToEnumConverterFactory());
+		conversionService.addConverterFactory(new StringToEnumConverterFactory());
+		assertThat(conversionService.canConvert(Integer.class, Enum.class)).isFalse();
+		assertThat(conversionService.canConvert(Integer.class, MyEnum.class)).isTrue();
+		assertThat(conversionService.canConvert(String.class, Enum.class)).isFalse();
+		assertThat(conversionService.canConvert(String.class, MyEnum.class)).isTrue();
+	}
+
+	@Test
 	void convertNullAnnotatedStringToString() throws Exception {
 		String source = null;
 		TypeDescriptor sourceType = new TypeDescriptor(getClass().getField("annotatedString"));

--- a/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
@@ -503,6 +503,20 @@ class GenericConversionServiceTests {
 		assertThat(conversionService.convert("base1", MyEnum.class)).isEqualTo(MyEnum.A);
 	}
 
+	@Test  // gh-34532
+	void canConvertToEnumDoesNotThrowForNonEnumTargetType() {
+		conversionService.addConverterFactory(new StringToEnumConverterFactory());
+		conversionService.addConverterFactory(new IntegerToEnumConverterFactory());
+
+		assertThat(conversionService.canConvert(String.class, Enum.class)).isFalse();
+		assertThat(conversionService.canConvert(Integer.class, Enum.class)).isFalse();
+
+		assertThat(conversionService.canConvert(String.class, MyEnum.class)).isTrue();
+		assertThat(conversionService.canConvert(Integer.class, MyEnum.class)).isTrue();
+		assertThat(conversionService.convert("A", MyEnum.class)).isEqualTo(MyEnum.A);
+		assertThat(conversionService.convert(0, MyEnum.class)).isEqualTo(MyEnum.A);
+	}
+
 	@Test
 	void convertNullAnnotatedStringToString() throws Exception {
 		String source = null;


### PR DESCRIPTION
In my project, I use the following code to find an appropriate method to execute for a given class. It throws an `IllegalArgumentException: The target type java.lang.Enum does not refer to an enum` when there is a more appropriate “method”: `asString(CharSequence)`. 

```java
public class MyTest {

    public static void main(String[] args) throws AccessException {
        EvaluationContext evaluationContext = SimpleEvaluationContext.forReadOnlyDataBinding().build();
        ReflectiveMethodResolver methodResolver = new ReflectiveMethodResolver();
        MethodExecutor asString = methodResolver.resolve(evaluationContext, MyTest.class, "asString",
                Collections.singletonList(TypeDescriptor.valueOf(String.class)));
        TypedValue result = asString.execute(evaluationContext, MyTest.class, "value");
        System.out.println(result);
    }

    public static String asString(Enum<?> left) {
        return left.name();
    }

    public static String asString(CharSequence left) {
        return left.toString();
    }
}

```

After doing some research I realized that the root cause was that `StringToEnumConverterFactory.getConverter(Enum.class)` threw an exception when it couldn't convert and resolve the concrete `Enum`. This directly causes `ConversionService.canConvert(String.class,Enum.class)` to throw an exception. I don't think the method `canConvert()` should throw an exception, it returns `true` if it can convert and `false` if it can't. That's what this method is for, to avoid throwing an exception when calling the `convert` method directly.

So I've modified `StringToEnumConverterFactory` and `IntegerToEnumConverterFactory` a little and hopefully this PR will be accepted.