### PR TITLE
refactor: add IllegalArgumentException in getMostSpecificCause Method

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/NestedExceptionUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/NestedExceptionUtils.java
@@ -82,6 +82,9 @@ public abstract class NestedExceptionUtils {
 	 * @since 4.3.9
 	 */
 	public static Throwable getMostSpecificCause(Throwable original) {
+		if (original == null) {
+			throw new IllegalArgumentException("Original exception must not be null");
+		}
 		Throwable rootCause = getRootCause(original);
 		return (rootCause != null ? rootCause : original);
 	}


### PR DESCRIPTION
# Add null check to NestedExceptionUtils.getMostSpecificCause

## Description
This pull request adds a defensive null check to the `getMostSpecificCause` method in the `NestedExceptionUtils` class. The method now throws an `IllegalArgumentException` when a null value is passed as the `original` parameter.

## Motivation
The `getMostSpecificCause` method is documented to never return null, as indicated by its JavaDoc comment: "return the most specific cause (never {@code null})". However, before this change, if a null value was passed to the method, it would attempt to call `getRootCause(null)` and then potentially return null, contradicting its contract.

## Changes Made
Added a null check at the beginning of the `getMostSpecificCause` method that throws an `IllegalArgumentException` with the message "Original exception must not be null" when the original parameter is null.

## Benefits
1. **Improved API Contract Enforcement**: The method now properly enforces its documented contract of never returning null.
2. **Early Failure**: Problems are detected at the source rather than propagating through the application, making debugging easier.
3. **Consistent Error Handling**: This change aligns with Spring Framework's defensive programming practices seen throughout the codebase.
4. **Better Developer Experience**: Provides a clear and immediate error message when the method is used incorrectly.

## Impact
This is a non-breaking change for code that uses the method correctly (passing non-null exceptions). It only affects code that incorrectly passes null values, which would have led to unexpected behavior anyway.

The change is minimal and focused on improving robustness without altering the method's core functionality.
