### PR TITLE
Update deprecated Gradle task creation

### DIFF
--- a/gradle/ide.gradle
+++ b/gradle/ide.gradle
@@ -98,7 +98,7 @@ if (project.name == "spring-oxm") {
 }
 
 // Include project specific settings
-task eclipseSettings(type: Copy) {
+tasks.register('eclipseSettings', Copy) {
 	from rootProject.files(
 		'src/eclipse/org.eclipse.core.resources.prefs',
 		'src/eclipse/org.eclipse.jdt.core.prefs',
@@ -107,7 +107,7 @@ task eclipseSettings(type: Copy) {
 	outputs.upToDateWhen { false }
 }
 
-task cleanEclipseSettings(type: Delete) {
+tasks.register('cleanEclipseSettings', Delete) {
 	delete project.file('.settings/org.eclipse.core.resources.prefs')
 	delete project.file('.settings/org.eclipse.jdt.core.prefs')
 	delete project.file('.settings/org.eclipse.jdt.ui.prefs')

--- a/gradle/spring-module.gradle
+++ b/gradle/spring-module.gradle
@@ -87,14 +87,15 @@ javadoc {
 	logging.captureStandardOutput LogLevel.INFO  // suppress "## warnings" message
 }
 
-task sourcesJar(type: Jar, dependsOn: classes) {
+tasks.register('sourcesJar', Jar) {
+	dependsOn classes
 	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 	archiveClassifier.set("sources")
 	from sourceSets.main.allSource
 	// Don't include or exclude anything explicitly by default. See SPR-12085.
 }
 
-task javadocJar(type: Jar) {
+tasks.register('javadocJar', Jar) {
 	archiveClassifier.set("javadoc")
 	from javadoc
 }

--- a/spring-core/spring-core.gradle
+++ b/spring-core/spring-core.gradle
@@ -25,40 +25,40 @@ configurations {
 	graalvm
 }
 
-task javapoetRepackJar(type: ShadowJar) {
+tasks.register('javapoetRepackJar', ShadowJar) {
 	archiveBaseName = 'spring-javapoet-repack'
 	archiveVersion = javapoetVersion
 	configurations = [project.configurations.javapoet]
 	relocate('com.squareup.javapoet', 'org.springframework.javapoet')
 }
 
-task javapoetSource(type: ShadowSource) {
+tasks.register('javapoetSource', ShadowSource) {
 	configurations = [project.configurations.javapoet]
 	relocate('com.squareup.javapoet', 'org.springframework.javapoet')
 	outputDirectory = file("build/shadow-source/javapoet")
 }
 
-task javapoetSourceJar(type: Jar) {
+tasks.register('javapoetSourceJar', Jar) {
 	archiveBaseName = 'spring-javapoet-repack'
 	archiveVersion = javapoetVersion
 	archiveClassifier = 'sources'
 	from javapoetSource
 }
 
-task objenesisRepackJar(type: ShadowJar) {
+tasks.register('objenesisRepackJar', ShadowJar) {
 	archiveBaseName = 'spring-objenesis-repack'
 	archiveVersion = objenesisVersion
 	configurations = [project.configurations.objenesis]
 	relocate('org.objenesis', 'org.springframework.objenesis')
 }
 
-task objenesisSource(type: ShadowSource) {
+tasks.register('objenesisSource', ShadowSource) {
 	configurations = [project.configurations.objenesis]
 	relocate('org.objenesis', 'org.springframework.objenesis')
 	outputDirectory = file("build/shadow-source/objenesis")
 }
 
-task objenesisSourceJar(type: Jar) {
+tasks.register('objenesisSourceJar', Jar) {
 	archiveBaseName = 'spring-objenesis-repack'
 	archiveVersion = objenesisVersion
 	archiveClassifier = 'sources'


### PR DESCRIPTION
Gradle `Project.task` methods [are deprecated](https://docs.gradle.org/current/userguide/upgrading_version_8.html#source_level_deprecation_of_project_task_methods) in favor of [tasks.register](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/TaskContainer.html#register(java.lang.String)) methods.

This PR replaces all occurrences of deprecated methods in `build.gradle` files.