### PR TITLE
Refine `UriUtils#decode` and `StringUtils#uriDecode` implementation and documentation

### DIFF
--- a/spring-web/src/test/java/org/springframework/web/util/UriUtilsTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriUtilsTests.java
@@ -107,12 +107,19 @@ class UriUtilsTests {
 		assertThat(UriUtils.decode("T%C5%8Dky%C5%8D", CHARSET)).as("Invalid encoded result").isEqualTo("T\u014dky\u014d");
 		assertThat(UriUtils.decode("/Z%C3%BCrich", CHARSET)).as("Invalid encoded result").isEqualTo("/Z\u00fcrich");
 		assertThat(UriUtils.decode("T\u014dky\u014d", CHARSET)).as("Invalid encoded result").isEqualTo("T\u014dky\u014d");
+		assertThat(UriUtils.decode("%20\u2019", CHARSET)).as("Invalid encoded result").isEqualTo(" \u2019");
 	}
 
 	@Test
 	void decodeInvalidSequence() {
 		assertThatIllegalArgumentException().isThrownBy(() ->
 				UriUtils.decode("foo%2", CHARSET));
+		assertThatIllegalArgumentException().isThrownBy(() ->
+				UriUtils.decode("foo%", CHARSET));
+		assertThatIllegalArgumentException().isThrownBy(() ->
+				UriUtils.decode("%", CHARSET));
+		assertThatIllegalArgumentException().isThrownBy(() ->
+				UriUtils.decode("%zz", CHARSET));
 	}
 
 	@Test


### PR DESCRIPTION
Optimize the StringUtils.uriDecode method in the following ways:

- Use a StringBuilder instead of ByteArrayOutputStream, and only decode %-encoded sequences.
- Use HexFormat.fromHexDigits to decode hex sequences.
- Decode to a byte array that is only allocated if encoded sequences are encountered.

Using a StringBuilder and decoding to a temporary byte buffer are inspired by how JDK's URLDecoder works; HexFormat was added in JDK17 and should be more performant than Integer.parseInt as it uses lookup tables.

I initially looked at this as an easy optimization opportunity, but it appears this also resolves the issue raised in #34570; I've added a test case to exercise the problem described in that issue.