### PR TITLE
Improve handling of `mainThreadPrefix` and remove redundant null check

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
@@ -1069,7 +1069,7 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 			}
 			else if (this.strictLocking == null) {
 				// No explicit locking configuration -> infer appropriate locking.
-				if (mainThreadPrefix != null && !getThreadNamePrefix().equals(mainThreadPrefix)) {
+				if (!getThreadNamePrefix().equals(mainThreadPrefix)) {
 					// An unmanaged thread (assumed to be application-internal) with lenient locking,
 					// and not part of the same thread pool that provided the main bootstrap thread
 					// (excluding scenarios where we are hit by multiple external bootstrap threads).

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
@@ -1048,7 +1048,7 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 	@Override
 	protected @Nullable Boolean isCurrentThreadAllowedToHoldSingletonLock() {
 		String mainThreadPrefix = this.mainThreadPrefix;
-		if (this.mainThreadPrefix != null) {
+		if (mainThreadPrefix != null) {
 			// We only differentiate in the preInstantiateSingletons phase.
 
 			PreInstantiation preInstantiation = this.preInstantiationThread.get();


### PR DESCRIPTION
This Pull Request refactors the `isCurrentThreadAllowedToHoldSingletonLock` method to improve the consistency of `mainThreadPrefix` variable usage and remove a redundant null check.

## Changes
**Consistent Variable Usage**
- After assigning the value of `this.mainThreadPrefix` to the local variable `mainThreadPrefix` at the beginning of the method, the subsequent `if` check now consistently uses the local variable (`if (mainThreadPrefix != null)` instead of if `(this.mainThreadPrefix != null)`).

**Removed Redundant Null Check**

- The `mainThreadPrefix != null` check within the `else if (this.strictLocking == null)` block has been removed.
- This check was redundant because `if (maainThreadPrefix != null)` condition has already passed, guaranteeing the variable is not null at that point.

---

 I hope my PR useful :) 
Thank you. 