### PR TITLE
Exclude the duplicate media types in AbstractMessageConverterMethodProcessor::determineCompatibleMediaTypes

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodProcessor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodProcessor.java
@@ -459,7 +459,10 @@ public abstract class AbstractMessageConverterMethodProcessor extends AbstractMe
 		for (MediaType requestedType : acceptableTypes) {
 			for (MediaType producibleType : producibleTypes) {
 				if (requestedType.isCompatibleWith(producibleType)) {
-					mediaTypesToUse.add(getMostSpecificMediaType(requestedType, producibleType));
+					MediaType mostSpecificMediaType = getMostSpecificMediaType(requestedType, producibleType);
+					if (!mediaTypesToUse.contains(mostSpecificMediaType)) {
+						mediaTypesToUse.add(mostSpecificMediaType);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Hi all,

This trivial patch excludes the duplicate media types in the method `AbstractMessageConverterMethodProcessor::determineCompatibleMediaTypes`.

Thanks for your review.

Best Regards,
-- Guoxiong