### PR TITLE
Recursively boxing Kotlin nested value classes in `CoroutinesUtils`

### DIFF
--- a/spring-core/src/test/kotlin/org/springframework/core/CoroutinesUtilsTests.kt
+++ b/spring-core/src/test/kotlin/org/springframework/core/CoroutinesUtilsTests.kt
@@ -200,6 +200,15 @@ class CoroutinesUtilsTests {
 	}
 
 	@Test
+	fun invokeSuspendingFunctionWithNestedValueClassParameter() {
+		val method = CoroutinesUtilsTests::class.java.declaredMethods.first { it.name.startsWith("suspendingFunctionWithNestedValueClassParameter") }
+		val mono = CoroutinesUtils.invokeSuspendingFunction(method, this, "foo", null) as Mono
+		runBlocking {
+			Assertions.assertThat(mono.awaitSingle()).isEqualTo("foo")
+		}
+	}
+
+	@Test
 	fun invokeSuspendingFunctionWithValueClassReturnValue() {
 		val method = CoroutinesUtilsTests::class.java.declaredMethods.first { it.name.startsWith("suspendingFunctionWithValueClassReturnValue") }
 		val mono = CoroutinesUtils.invokeSuspendingFunction(method, this, null) as Mono
@@ -328,6 +337,11 @@ class CoroutinesUtilsTests {
 		return value.value
 	}
 
+	suspend fun suspendingFunctionWithNestedValueClassParameter(value: NestedValueClass): String {
+		delay(1)
+		return value.value.value
+	}
+
 	suspend fun suspendingFunctionWithValueClassReturnValue(): ValueClass {
 		delay(1)
 		return ValueClass("foo")
@@ -381,6 +395,9 @@ class CoroutinesUtilsTests {
 
 	@JvmInline
 	value class ValueClass(val value: String)
+
+	@JvmInline
+	value class NestedValueClass(val value: ValueClass)
 
 	@JvmInline
 	value class ValueClassWithInit(val value: String) {


### PR DESCRIPTION
This PR is a follow-up to #34592.

Unfortunately #34592 does not fully resolve the original issue (#34458), as the invocation of suspended functions occurs in `CoroutinesUtils` which was not addressed in that PR.

While #33630 may eventually eliminate this logic duplication, it's still worthwhile to add recursive boxing to `CoroutinesUtils` in the meantime.