### PR TITLE
Fix #34760: ignore Kotlin DefaultConstructorMarker in BeanUtils#getParameterNames

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 
 import kotlin.jvm.JvmClassMappingKt;
+import kotlin.jvm.internal.DefaultConstructorMarker;
 import kotlin.reflect.KClass;
 import kotlin.reflect.KFunction;
 import kotlin.reflect.KParameter;
@@ -659,7 +660,13 @@ public abstract class BeanUtils {
 		ConstructorProperties cp = ctor.getAnnotation(ConstructorProperties.class);
 		@Nullable String[] paramNames = (cp != null ? cp.value() : parameterNameDiscoverer.getParameterNames(ctor));
 		Assert.state(paramNames != null, () -> "Cannot resolve parameter names for constructor " + ctor);
-		Assert.state(paramNames.length == ctor.getParameterCount(),
+
+		// The generated param "DefaultConstructorMarker" is used to avoid collision of signatures
+		// and should be filtered out
+		long realParamsCount = Arrays.stream(ctor.getParameters())
+				.filter(p -> !DefaultConstructorMarker.class.equals(p.getType()))
+				.count();
+		Assert.state(paramNames.length == realParamsCount,
 				() -> "Invalid number of parameter names: " + paramNames.length + " for constructor " + ctor);
 		return paramNames;
 	}

--- a/spring-beans/src/test/kotlin/org/springframework/beans/BeanUtilsKotlinTests.kt
+++ b/spring-beans/src/test/kotlin/org/springframework/beans/BeanUtilsKotlinTests.kt
@@ -157,6 +157,67 @@ class BeanUtilsKotlinTests {
 		assertThat(instance).isEqualTo(ConstructorWithNullablePrimitiveValueClass(null))
 	}
 
+	@Test
+	fun `getParameterNames filters out DefaultConstructorMarker with Foo`() {
+		val ctor = BeanUtils.findPrimaryConstructor(Foo::class.java)!!
+		val names = BeanUtils.getParameterNames(ctor)
+		assertThat(names).containsExactly("param1", "param2")
+	}
+
+
+	@Test
+	fun `getParameterNames filters out DefaultConstructorMarker with Bar`() {
+		val ctor = BeanUtils.findPrimaryConstructor(Bar::class.java)!!
+		val names = BeanUtils.getParameterNames(ctor)
+		assertThat(names).containsExactly("param1", "param2")
+	}
+
+	@Test
+	fun `getParameterNames filters out DefaultConstructorMarker with Baz`() {
+		val ctor = BeanUtils.findPrimaryConstructor(Baz::class.java)!!
+		val names = BeanUtils.getParameterNames(ctor)
+		assertThat(names).containsExactly("param1", "param2")
+	}
+
+	@Test
+	fun `getParameterNames filters out DefaultConstructorMarker with Qux`() {
+		val ctor = BeanUtils.findPrimaryConstructor(Qux::class.java)!!
+		val names = BeanUtils.getParameterNames(ctor)
+		assertThat(names).containsExactly("param1", "param2")
+	}
+
+	@Test
+	fun `getParameterNames filters out DefaultConstructorMarker with ConstructorWithValueClass`() {
+		val ctor = BeanUtils.findPrimaryConstructor(ConstructorWithValueClass::class.java)!!
+		assertThat(ctor).isNotNull()
+		val names = BeanUtils.getParameterNames(ctor)
+		assertThat(names).containsExactly("value")
+	}
+
+	@Test
+	fun `getParameterNames filters out DefaultConstructorMarker with ConstructorWithNullableValueClass`() {
+		val ctor = BeanUtils.findPrimaryConstructor(ConstructorWithNullableValueClass::class.java)!!
+		assertThat(ctor).isNotNull()
+		val names = BeanUtils.getParameterNames(ctor)
+		assertThat(names).containsExactly("value")
+	}
+
+	@Test
+	fun `getParameterNames filters out DefaultConstructorMarker with ConstructorWithPrimitiveValueClass`() {
+		val ctor = BeanUtils.findPrimaryConstructor(ConstructorWithPrimitiveValueClass::class.java)!!
+		assertThat(ctor).isNotNull()
+		val names = BeanUtils.getParameterNames(ctor)
+		assertThat(names).containsExactly("value")
+	}
+
+	@Test
+	fun `getParameterNames filters out DefaultConstructorMarker with ConstructorWithNullablePrimitiveValueClass`() {
+		val ctor = BeanUtils.findPrimaryConstructor(ConstructorWithNullablePrimitiveValueClass::class.java)!!
+		assertThat(ctor).isNotNull()
+		val names = BeanUtils.getParameterNames(ctor)
+		assertThat(names).containsExactly("value")
+	}
+
 
 	class Foo(val param1: String, val param2: Int)
 

--- a/spring-beans/src/test/kotlin/org/springframework/beans/BeanUtilsKotlinTests.kt
+++ b/spring-beans/src/test/kotlin/org/springframework/beans/BeanUtilsKotlinTests.kt
@@ -93,7 +93,6 @@ class BeanUtilsKotlinTests {
 	@Test
 	fun `Instantiate value class`() {
 		val constructor = BeanUtils.findPrimaryConstructor(ValueClass::class.java)!!
-		assertThat(constructor).isNotNull()
 		val value = "Hello value class!"
 		val instance = BeanUtils.instantiateClass(constructor, value)
 		assertThat(instance).isEqualTo(ValueClass(value))
@@ -102,7 +101,6 @@ class BeanUtilsKotlinTests {
 	@Test
 	fun `Instantiate value class with multiple constructors`() {
 		val constructor = BeanUtils.findPrimaryConstructor(ValueClassWithMultipleConstructors::class.java)!!
-		assertThat(constructor).isNotNull()
 		val value = "Hello value class!"
 		val instance = BeanUtils.instantiateClass(constructor, value)
 		assertThat(instance).isEqualTo(ValueClassWithMultipleConstructors(value))
@@ -111,7 +109,6 @@ class BeanUtilsKotlinTests {
 	@Test
 	fun `Instantiate class with value class parameter`() {
 		val constructor = BeanUtils.findPrimaryConstructor(ConstructorWithValueClass::class.java)!!
-		assertThat(constructor).isNotNull()
 		val value = ValueClass("Hello value class!")
 		val instance = BeanUtils.instantiateClass(constructor, value)
 		assertThat(instance).isEqualTo(ConstructorWithValueClass(value))
@@ -120,7 +117,6 @@ class BeanUtilsKotlinTests {
 	@Test
 	fun `Instantiate class with nullable value class parameter`() {
 		val constructor = BeanUtils.findPrimaryConstructor(ConstructorWithNullableValueClass::class.java)!!
-		assertThat(constructor).isNotNull()
 		val value = ValueClass("Hello value class!")
 		var instance = BeanUtils.instantiateClass(constructor, value)
 		assertThat(instance).isEqualTo(ConstructorWithNullableValueClass(value))
@@ -131,7 +127,6 @@ class BeanUtilsKotlinTests {
 	@Test
 	fun `Instantiate primitive value class`() {
 		val constructor = BeanUtils.findPrimaryConstructor(PrimitiveValueClass::class.java)!!
-		assertThat(constructor).isNotNull()
 		val value = 0
 		val instance = BeanUtils.instantiateClass(constructor, value)
 		assertThat(instance).isEqualTo(PrimitiveValueClass(value))
@@ -140,7 +135,6 @@ class BeanUtilsKotlinTests {
 	@Test
 	fun `Instantiate class with primitive value class parameter`() {
 		val constructor = BeanUtils.findPrimaryConstructor(ConstructorWithPrimitiveValueClass::class.java)!!
-		assertThat(constructor).isNotNull()
 		val value = PrimitiveValueClass(0)
 		val instance = BeanUtils.instantiateClass(constructor, value)
 		assertThat(instance).isEqualTo(ConstructorWithPrimitiveValueClass(value))
@@ -149,7 +143,6 @@ class BeanUtilsKotlinTests {
 	@Test
 	fun `Instantiate class with nullable primitive value class parameter`() {
 		val constructor = BeanUtils.findPrimaryConstructor(ConstructorWithNullablePrimitiveValueClass::class.java)!!
-		assertThat(constructor).isNotNull()
 		val value = PrimitiveValueClass(0)
 		var instance = BeanUtils.instantiateClass(constructor, value)
 		assertThat(instance).isEqualTo(ConstructorWithNullablePrimitiveValueClass(value))
@@ -189,7 +182,6 @@ class BeanUtilsKotlinTests {
 	@Test
 	fun `getParameterNames filters out DefaultConstructorMarker with ConstructorWithValueClass`() {
 		val ctor = BeanUtils.findPrimaryConstructor(ConstructorWithValueClass::class.java)!!
-		assertThat(ctor).isNotNull()
 		val names = BeanUtils.getParameterNames(ctor)
 		assertThat(names).containsExactly("value")
 	}
@@ -197,7 +189,6 @@ class BeanUtilsKotlinTests {
 	@Test
 	fun `getParameterNames filters out DefaultConstructorMarker with ConstructorWithNullableValueClass`() {
 		val ctor = BeanUtils.findPrimaryConstructor(ConstructorWithNullableValueClass::class.java)!!
-		assertThat(ctor).isNotNull()
 		val names = BeanUtils.getParameterNames(ctor)
 		assertThat(names).containsExactly("value")
 	}
@@ -205,7 +196,6 @@ class BeanUtilsKotlinTests {
 	@Test
 	fun `getParameterNames filters out DefaultConstructorMarker with ConstructorWithPrimitiveValueClass`() {
 		val ctor = BeanUtils.findPrimaryConstructor(ConstructorWithPrimitiveValueClass::class.java)!!
-		assertThat(ctor).isNotNull()
 		val names = BeanUtils.getParameterNames(ctor)
 		assertThat(names).containsExactly("value")
 	}
@@ -213,7 +203,6 @@ class BeanUtilsKotlinTests {
 	@Test
 	fun `getParameterNames filters out DefaultConstructorMarker with ConstructorWithNullablePrimitiveValueClass`() {
 		val ctor = BeanUtils.findPrimaryConstructor(ConstructorWithNullablePrimitiveValueClass::class.java)!!
-		assertThat(ctor).isNotNull()
 		val names = BeanUtils.getParameterNames(ctor)
 		assertThat(names).containsExactly("value")
 	}


### PR DESCRIPTION
[Issue#34760](https://github.com/spring-projects/spring-framework/issues/34760)

## Description

When a Kotlin value class is used as a constructor parameter, the compiler generates an extra synthetic parameter of type `kotlin.jvm.internal.DefaultConstructorMarker`.

When this step is executed:
```java
@Nullable String[] paramNames = (cp != null ? cp.value() : parameterNameDiscoverer.getParameterNames(ctor));
```
It will call `KotlinReflectionParameterNameDiscoverer#getParameterNames(List<KParameter>)`, where `ReflectJvmMapping#getKotlinFunction` is called to convert a constructor into a function. `DefaultConstructorMarker` will be dropped after the conversion. This then causes a mismatch between the number of parameter names discovered and the actual constructor parameter count in `BeanUtils#getParameterNames`:
```java
Assert.state(paramNames.length == ctor.getParametersCount(),
            () -> "Invalid number of parameter names: " + paramNames.length + " for constructor " + ctor);
```
Since `DefaultConstructorMarker` exists solely to prevent signature clashes, it is safe to exclude it from the parameter count. Similar thought as in: [Ignore binding Kotlin synthetic default constructors](https://github.com/dotnet/java-interop/issues/694)

## Proposed Change
Replace the existing assertion with:
```java
long realParamsCount = Arrays.stream(ctor.getParameters())
        .filter(p -> !DefaultConstructorMarker.class.equals(p.getType()))
        .count();
Assert.state(paramNames.length == realParamsCount,
        () -> "Invalid number of parameter names: " + paramNames.length + " for constructor " + ctor);
```

## Tests
Added new cases to `BeanUtilsKotlinTests` to test `BeanUtils#getParameterNames`.