### PR TITLE
Fix GenericConversionService selects incorrect converter

### DIFF
--- a/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/support/GenericConversionServiceTests.java
@@ -594,6 +594,19 @@ class GenericConversionServiceTests {
 		assertThat("foo").isEqualTo(result.get(0).get("bar"));
 	}
 
+	@Test
+	@SuppressWarnings("unchecked")
+	void stringToListOfString() {
+		conversionService.addConverter(new StringToCollectionConverter(conversionService));
+		conversionService.addConverter(new StringToListOfMapConverter());
+
+		List<String> result = (List<String>) conversionService.convert("foo,bar",
+				TypeDescriptor.valueOf(String.class),
+				TypeDescriptor.collection(List.class, TypeDescriptor.valueOf(String.class))
+		);
+
+		assertThat(result.get(0)).isEqualTo("foo");
+	}
 
 	@ExampleAnnotation(active = true)
 	public String annotatedString;
@@ -990,5 +1003,4 @@ class GenericConversionServiceTests {
 			return List.of(Map.of("bar", source));
 		}
 	}
-
 }


### PR DESCRIPTION
Fix [gh-34685](https://github.com/spring-projects/spring-framework/issues/34685)

This method is implemented to determine type compatibility between ResolvableType instances,
not only by comparing raw types but also by recursively checking deep assignability of generic types.
An alternative approach could be using TypeDescriptor.isAssignableTo.
I would appreciate your review and feedback on this.