### PR TITLE
Convert applicable methods in `Scope` to `default` methods

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/Scope.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/Scope.java
@@ -130,7 +130,9 @@ public interface Scope {
 	 * @return the corresponding object, or {@code null} if none found
 	 * @throws IllegalStateException if the underlying scope is not currently active
 	 */
-	@Nullable Object resolveContextualObject(String key);
+	default @Nullable Object resolveContextualObject(String key) {
+		return null;
+	}
 
 	/**
 	 * Return the <em>conversation ID</em> for the current underlying scope, if any.
@@ -147,6 +149,8 @@ public interface Scope {
 	 * conversation ID for the current scope
 	 * @throws IllegalStateException if the underlying scope is not currently active
 	 */
-	@Nullable String getConversationId();
+	default @Nullable String getConversationId() {
+		return null;
+	}
 
 }

--- a/spring-beans/src/test/java/org/springframework/beans/factory/config/TestTypes.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/config/TestTypes.java
@@ -44,14 +44,4 @@ class NoOpScope implements Scope {
 	public void registerDestructionCallback(String name, Runnable callback) {
 	}
 
-	@Override
-	public Object resolveContextualObject(String key) {
-		return null;
-	}
-
-	@Override
-	public String getConversationId() {
-		return null;
-	}
-
 }

--- a/spring-context/src/main/java/org/springframework/context/support/SimpleThreadScope.java
+++ b/spring-context/src/main/java/org/springframework/context/support/SimpleThreadScope.java
@@ -84,11 +84,6 @@ public class SimpleThreadScope implements Scope {
 	}
 
 	@Override
-	public @Nullable Object resolveContextualObject(String key) {
-		return null;
-	}
-
-	@Override
 	public String getConversationId() {
 		return Thread.currentThread().getName();
 	}

--- a/spring-context/src/test/java/org/springframework/context/annotation/configuration/ScopingTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/configuration/ScopingTests.java
@@ -354,11 +354,6 @@ class ScopingTests {
 		}
 
 		@Override
-		public String getConversationId() {
-			return null;
-		}
-
-		@Override
 		public void registerDestructionCallback(String name, Runnable callback) {
 			throw new IllegalStateException("Not supposed to be called");
 		}
@@ -368,10 +363,6 @@ class ScopingTests {
 			return beans.remove(name);
 		}
 
-		@Override
-		public Object resolveContextualObject(String key) {
-			return null;
-		}
 	}
 
 }

--- a/spring-context/src/test/java/org/springframework/context/annotation/configuration/Spr10744Tests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/configuration/Spr10744Tests.java
@@ -83,16 +83,6 @@ class Spr10744Tests {
 		@Override
 		public void registerDestructionCallback(String name, Runnable callback) {
 		}
-
-		@Override
-		public Object resolveContextualObject(String key) {
-			return null;
-		}
-
-		@Override
-		public String getConversationId() {
-			return null;
-		}
 	}
 
 

--- a/spring-context/src/test/java/org/springframework/context/event/AnnotationDrivenEventListenerTests.java
+++ b/spring-context/src/test/java/org/springframework/context/event/AnnotationDrivenEventListenerTests.java
@@ -1090,16 +1090,6 @@ class AnnotationDrivenEventListenerTests {
 		@Override
 		public void registerDestructionCallback(String name, Runnable callback) {
 		}
-
-		@Override
-		public Object resolveContextualObject(String key) {
-			return null;
-		}
-
-		@Override
-		public String getConversationId() {
-			return null;
-		}
 	}
 
 

--- a/spring-context/src/test/java/org/springframework/context/expression/ApplicationContextExpressionTests.java
+++ b/spring-context/src/test/java/org/springframework/context/expression/ApplicationContextExpressionTests.java
@@ -94,10 +94,6 @@ class ApplicationContextExpressionTests {
 					return null;
 				}
 			}
