### PR TITLE
Allow `ContentResultMatchersDsl` matchers for supertypes of the checked type

### DIFF
--- a/spring-test/src/main/kotlin/org/springframework/test/web/servlet/result/ContentResultMatchersDsl.kt
+++ b/spring-test/src/main/kotlin/org/springframework/test/web/servlet/result/ContentResultMatchersDsl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ class ContentResultMatchersDsl internal constructor (private val actions: Result
 	/**
 	 * @see ContentResultMatchers.string
 	 */
-	fun string(matcher: Matcher<String>) {
+	fun string(matcher: Matcher<in String>) {
 		actions.andExpect(matchers.string(matcher))
 	}
 
@@ -99,14 +99,14 @@ class ContentResultMatchersDsl internal constructor (private val actions: Result
 	/**
 	 * @see ContentResultMatchers.node
 	 */
-	fun node(matcher: Matcher<Node>) {
+	fun node(matcher: Matcher<in Node>) {
 		actions.andExpect(matchers.node(matcher))
 	}
 
 	/**
 	 * @see ContentResultMatchers.source
 	 */
-	fun source(matcher: Matcher<Source>) {
+	fun source(matcher: Matcher<in Source>) {
 		actions.andExpect(matchers.source(matcher))
 	}
 

--- a/spring-test/src/test/kotlin/org/springframework/test/web/servlet/result/ContentResultMatchersDslTests.kt
+++ b/spring-test/src/test/kotlin/org/springframework/test/web/servlet/result/ContentResultMatchersDslTests.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.web.servlet.result
+
+import io.mockk.mockk
+import org.hamcrest.text.CharSequenceLength.*
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import org.springframework.test.web.servlet.*
+import org.springframework.web.servlet.FlashMap
+import org.springframework.web.servlet.ModelAndView
+import java.nio.charset.StandardCharsets
+
+/**
+ * Tests for [ContentResultMatchersDsl].
+ *
+ * @author Dmitry Sulman
+ */
+class ContentResultMatchersDslTests {
+
+	val mockMvc = mockk<MockMvc>()
+
+	@Test
+	fun `ContentResultMatchersDsl#string accepts Matcher parameterized with String supertype`() {
+		getStubResultActionsDsl("some string")
+			.andExpect { content { string(hasLength(11)) } }
+	}
+
+	private fun getStubResultActionsDsl(content: String): ResultActionsDsl {
+		val resultActions = object : ResultActions {
+			override fun andExpect(matcher: ResultMatcher): ResultActions {
+				matcher.match(getStubMvcResult(content))
+				return this
+			}
+
+			override fun andDo(handler: ResultHandler): ResultActions {
+				throw UnsupportedOperationException()
+			}
+
+			override fun andReturn(): MvcResult {
+				throw UnsupportedOperationException()
+			}
+
+		}
+		return ResultActionsDsl(resultActions, mockMvc)
+	}
+
+	private fun getStubMvcResult(content: String): StubMvcResult {
+		val response = MockHttpServletResponse()
+		response.outputStream.write(content.toByteArray(StandardCharsets.UTF_8))
+		return StubMvcResult(MockHttpServletRequest(), Any(), emptyArray(),  Exception(), ModelAndView(), FlashMap(), response)
+	}
+}


### PR DESCRIPTION
This PR allows accepting `Matcher<CharSequence>` for  [ContentResultMatchersDsl#string](https://github.com/spring-projects/spring-framework/blob/main/spring-test/src/main/kotlin/org/springframework/test/web/servlet/result/ContentResultMatchersDsl.kt#L74).

**Before:**
```kotlin
fun string(matcher: Matcher<String>)
```

**After:**
```kotlin
fun string(matcher: Matcher<in String>)
```


Fixes spring-projectsgh-34494