### PR TITLE
Fix inconsistent query parameter conversion for String param

### DIFF
--- a/spring-web/src/test/java/org/springframework/web/bind/support/WebRequestDataBinderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/bind/support/WebRequestDataBinderTests.java
@@ -40,6 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Juergen Hoeller
+ * @author Sumin Kim
  */
 class WebRequestDataBinderTests {
 
@@ -122,6 +123,18 @@ class WebRequestDataBinderTests {
 		request.addParameter("stringArray[]", "TWO");
 		binder.bind(new ServletWebRequest(request));
 		assertThat(target.getStringArray()).containsExactly("ONE", "TWO");
+	}
+
+	@Test
+	public void testFieldWithEmptyArrayIndex1() {
+		TestBean target = new TestBean();
+		WebRequestDataBinder binder = new WebRequestDataBinder(target);
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("touchy", "ONE");
+		request.addParameter("touchy", "TWO");
+		binder.bind(new ServletWebRequest(request));
+		assertThat(target.getTouchy()).isEqualTo("ONE");
 	}
 
 	@Test


### PR DESCRIPTION
## Issue

When converting multiple query parameters with the same name to a single value, Spring behaves inconsistently depending on the target type:

* For Integer parameters: `/endpoint?param=1&param=2` → first value is used (`1`)
* For String parameters: `/endpoint?param=1&param=2` → comma-separated string is created (`1,2`)

This inconsistency makes behavior unpredictable and forces developers to implement workarounds.

## Changes

This PR modifies `WebRequestDataBinder` to handle `String[]` to `String` conversion consistently with other types by only using the first value when binding web request parameters.

## Tests

Added unit tests to verify consistent behavior across different parameter types.

Fixes #34613