### PR TITLE
Refactor ContentDisposition type check

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
+++ b/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
@@ -99,7 +99,7 @@ public final class ContentDisposition {
 	 * @since 5.3
 	 */
 	public boolean isAttachment() {
-		return (this.type != null && this.type.equalsIgnoreCase("attachment"));
+		return isDepositionType("attachment");
 	}
 
 	/**
@@ -107,7 +107,7 @@ public final class ContentDisposition {
 	 * @since 5.3
 	 */
 	public boolean isFormData() {
-		return (this.type != null && this.type.equalsIgnoreCase("form-data"));
+		return isDepositionType("form-data");
 	}
 
 	/**
@@ -115,7 +115,7 @@ public final class ContentDisposition {
 	 * @since 5.3
 	 */
 	public boolean isInline() {
-		return (this.type != null && this.type.equalsIgnoreCase("inline"));
+		return isDepositionType("inline");
 	}
 
 	/**
@@ -553,6 +553,10 @@ public final class ContentDisposition {
 
 	private static char hexDigit(int b) {
 		return Character.toUpperCase(Character.forDigit(b & 0xF, 16));
+	}
+
+	private boolean isDepositionType(String type) {
+		return this.type != null && this.type.equalsIgnoreCase(type);
 	}
 
 

--- a/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
+++ b/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
@@ -99,7 +99,7 @@ public final class ContentDisposition {
 	 * @since 5.3
 	 */
 	public boolean isAttachment() {
-		return isDepositionType("attachment");
+		return isDispositionType("attachment");
 	}
 
 	/**
@@ -107,7 +107,7 @@ public final class ContentDisposition {
 	 * @since 5.3
 	 */
 	public boolean isFormData() {
-		return isDepositionType("form-data");
+		return isDispositionType("form-data");
 	}
 
 	/**
@@ -115,7 +115,7 @@ public final class ContentDisposition {
 	 * @since 5.3
 	 */
 	public boolean isInline() {
-		return isDepositionType("inline");
+		return isDispositionType("inline");
 	}
 
 	/**
@@ -555,7 +555,7 @@ public final class ContentDisposition {
 		return Character.toUpperCase(Character.forDigit(b & 0xF, 16));
 	}
 
-	private boolean isDepositionType(String type) {
+	private boolean isDispositionType(String type) {
 		return this.type != null && this.type.equalsIgnoreCase(type);
 	}
 

--- a/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
+++ b/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
@@ -310,4 +310,34 @@ class ContentDispositionTests {
 				.isEqualTo(filename);
 	}
 
+	@Test
+	void isAttachment(){
+		ContentDisposition attachment = ContentDisposition.attachment().build();
+		ContentDisposition inline = ContentDisposition.inline().build();
+		ContentDisposition formData = ContentDisposition.formData().build();
+		assertThat(attachment.isAttachment()).isTrue();
+		assertThat(inline.isAttachment()).isFalse();
+		assertThat(formData.isAttachment()).isFalse();
+	}
+
+	@Test
+	void isInline(){
+		ContentDisposition attachment = ContentDisposition.attachment().build();
+		ContentDisposition inline = ContentDisposition.inline().build();
+		ContentDisposition formData = ContentDisposition.formData().build();
+		assertThat(attachment.isInline()).isFalse();
+		assertThat(inline.isInline()).isTrue();
+		assertThat(formData.isInline()).isFalse();
+	}
+
+	@Test
+	void isFormData(){
+		ContentDisposition attachment = ContentDisposition.attachment().build();
+		ContentDisposition inline = ContentDisposition.inline().build();
+		ContentDisposition formData = ContentDisposition.formData().build();
+		assertThat(attachment.isFormData()).isFalse();
+		assertThat(inline.isFormData()).isFalse();
+		assertThat(formData.isFormData()).isTrue();
+	}
+
 }


### PR DESCRIPTION
I noticed that there was duplicated logic when checking the definitions of DispositionType in ContentDisposition.java, so I extracted this logic into a private method.

After that, I realized there weren't any tests to verify this code was working properly, so I went ahead and added test code for it.
```
    public boolean isAttachment() {
	return (this.type != null && this.type.equalsIgnoreCase("attachment"));
    }
    ...
```
I've modified the existing code to follow the format shown below.
```
    public boolean isAttachment() {
	return isDispositionType("attachment");
    }

    private boolean isDispositionType(String type) {
	return this.type != null && this.type.equalsIgnoreCase(type);
    }

```