### PR TITLE
Correctly expand query param with same name from URI variables array 

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
+++ b/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
@@ -443,7 +443,7 @@ final class HierarchicalUriComponents extends UriComponents {
 		UriTemplateVariables queryVariables = new QueryUriTemplateVariables(variables);
 		this.queryParams.forEach((key, values) -> {
 			String name = expandUriComponent(key, queryVariables, this.variableEncoder);
-			List<String> expandedValues = new ArrayList<>(values.size());
+			List<String> expandedValues = result.getOrDefault(name, new ArrayList<>(values.size()));
 			for (String value : values) {
 				expandedValues.add(expandUriComponent(value, queryVariables, this.variableEncoder));
 			}

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -631,6 +631,20 @@ class UriComponentsBuilderTests {
 
 	@ParameterizedTest
 	@EnumSource
+	void parseBuildAndExpandHierarchicalWithDuplicateQueryKeys(ParserType parserType) {
+		UriComponents result = UriComponentsBuilder.fromUriString("/?{pk1}={pv1}&{pk2}={pv2}", parserType)
+				.buildAndExpand("k1", "v1", "k1", "v2");
+		assertThat(result.getQuery()).isEqualTo("k1=v1&k1=v2");
+		assertThat(result.getQueryParams().get("k1")).containsExactly("v1", "v2");
+
+		UriComponents result2 = UriComponentsBuilder.fromUriString("/?{pk1}={pv1}&{pk2}={pv2}", parserType)
+				.buildAndExpand(Map.of("pk1", "k1", "pv1", "v1", "pk2", "k1", "pv2", "v2"));
+		assertThat(result2.getQuery()).isEqualTo("k1=v1&k1=v2");
+		assertThat(result.getQueryParams().get("k1")).containsExactly("v1", "v2");
+	}
+
+	@ParameterizedTest
+	@EnumSource
 	void buildAndExpandOpaque(ParserType parserType) {
 		UriComponents result = UriComponentsBuilder.fromUriString("mailto:{user}@{domain}", parserType)
 				.buildAndExpand("foo", "example.com");


### PR DESCRIPTION
Fixes #34781 

For repeated fields, the original method is to overwrite them instead of adding them to the original array.