### PR TITLE
Fix broken link for Server-Sent Events

### DIFF
--- a/framework-docs/modules/ROOT/pages/web/webmvc-functional.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc-functional.adoc
@@ -276,7 +276,7 @@ ServerResponse.async(asyncResponse);
 ----
 ======
 
-https://www.w3.org/TR/eventsource/[Server-Sent Events] can be provided via the
+https://html.spec.whatwg.org/multipage/server-sent-events.html[Server-Sent Events] can be provided via the
 static `sse` method on `ServerResponse`. The builder provided by that method
 allows you to send Strings, or other objects as JSON. For example:
 

--- a/framework-docs/modules/ROOT/pages/web/webmvc/mvc-ann-async.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc/mvc-ann-async.adoc
@@ -281,7 +281,7 @@ invokes the configured exception resolvers and completes the request.
 === SSE
 
 `SseEmitter` (a subclass of `ResponseBodyEmitter`) provides support for
-https://www.w3.org/TR/eventsource/[Server-Sent Events], where events sent from the server
+https://html.spec.whatwg.org/multipage/server-sent-events.html[Server-Sent Events], where events sent from the server
 are formatted according to the W3C SSE specification. To produce an SSE
 stream from a controller, return `SseEmitter`, as the following example shows:
 

--- a/spring-web/src/main/java/org/springframework/http/MediaType.java
+++ b/spring-web/src/main/java/org/springframework/http/MediaType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,7 @@ import org.springframework.util.StringUtils;
  * @author Kazuki Shimizu
  * @author Sam Brannen
  * @author Hyoungjune Kim
+ * @author Taeik Lim
  * @since 3.0
  * @see <a href="https://tools.ietf.org/html/rfc7231#section-3.1.1.1">
  *     HTTP 1.1: Semantics and Content, section 3.1.1.1</a>
@@ -308,7 +309,7 @@ public class MediaType extends MimeType implements Serializable {
 	/**
 	 * Media type for {@code text/event-stream}.
 	 * @since 4.3.6
-	 * @see <a href="https://www.w3.org/TR/eventsource/">Server-Sent Events W3C recommendation</a>
+	 * @see <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html">Server-Sent Events</a>
 	 */
 	public static final MediaType TEXT_EVENT_STREAM;
 

--- a/spring-web/src/main/java/org/springframework/http/codec/ServerSentEvent.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/ServerSentEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,10 +30,11 @@ import org.springframework.util.StringUtils;
  *
  * @author Sebastien Deleuze
  * @author Arjen Poutsma
+ * @author Taeik Lim
  * @since 5.0
  * @param <T> the type of data that this event contains
  * @see ServerSentEventHttpMessageWriter
- * @see <a href="https://www.w3.org/TR/eventsource/">Server-Sent Events W3C recommendation</a>
+ * @see <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html">Server-Sent Events</a>
  */
 public final class ServerSentEvent<T> {
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/BodyInserters.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/BodyInserters.java
@@ -51,6 +51,7 @@ import org.springframework.util.MultiValueMap;
  * @author Arjen Poutsma
  * @author Rossen Stoyanchev
  * @author Sebastien Deleuze
+ * @author Taeik Lim
  * @since 5.0
  */
 public abstract class BodyInserters {
@@ -241,7 +242,7 @@ public abstract class BodyInserters {
 	 * @param eventsPublisher the {@code ServerSentEvent} publisher to write to the response body
 	 * @param <T> the type of the data elements in the {@link ServerSentEvent}
 	 * @return the inserter to write a {@code ServerSentEvent} publisher
-	 * @see <a href="https://www.w3.org/TR/eventsource/">Server-Sent Events W3C recommendation</a>
+	 * @see <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html">Server-Sent Events</a>
 	 */
 	// Parameterized for server-side use
 	public static <T, S extends Publisher<ServerSentEvent<T>>> BodyInserter<S, ServerHttpResponse> fromServerSentEvents(

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/ServerResponse.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/ServerResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ import org.springframework.web.servlet.ModelAndView;
  * {@linkplain HandlerFilterFunction filter function}.
  *
  * @author Arjen Poutsma
+ * @author Taeik Lim
  * @since 5.2
  */
 public interface ServerResponse {
@@ -284,7 +285,7 @@ public interface ServerResponse {
 	 * @param consumer consumer that will be provided with an event builder
 	 * @return the server-side event response
 	 * @since 5.3.2
-	 * @see <a href="https://www.w3.org/TR/eventsource/">Server-Sent Events</a>
+	 * @see <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html">Server-Sent Events</a>
 	 */
 	static ServerResponse sse(Consumer<SseBuilder> consumer) {
 		return SseServerResponse.create(consumer, null);
@@ -314,7 +315,7 @@ public interface ServerResponse {
 	 * @param timeout  maximum time period to wait before timing out
 	 * @return the server-side event response
 	 * @since 5.3.2
-	 * @see <a href="https://www.w3.org/TR/eventsource/">Server-Sent Events</a>
+	 * @see <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html">Server-Sent Events</a>
 	 */
 	static ServerResponse sse(Consumer<SseBuilder> consumer, Duration timeout) {
 		return SseServerResponse.create(consumer, timeout);

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/SseServerResponse.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/SseServerResponse.java
@@ -46,10 +46,11 @@ import org.springframework.web.servlet.ModelAndView;
 
 /**
  * Implementation of {@link ServerResponse} for sending
- * <a href="https://www.w3.org/TR/eventsource/">Server-Sent Events</a>.
+ * <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html">Server-Sent Events</a>.
  *
  * @author Arjen Poutsma
  * @author Sebastien Deleuze
+ * @author Taeik Lim
  * @since 5.3.2
  */
 final class SseServerResponse extends AbstractServerResponse {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/SseEmitter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/SseEmitter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2024 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,12 +35,13 @@ import org.springframework.web.servlet.ModelAndView;
 
 /**
  * A specialization of {@link ResponseBodyEmitter} for sending
- * <a href="https://www.w3.org/TR/eventsource/">Server-Sent Events</a>.
+ * <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html">Server-Sent Events</a>.
  *
  * @author Rossen Stoyanchev
  * @author Juergen Hoeller
  * @author Sam Brannen
  * @author Brian Clozel
+ * @author Taeik Lim
  * @since 4.2
  */
 public class SseEmitter extends ResponseBodyEmitter {

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/handler/EventSourceTransportHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/handler/EventSourceTransportHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,9 +31,10 @@ import org.springframework.web.socket.sockjs.transport.session.StreamingSockJsSe
 
 /**
  * A TransportHandler for sending messages via Server-Sent Events:
- * <a href="https://dev.w3.org/html5/eventsource/">https://dev.w3.org/html5/eventsource/</a>.
+ * <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html">Server-Sent Events</a>.
  *
  * @author Rossen Stoyanchev
+ * @author Taeik Lim
  * @since 4.0
  */
 public class EventSourceTransportHandler extends AbstractHttpSendingTransportHandler {


### PR DESCRIPTION
Closes gh-34704

I've searched with `/eventsource` text