### PR TITLE
Improve BeanFactoryExtensionsTests

### DIFF
--- a/spring-beans/src/test/kotlin/org/springframework/beans/factory/BeanFactoryExtensionsTests.kt
+++ b/spring-beans/src/test/kotlin/org/springframework/beans/factory/BeanFactoryExtensionsTests.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.beans.factory
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.core.ResolvableType
 
@@ -26,6 +27,7 @@ import org.springframework.core.ResolvableType
  * Mock object based tests for BeanFactory Kotlin extensions.
  *
  * @author Sebastien Deleuze
+ * @author Yanming Zhou
  */
 class BeanFactoryExtensionsTests {
 
@@ -35,8 +37,16 @@ class BeanFactoryExtensionsTests {
 	fun `getBean with reified type parameters`() {
 		val foo = Foo()
 		every { bf.getBeanProvider<Foo>(ofType<ResolvableType>()).getObject() } returns foo
-		bf.getBean<Foo>()
+		assertThat(bf.getBean<Foo>()).isSameAs(foo)
 		verify { bf.getBeanProvider<ObjectProvider<Foo>>(ofType<ResolvableType>()).getObject() }
+	}
+
+	@Test
+	fun `getBean with reified generic type parameters`() {
+		val foo = listOf(Foo())
+		every { bf.getBeanProvider<List<Foo>>(ofType<ResolvableType>()).getObject() } returns foo
+		assertThat(bf.getBean<List<Foo>>()).isSameAs(foo)
+		verify { bf.getBeanProvider<ObjectProvider<List<Foo>>>(ofType<ResolvableType>()).getObject() }
 	}
 
 	@Test
@@ -52,7 +62,7 @@ class BeanFactoryExtensionsTests {
 		val arg2 = "arg2"
 		val bar = Bar(arg1, arg2)
 		every { bf.getBeanProvider<Bar>(ofType<ResolvableType>()).getObject(arg1, arg2) } returns bar
-		bf.getBean<Bar>(arg1, arg2)
+		assertThat(bf.getBean<Bar>(arg1, arg2)).isSameAs(bar)
 		verify { bf.getBeanProvider<Bar>(ofType<ResolvableType>()).getObject(arg1, arg2) }
 	}
 


### PR DESCRIPTION
Comparing to Java's `BeanFactory.getBean(Class<T> requiredType)`, Kotlin's `BeanFactory.getBean<T>()` supports generic type as `T`, this commit add test to cover that and add assertions.