### PR TITLE
Use HexFormat in CharacterEditor

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/propertyeditors/CharacterEditor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/propertyeditors/CharacterEditor.java
@@ -17,6 +17,7 @@
 package org.springframework.beans.propertyeditors;
 
 import java.beans.PropertyEditorSupport;
+import java.util.HexFormat;
 
 import org.jspecify.annotations.Nullable;
 
@@ -97,13 +98,12 @@ public class CharacterEditor extends PropertyEditorSupport {
 		return (value != null ? value.toString() : "");
 	}
 
-
-	private boolean isUnicodeCharacterSequence(String sequence) {
+	private static boolean isUnicodeCharacterSequence(String sequence) {
 		return (sequence.startsWith(UNICODE_PREFIX) && sequence.length() == UNICODE_LENGTH);
 	}
 
 	private void setAsUnicode(String text) {
-		int code = Integer.parseInt(text.substring(UNICODE_PREFIX.length()), 16);
+		int code = HexFormat.fromHexDigits(text, UNICODE_PREFIX.length(), text.length());
 		setValue((char) code);
 	}
 


### PR DESCRIPTION
Use HexFormat to perform conversion for unicode-prefixed Strings in CharacterEditor.