### PR TITLE
`FormHttpMessageConverter` should throw `HttpMessageNotReadableException` when the http form data is invalid

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/FormHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/FormHttpMessageConverter.java
@@ -353,12 +353,22 @@ public class FormHttpMessageConverter implements HttpMessageConverter<MultiValue
 		for (String pair : pairs) {
 			int idx = pair.indexOf('=');
 			if (idx == -1) {
-				result.add(URLDecoder.decode(pair, charset), null);
+				try {
+					result.add(URLDecoder.decode(pair, charset), null);
+				}
+				catch (IllegalArgumentException ex) {
+					throw new HttpMessageNotReadableException("Could not decode HTTP form payload", ex, inputMessage);
+				}
 			}
 			else {
-				String name = URLDecoder.decode(pair.substring(0, idx), charset);
-				String value = URLDecoder.decode(pair.substring(idx + 1), charset);
-				result.add(name, value);
+				try {
+					String name = URLDecoder.decode(pair.substring(0, idx), charset);
+					String value = URLDecoder.decode(pair.substring(idx + 1), charset);
+					result.add(name, value);
+				}
+				catch (IllegalArgumentException ex) {
+					throw new HttpMessageNotReadableException("Could not decode HTTP form payload", ex, inputMessage);
+				}
 			}
 		}
 		return result;


### PR DESCRIPTION
`HttpMessageNotReadableException` is a more specific exception that will allow users to better target and react to invalid request payloads.

@sdeleuze here is the change per our conversation per #34584 