-			@Override
-			public String getConversationId() {
-				return null;
-			}
 		});
 
 		ac.getBeanFactory().setConversionService(new DefaultConversionService());

--- a/spring-context/src/test/java/org/springframework/context/groovy/GroovyBeanDefinitionReaderTests.java
+++ b/spring-context/src/test/java/org/springframework/context/groovy/GroovyBeanDefinitionReaderTests.java
@@ -1215,19 +1215,9 @@ class TestScope implements Scope {
 	}
 
 	@Override
-	public String getConversationId() {
-		return null;
-	}
-
-	@Override
 	public Object get(String name, ObjectFactory<?> objectFactory) {
 		instanceCount++;
 		return objectFactory.getObject();
-	}
-
-	@Override
-	public Object resolveContextualObject(String s) {
-		return null;
 	}
 }
 

--- a/spring-context/src/testFixtures/java/org/springframework/context/testfixture/SimpleMapScope.java
+++ b/spring-context/src/testFixtures/java/org/springframework/context/testfixture/SimpleMapScope.java
@@ -68,20 +68,10 @@ public class SimpleMapScope implements Scope, Serializable {
 		this.callbacks.add(callback);
 	}
 
-	@Override
-	public Object resolveContextualObject(String key) {
-		return null;
-	}
-
 	public void close() {
 		for (Runnable runnable : this.callbacks) {
 			runnable.run();
 		}
-	}
-
-	@Override
-	public String getConversationId() {
-		return null;
 	}
 
 }

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpSessionScope.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpSessionScope.java
@@ -71,11 +71,6 @@ public class SimpSessionScope implements Scope {
 	}
 
 	@Override
-	public @Nullable Object resolveContextualObject(String key) {
-		return null;
-	}
-
-	@Override
 	public String getConversationId() {
 		return SimpAttributesContextHolder.currentAttributes().getSessionId();
 	}

--- a/spring-tx/src/main/java/org/springframework/transaction/support/SimpleTransactionScope.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/support/SimpleTransactionScope.java
@@ -82,11 +82,6 @@ public class SimpleTransactionScope implements Scope {
 	}
 
 	@Override
-	public @Nullable Object resolveContextualObject(String key) {
-		return null;
-	}
-
-	@Override
 	public @Nullable String getConversationId() {
 		return TransactionSynchronizationManager.getCurrentTransactionName();
 	}

--- a/spring-web/src/main/java/org/springframework/web/context/request/RequestScope.java
+++ b/spring-web/src/main/java/org/springframework/web/context/request/RequestScope.java
@@ -16,8 +16,6 @@
 
 package org.springframework.web.context.request;
 
-import org.jspecify.annotations.Nullable;
-
 /**
  * Request-backed {@link org.springframework.beans.factory.config.Scope}
  * implementation.
@@ -42,15 +40,6 @@ public class RequestScope extends AbstractRequestAttributesScope {
 	@Override
 	protected int getScope() {
 		return RequestAttributes.SCOPE_REQUEST;
-	}
-
-	/**
-	 * There is no conversation id concept for a request, so this method
-	 * returns {@code null}.
-	 */
-	@Override
-	public @Nullable String getConversationId() {
-		return null;
 	}
 
 }

--- a/spring-web/src/main/java/org/springframework/web/context/support/ServletContextScope.java
+++ b/spring-web/src/main/java/org/springframework/web/context/support/ServletContextScope.java
@@ -96,17 +96,6 @@ public class ServletContextScope implements Scope, DisposableBean {
 		}
 	}
 
-	@Override
-	public @Nullable Object resolveContextualObject(String key) {
-		return null;
-	}
-
-	@Override
-	public @Nullable String getConversationId() {
-		return null;
-	}
-
-
 	/**
 	 * Invoke all registered destruction callbacks.
 	 * To be called on ServletContext shutdown.


### PR DESCRIPTION
`getConversationId` and `resolveContextualObject` are candidates for being converted to `default` methods, not sure about `registerDestructionCallback`.
