### PR TITLE
Add caching headers to unmodified static resources

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -538,6 +538,9 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 		// Supported methods and required session
 		checkRequest(request);
 
+		// Apply cache settings, if any
+		prepareResponse(response);
+
 		// Header phase
 		String eTagValue = (this.getEtagGenerator() != null) ? this.getEtagGenerator().apply(resource) : null;
 		long lastModified = (this.isUseLastModified()) ? resource.lastModified() : -1;
@@ -545,9 +548,6 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 			logger.trace("Resource not modified");
 			return;
 		}
-
-		// Apply cache settings, if any
-		prepareResponse(response);
 
 		// Check the media type for the resource
 		MediaType mediaType = getMediaType(request, resource);

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandlerTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -465,11 +465,13 @@ class ResourceHttpRequestHandlerTests {
 
 		@Test
 		void shouldRespondWithNotModifiedWhenModifiedSince() throws Exception {
+			this.handler.setCacheSeconds(3600);
 			this.handler.afterPropertiesSet();
 			this.request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "foo.css");
 			this.request.addHeader("If-Modified-Since", resourceLastModified("test/foo.css"));
 			this.handler.handleRequest(this.request, this.response);
 			assertThat(this.response.getStatus()).isEqualTo(HttpServletResponse.SC_NOT_MODIFIED);
+			assertThat(this.response.getHeader("Cache-Control")).isEqualTo("max-age=3600");
 		}
 
 		@Test
@@ -484,12 +486,14 @@ class ResourceHttpRequestHandlerTests {
 
 		@Test
 		void shouldRespondWithNotModifiedWhenEtag() throws Exception {
+			this.handler.setCacheSeconds(3600);
 			this.handler.setEtagGenerator(resource -> "testEtag");
 			this.handler.afterPropertiesSet();
 			this.request.setAttribute(HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE, "foo.css");
 			this.request.addHeader("If-None-Match", "\"testEtag\"");
 			this.handler.handleRequest(this.request, this.response);
 			assertThat(this.response.getStatus()).isEqualTo(HttpServletResponse.SC_NOT_MODIFIED);
+			assertThat(this.response.getHeader("Cache-Control")).isEqualTo("max-age=3600");
 		}
 
 		@Test


### PR DESCRIPTION
I was playing around with a CDN and noticed some interesting behavior. It was caching using the original Cache-Control max-age on the original 200, but when a refresh and 304 was returned by spring, the Cache-Control was missing, so the caching proxy used its default max-age (which was longer than my original max-age). I found this https://stackoverflow.com/questions/1587667/should-http-304-not-modified-responses-contain-cache-control-headers which pointed me at https://www.rfc-editor.org/rfc/rfc7232#section-4.1 which states:

> The server generating a 304 response MUST generate any of the following header fields that would have been sent in a 200 (OK) response to the same request: Cache-Control, Content-Location, Date, ETag, Expires, and Vary.