### PR TITLE
Fix typo in JavaDoc of setResponse method in MockClientHttpRequest

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/http/client/MockClientHttpRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/http/client/MockClientHttpRequest.java
@@ -104,7 +104,7 @@ public class MockClientHttpRequest extends MockHttpOutputMessage implements Clie
 
 	/**
 	 * Set the {@link ClientHttpResponse} to be used as the result of executing
-	 * the this request.
+	 * this request.
 	 * @see #execute()
 	 */
 	public void setResponse(ClientHttpResponse clientHttpResponse) {


### PR DESCRIPTION
Hello,

This pull request fixes a grammatical error in the JavaDoc for the setResponse method in MockClientHttpRequest.

File: spring-test/src/main/java/org/springframework/mock/http/client/MockClientHttpRequest.java
Line: 107

Change:
- Original: "the this request"
- Changed to: "this request"

This update improves the clarity and professionalism of the documentation.

Thank you.