### PR TITLE
Pull #34810: align `xmx args`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 version=7.0.0-SNAPSHOT
 
 org.gradle.caching=true
-org.gradle.jvmargs=-Xmx2048m
+org.gradle.jvmargs=-Xmx2g
 org.gradle.parallel=true
 
 kotlinVersion=2.1.20

--- a/import-into-eclipse.md
+++ b/import-into-eclipse.md
@@ -48,7 +48,7 @@ _When instructed to execute `./gradlew` from the command line, be sure to execut
 1. While JUnit tests pass from the command line with Gradle, some may fail when run from
    the IDE.
    - Resolving this is a work in progress.
-   - If attempting to run all JUnit tests from within the IDE, you may need to set the following VM options to avoid out of memory errors: `-XX:MaxPermSize=2048m -Xmx2048m -XX:MaxHeapSize=2048m`
+   - If attempting to run all JUnit tests from within the IDE, you may need to set the following VM options to avoid out of memory errors: `-XX:MaxPermSize=2g -Xmx2g -XX:MaxHeapSize=2g`
 
 ## Tips
 

--- a/import-into-idea.md
+++ b/import-into-idea.md
@@ -19,7 +19,7 @@ IntelliJ IDEA. See https://youtrack.jetbrains.com/issue/IDEA-64446 for details. 
 3. While JUnit tests pass from the command line with Gradle, some may fail when run from
 IntelliJ IDEA. Resolving this is a work in progress. If attempting to run all JUnit tests from within
 IntelliJ IDEA, you will likely need to set the following VM options to avoid out of memory errors:
-    -XX:MaxPermSize=2048m -Xmx2048m -XX:MaxHeapSize=2048m
+    -XX:MaxPermSize=2g -Xmx2g -XX:MaxHeapSize=2g
 4. If you invoke "Rebuild Project" in the IDE, you'll have to generate some test
 resources of the `spring-oxm` module again (`./gradlew :spring-oxm:compileTestJava`)    
 


### PR DESCRIPTION
Pull #34810: align `xmx args`

align to same (memory) unit from `mb` to `gb`, as its actually about `gb`.

like done in: https://github.com/checkstyle/checkstyle/pull/16608