### PR TITLE
Enhance aspect to support superclass aspects

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJAdviceParameterNameDiscoverer.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJAdviceParameterNameDiscoverer.java
@@ -48,11 +48,11 @@ import org.springframework.util.StringUtils;
  * <h3>Algorithm Details</h3>
  * <p>This class interprets arguments in the following way:
  * <ol>
- * <li>If the first parameter of the method is of type {@link JoinPoint}
+ * <li>If the parameter of the method is of type {@link JoinPoint}
  * or {@link ProceedingJoinPoint}, it is assumed to be for passing
  * {@code thisJoinPoint} to the advice, and the parameter name will
  * be assigned the value {@code "thisJoinPoint"}.</li>
- * <li>If the first parameter of the method is of type
+ * <li>If the parameter of the method is of type
  * {@code JoinPoint.StaticPart}, it is assumed to be for passing
  * {@code "thisJoinPointStaticPart"} to the advice, and the parameter name
  * will be assigned the value {@code "thisJoinPointStaticPart"}.</li>
@@ -115,6 +115,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Adrian Colyer
  * @author Juergen Hoeller
+ * @author Joshua Chen
  * @since 2.0
  */
 public class AspectJAdviceParameterNameDiscoverer implements ParameterNameDiscoverer {
@@ -308,22 +309,29 @@ public class AspectJAdviceParameterNameDiscoverer implements ParameterNameDiscov
 	}
 
 	/**
-	 * If the first parameter is of type JoinPoint or ProceedingJoinPoint, bind "thisJoinPoint" as
+	 * If the parameter is of type JoinPoint or ProceedingJoinPoint, bind "thisJoinPoint" as
 	 * parameter name and return true, else return false.
 	 */
 	private boolean maybeBindThisJoinPoint() {
-		if ((this.argumentTypes[0] == JoinPoint.class) || (this.argumentTypes[0] == ProceedingJoinPoint.class)) {
-			bindParameterName(0, THIS_JOIN_POINT);
-			return true;
+		for (int i = 0; i < this.argumentTypes.length; i++) {
+			if (isUnbound(i) && (this.argumentTypes[i] == JoinPoint.class || this.argumentTypes[i] == ProceedingJoinPoint.class)) {
+				bindParameterName(i, THIS_JOIN_POINT);
+				return true;
+			}
 		}
-		else {
-			return false;
-		}
+		return false;
 	}
 
+	/**
+	 * If the parameter is of type JoinPoint.StaticPart, bind "thisJoinPointStaticPart" as
+	 * parameter name.
+	 */
 	private void maybeBindThisJoinPointStaticPart() {
-		if (this.argumentTypes[0] == JoinPoint.StaticPart.class) {
-			bindParameterName(0, THIS_JOIN_POINT_STATIC_PART);
+		for (int i = 0; i < this.argumentTypes.length; i++) {
+			if (isUnbound(i) && this.argumentTypes[i] == JoinPoint.StaticPart.class) {
+				bindParameterName(i, THIS_JOIN_POINT_STATIC_PART);
+				return;
+			}
 		}
 	}
 

--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/annotation/AbstractAspectJAdvisorFactory.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/annotation/AbstractAspectJAdvisorFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ import org.springframework.lang.Nullable;
  * @author Adrian Colyer
  * @author Juergen Hoeller
  * @author Sam Brannen
+ * @author Joshua Chen
  * @since 2.0
  */
 public abstract class AbstractAspectJAdvisorFactory implements AspectJAdvisorFactory {
@@ -93,6 +94,17 @@ public abstract class AbstractAspectJAdvisorFactory implements AspectJAdvisorFac
 	@Override
 	public void validate(Class<?> aspectClass) throws AopConfigException {
 		AjType<?> ajType = AjTypeSystem.getAjType(aspectClass);
+		if (aspectClass.getSuperclass() != null) {
+			Class<?> currSupperClass = aspectClass;
+			while (currSupperClass != Object.class) {
+				AjType<?> ajTypeToCheck = AjTypeSystem.getAjType(currSupperClass);
+				if (ajTypeToCheck.isAspect()) {
+					ajType = ajTypeToCheck;
+					break;
+				}
+				currSupperClass = currSupperClass.getSuperclass();
+			}
+		}
 		if (!ajType.isAspect()) {
 			throw new NotAnAtAspectException(aspectClass);
 		}

--- a/spring-aop/src/test/java/org/springframework/aop/aspectj/AbstractAspectJAdviceTests.java
+++ b/spring-aop/src/test/java/org/springframework/aop/aspectj/AbstractAspectJAdviceTests.java
@@ -45,31 +45,31 @@ class AbstractAspectJAdviceTests {
 	@Test
 	void setArgumentNamesFromStringArray_withJoinPointAsFirstParameter() {
 		AbstractAspectJAdvice advice = getAspectJAdvice("methodWithJoinPointAsFirstParameter");
-		assertThat(advice).satisfies(hasArgumentNames("THIS_JOIN_POINT", "arg1", "arg2"));
+		assertThat(advice).satisfies(hasArgumentNames("thisJoinPoint", "arg1", "arg2"));
 	}
 
 	@Test
 	void setArgumentNamesFromStringArray_withJoinPointAsLastParameter() {
 		AbstractAspectJAdvice advice = getAspectJAdvice("methodWithJoinPointAsLastParameter");
-		assertThat(advice).satisfies(hasArgumentNames("arg1", "arg2", "THIS_JOIN_POINT"));
+		assertThat(advice).satisfies(hasArgumentNames("arg1", "arg2", "thisJoinPoint"));
 	}
 
 	@Test
 	void setArgumentNamesFromStringArray_withJoinPointAsMiddleParameter() {
 		AbstractAspectJAdvice advice = getAspectJAdvice("methodWithJoinPointAsMiddleParameter");
-		assertThat(advice).satisfies(hasArgumentNames("arg1", "THIS_JOIN_POINT", "arg2"));
+		assertThat(advice).satisfies(hasArgumentNames("arg1", "thisJoinPoint", "arg2"));
 	}
 
 	@Test
 	void setArgumentNamesFromStringArray_withProceedingJoinPoint() {
 		AbstractAspectJAdvice advice = getAspectJAdvice("methodWithProceedingJoinPoint");
-		assertThat(advice).satisfies(hasArgumentNames("THIS_JOIN_POINT", "arg1", "arg2"));
+		assertThat(advice).satisfies(hasArgumentNames("thisJoinPoint", "arg1", "arg2"));
 	}
 
 	@Test
 	void setArgumentNamesFromStringArray_withStaticPart() {
 		AbstractAspectJAdvice advice = getAspectJAdvice("methodWithStaticPart");
-		assertThat(advice).satisfies(hasArgumentNames("THIS_JOIN_POINT", "arg1", "arg2"));
+		assertThat(advice).satisfies(hasArgumentNames("thisJoinPoint", "arg1", "arg2"));
 	}
 
 	private Consumer<AbstractAspectJAdvice> hasArgumentNames(String... argumentNames) {

--- a/spring-aspects/src/main/java/org/springframework/transaction/aspectj/AbstractTransactionAspect.aj
+++ b/spring-aspects/src/main/java/org/springframework/transaction/aspectj/AbstractTransactionAspect.aj
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.transaction.aspectj;
 
+import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.SuppressAjWarnings;
 import org.aspectj.lang.reflect.MethodSignature;
 
@@ -43,69 +44,76 @@ import org.springframework.transaction.interceptor.TransactionAttributeSource;
  * @author Rod Johnson
  * @author Ramnivas Laddad
  * @author Juergen Hoeller
+ * @author Joshua Chen
  * @since 2.0
  */
 public abstract aspect AbstractTransactionAspect extends TransactionAspectSupport implements DisposableBean {
 
-	/**
-	 * Construct the aspect using the given transaction metadata retrieval strategy.
-	 * @param tas TransactionAttributeSource implementation, retrieving Spring
-	 * transaction metadata for each joinpoint. Implement the subclass to pass in
-	 * {@code null} if it is intended to be configured through Setter Injection.
-	 */
-	protected AbstractTransactionAspect(TransactionAttributeSource tas) {
-		setTransactionAttributeSource(tas);
-	}
+    /**
+     * Construct the aspect using the given transaction metadata retrieval strategy.
+     * @param tas TransactionAttributeSource implementation, retrieving Spring
+     * transaction metadata for each joinpoint. Implement the subclass to pass in
+     * {@code null} if it is intended to be configured through Setter Injection.
+     */
+    protected AbstractTransactionAspect(TransactionAttributeSource tas) {
+        setTransactionAttributeSource(tas);
+    }
 
-	@Override
-	public void destroy() {
-		// An aspect is basically a singleton -> cleanup on destruction
-		clearTransactionManagerCache();
-	}
+    @Override
+    public void destroy() {
+        // An aspect is basically a singleton -> cleanup on destruction
+        clearTransactionManagerCache();
+    }
 
-	@SuppressAjWarnings("adviceDidNotMatch")
-	Object around(final Object txObject): transactionalMethodExecution(txObject) {
-		MethodSignature methodSignature = (MethodSignature) thisJoinPoint.getSignature();
-		// Adapt to TransactionAspectSupport's invokeWithinTransaction...
-		try {
-			return invokeWithinTransaction(methodSignature.getMethod(), txObject.getClass(), new InvocationCallback() {
-				public Object proceedWithInvocation() throws Throwable {
-					return proceed(txObject);
-				}
-			});
-		}
-		catch (RuntimeException | Error ex) {
-			throw ex;
-		}
-		catch (Throwable thr) {
-			Rethrower.rethrow(thr);
-			throw new IllegalStateException("Should never get here", thr);
-		}
-	}
+    @SuppressAjWarnings("adviceDidNotMatch")
+    Object around(final Object txObject): transactionalMethodExecution(txObject) {
+        ProceedingJoinPoint proceedingJoinPoint = (ProceedingJoinPoint) thisJoinPoint;
+        MethodSignature methodSignature = (MethodSignature) proceedingJoinPoint.getSignature();
+        // Adapt to TransactionAspectSupport's invokeWithinTransaction...
+        try {
+            return invokeWithinTransaction(methodSignature.getMethod(), txObject.getClass(), new InvocationCallback() {
+                public Object proceedWithInvocation() throws Throwable {
+                    if (proceedingJoinPoint.getArgs().length > 0) {
+                        // Support for method with arguments, in case of exception
+                        return proceed(txObject);
+                    }
+                    else {
+                        return proceedingJoinPoint.proceed();
+                    }
+                }
+            });
+        }
+        catch (RuntimeException | Error ex) {
+            throw ex;
+        }
+        catch (Throwable thr) {
+            Rethrower.rethrow(thr);
+            throw new IllegalStateException("Should never get here", thr);
+        }
+    }
 
-	/**
-	 * Concrete subaspects must implement this pointcut, to identify
-	 * transactional methods. For each selected joinpoint, TransactionMetadata
-	 * will be retrieved using Spring's TransactionAttributeSource interface.
-	 */
-	protected abstract pointcut transactionalMethodExecution(Object txObject);
+    /**
+     * Concrete subaspects must implement this pointcut, to identify
+     * transactional methods. For each selected joinpoint, TransactionMetadata
+     * will be retrieved using Spring's TransactionAttributeSource interface.
+     */
+    protected abstract pointcut transactionalMethodExecution(Object txObject);
 
+    /**
+     * Ugly but safe workaround: We need to be able to propagate checked exceptions,
+     * despite AspectJ around advice supporting specifically declared exceptions only.
+     */
+    private static class Rethrower {
 
-	/**
-	 * Ugly but safe workaround: We need to be able to propagate checked exceptions,
-	 * despite AspectJ around advice supporting specifically declared exceptions only.
-	 */
-	private static class Rethrower {
-
-		public static void rethrow(final Throwable exception) {
-			class CheckedExceptionRethrower<T extends Throwable> {
-				@SuppressWarnings("unchecked")
-				private void rethrow(Throwable exception) throws T {
-					throw (T) exception;
-				}
-			}
-			new CheckedExceptionRethrower<RuntimeException>().rethrow(exception);
-		}
-	}
+        public static void rethrow(final Throwable exception) {
+            class CheckedExceptionRethrower<T extends Throwable> {
+                @SuppressWarnings("unchecked")
+                private void rethrow(Throwable exception) throws T {
+                    throw (T) exception;
+                }
+            }
+            new CheckedExceptionRethrower<RuntimeException>().rethrow(exception);
+        }
+    }
 
 }


### PR DESCRIPTION
Summary:

1. Continue to fix the missing logic of parameter binding in PR #34316
2. AspectJ correctly identifies the subclasses of abstract classes, fixing the failure of pointcut binding
3. Change the JointPoint in AbstractTransactionAspect.aj to ProceedingJoinPoint to fix the problem of parameter binding failure when calling @Transaction at runtime

For more background, see PR #34316 and #34656

After this PR, the following exceptions have been fixed

```log
2025-03-26T16:24:33.336+08:00 DEBUG 17613 --- [           main] o.s.a.aspectj.AspectJExpressionPointcut  : Pointcut parser rejected expression [transactionalMethodExecution(txObject)]: java.lang.IllegalArgumentException: Pointcut is not well-formed: expecting 'identifier' at character position 0

```
