### PR TITLE
Update Javadoc for `ignoreDependencyInterface()` in `AbstractAutowireCapableBeanFactory`

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractAutowireCapableBeanFactory.java
@@ -285,7 +285,7 @@ public abstract class AbstractAutowireCapableBeanFactory extends AbstractBeanFac
 	 * <p>This will typically be used by application contexts to register
 	 * dependencies that are resolved in other ways, like BeanFactory through
 	 * BeanFactoryAware or ApplicationContext through ApplicationContextAware.
-	 * <p>By default, only the BeanFactoryAware interface is ignored.
+	 * <p>By default, the BeanNameAware,BeanFactoryAware,BeanClassLoaderAware interface are ignored.
 	 * For further types to ignore, invoke this method for each type.
 	 * @see org.springframework.beans.factory.BeanFactoryAware
 	 * @see org.springframework.context.ApplicationContextAware


### PR DESCRIPTION
Specifically, the documentation update reflects that:
- Initially, it was mentioned that only the `BeanFactoryAware` interface is ignored by default.
- The updated documentation now correctly states that `BeanNameAware`, `BeanFactoryAware`, and `BeanClassLoaderAware` interfaces are all ignored by default.

We can understand from the default constructor of AbstractAutowireCapableBeanFactory that:
``` java
/**
* Create a new AbstractAutowireCapableBeanFactory.
*/
public AbstractAutowireCapableBeanFactory() {
	super();
	ignoreDependencyInterface(BeanNameAware.class);
	ignoreDependencyInterface(BeanFactoryAware.class);
	ignoreDependencyInterface(BeanClassLoaderAware.class);
	this.instantiationStrategy = new CglibSubclassingInstantiationStrategy();
}
```