### PR TITLE
Preventing unmodifiableList from being affected by changes to the original List

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ReadOnlyHttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/ReadOnlyHttpHeaders.java
@@ -86,7 +86,7 @@ class ReadOnlyHttpHeaders extends HttpHeaders {
 	@Override
 	public @Nullable List<String> get(String headerName) {
 		List<String> values = this.headers.get(headerName);
-		return (values != null ? Collections.unmodifiableList(values) : null);
+		return (values != null ? List.copyOf(values) : null);
 	}
 
 	@Override
@@ -179,7 +179,7 @@ class ReadOnlyHttpHeaders extends HttpHeaders {
 
 	@Override
 	public void forEach(BiConsumer<? super String, ? super List<String>> action) {
-		this.headers.forEach((k, vs) -> action.accept(k, Collections.unmodifiableList(vs)));
+		this.headers.forEach((k, vs) -> action.accept(k, List.copyOf(vs)));
 	}
 
 }


### PR DESCRIPTION
This PR replaces `Collections.unmodifiableList()` with `List.copyOf()`.

When using `Collections.unmodifiableList()`, if the original list changes, it can affect the unmodifiable list, potentially causing unexpected bugs.

Using `List.copyOf` creates an immutable list by copying the original list, which prevents unexpected bugs and makes the code more readable, improving maintainability.

```
Collections.unmodifiableList(values)
```

I changed the code from the format above to the one below.
```
List.copyOf(values)
```