### PR TITLE
HttpEntity.EMPTY headers should not be possible to mutate via HttpHeaders constructor

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpEntity.java
@@ -50,6 +50,7 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Arjen Poutsma
  * @author Juergen Hoeller
+ * @author Yanming Zhou
  * @since 3.0.2
  * @param <T> the body type
  * @see org.springframework.web.client.RestTemplate
@@ -61,7 +62,7 @@ public class HttpEntity<T> {
 	/**
 	 * The empty {@code HttpEntity}, with no body or headers.
 	 */
-	public static final HttpEntity<?> EMPTY = new HttpEntity<>();
+	public static final HttpEntity<?> EMPTY = new HttpEntity<>(HttpHeaders.EMPTY);
 
 
 	private final HttpHeaders headers;

--- a/spring-web/src/test/java/org/springframework/http/HttpEntityTests.java
+++ b/spring-web/src/test/java/org/springframework/http/HttpEntityTests.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Arjen Poutsma
+ * @author Yanming Zhou
  */
 class HttpEntityTests {
 
@@ -118,6 +119,13 @@ class HttpEntityTests {
 		assertThat(requestEntity).isNotEqualTo(httpEntity);
 		assertThat(requestEntity).isEqualTo(requestEntity2);
 		assertThat(requestEntity2).isEqualTo(requestEntity);
+	}
+
+	@Test
+	void emptyHttpEntityShouldBeImmutable() {
+		HttpHeaders newHeaders = new HttpHeaders(HttpEntity.EMPTY.getHeaders());
+		newHeaders.add("Authorization", "Bearer some-token");
+		assertThat(HttpEntity.EMPTY.getHeaders().headerNames()).isEmpty();
 	}
 
 }


### PR DESCRIPTION
Fix GH-34806