### PR TITLE
Improve Javadoc for @ExceptionHandler

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/ExceptionHandler.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/ExceptionHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,6 +89,8 @@ import org.springframework.core.annotation.AliasFor;
  * (Servlet-only) to set response headers and content. The ResponseEntity body
  * will be converted and written to the response stream using
  * {@linkplain org.springframework.http.converter.HttpMessageConverter message converters}.
+ * <li>A {@link org.springframework.http.ProblemDetail} or {@link org.springframework.web.ErrorResponse}
+ * object to render an RFC 9457 error response with details in the body.
  * <li>{@code void} if the method handles the response itself (by
  * writing the response content directly, declaring an argument of type
  * {@link jakarta.servlet.ServletResponse} / {@link jakarta.servlet.http.HttpServletResponse}


### PR DESCRIPTION
This commit adds `ProblemDetail` and `ErrorResponse` to the list of supported return types for `@ExceptionHandler` methods.