### PR TITLE
Align ClassFileClassMetadata with other implementations

### DIFF
--- a/spring-core/src/main/java24/org/springframework/core/type/classreading/ClassFileClassMetadata.java
+++ b/spring-core/src/main/java24/org/springframework/core/type/classreading/ClassFileClassMetadata.java
@@ -72,7 +72,7 @@ class ClassFileClassMetadata implements AnnotationMetadata {
 		this.className = className;
 		this.accessFlags = accessFlags;
 		this.enclosingClassName = enclosingClassName;
-		this.superClassName = superClassName;
+		this.superClassName = (!className.endsWith(".package-info")) ? superClassName : null;
 		this.independentInnerClass = independentInnerClass;
 		this.interfaceNames = interfaceNames;
 		this.memberClassNames = memberClassNames;

--- a/spring-core/src/main/java24/org/springframework/core/type/classreading/ClassFileClassMetadata.java
+++ b/spring-core/src/main/java24/org/springframework/core/type/classreading/ClassFileClassMetadata.java
@@ -268,18 +268,16 @@ class ClassFileClassMetadata implements AnnotationMetadata {
 		void nestMembers(String currentClassName, InnerClassesAttribute innerClasses) {
 			for (InnerClassInfo classInfo : innerClasses.classes()) {
 				String innerClassName = classInfo.innerClass().name().stringValue();
-				// skip parent inner classes
-				if (!innerClassName.startsWith(currentClassName)) {
-					continue;
-				}
-				// the current class is an inner class
-				else if (currentClassName.equals(innerClassName)) {
+				if (currentClassName.equals(innerClassName)) {
+					// the current class is an inner class
 					this.innerAccessFlags = classInfo.flags();
 				}
-				// collecting data about actual inner classes
-				else {
-					this.memberClassNames.add(ClassUtils.convertResourcePathToClassName(innerClassName));
-				}
+				classInfo.outerClass().ifPresent(outerClass -> {
+					if (outerClass.name().stringValue().equals(currentClassName)) {
+						// collecting data about actual inner classes
+						this.memberClassNames.add(ClassUtils.convertResourcePathToClassName(innerClassName));
+					}
+				});
 			}
 		}
 

--- a/spring-core/src/test/java/org/springframework/core/type/AbstractAnnotationMetadataTests.java
+++ b/spring-core/src/test/java/org/springframework/core/type/AbstractAnnotationMetadataTests.java
@@ -162,6 +162,12 @@ public abstract class AbstractAnnotationMetadataTests {
 		}
 
 		@Test
+		void getSuperClassNameWhenPackageInfoReturnsNull() throws Exception {
+			Class<?> packageClass = Class.forName(getClass().getPackageName() + ".package-info");
+			assertThat(get(packageClass).getSuperClassName()).isNull();
+		}
+
+		@Test
 		void getInterfaceNamesWhenHasInterfacesReturnsNames() {
 			assertThat(get(TestSubclass.class).getInterfaceNames()).containsExactly(TestInterface.class.getName());
 			assertThat(get(TestSubInterface.class).getInterfaceNames()).containsExactly(TestInterface.class.getName());

--- a/spring-core/src/test/java/org/springframework/core/type/AbstractAnnotationMetadataTests.java
+++ b/spring-core/src/test/java/org/springframework/core/type/AbstractAnnotationMetadataTests.java
@@ -185,6 +185,13 @@ public abstract class AbstractAnnotationMetadataTests {
 		}
 
 		@Test
+		void getMemberClassNamesWhenHasNestedMemberClassesReturnsOnlyFirstLevel() {
+			assertThat(get(TestNestedMemberClass.class).getMemberClassNames()).containsOnly(
+					TestNestedMemberClass.TestMemberClassInnerClassA.class.getName(),
+					TestNestedMemberClass.TestMemberClassInnerClassB.class.getName());
+		}
+
+		@Test
 		void getMemberClassNamesWhenHasNoMemberClassesReturnsEmptyArray() {
 			assertThat(get(TestClass.class).getMemberClassNames()).isEmpty();
 		}
@@ -216,6 +223,22 @@ public abstract class AbstractAnnotationMetadataTests {
 			}
 
 			interface TestMemberClassInnerInterface {
+			}
+
+		}
+
+		public static class TestNestedMemberClass {
+
+			public static class TestMemberClassInnerClassA {
+
+				public static class TestMemberClassInnerClassAA {
+
+				}
+
+			}
+
+			public static class TestMemberClassInnerClassB {
+
 			}
 
 		}

--- a/spring-core/src/test/java/org/springframework/core/type/classreading/DefaultAnnotationMetadataTests.java
+++ b/spring-core/src/test/java/org/springframework/core/type/classreading/DefaultAnnotationMetadataTests.java
@@ -21,18 +21,18 @@ import org.springframework.core.type.AnnotationMetadata;
 
 /**
  * Tests for {@link SimpleAnnotationMetadata} and
- * {@link SimpleAnnotationMetadataReadingVisitor}.
+ * {@link SimpleAnnotationMetadataReadingVisitor} on Java < 24,
+ * and for the ClassFile API variant on Java >= 24.
  *
  * @author Phillip Webb
  */
-class SimpleAnnotationMetadataTests extends AbstractAnnotationMetadataTests {
+class DefaultAnnotationMetadataTests extends AbstractAnnotationMetadataTests {
 
 	@Override
 	protected AnnotationMetadata get(Class<?> source) {
 		try {
-			return new SimpleMetadataReaderFactory(
-					source.getClassLoader()).getMetadataReader(
-							source.getName()).getAnnotationMetadata();
+			return MetadataReaderFactory.create(source.getClassLoader())
+					.getMetadataReader(source.getName()).getAnnotationMetadata();
 		}
 		catch (Exception ex) {
 			throw new IllegalStateException(ex);


### PR DESCRIPTION
Return null for getSuperClassName() with package-info classes:

Upgrading Spring Boot to use Framework 7 hit an issue with `spring-hateoas` and AOT hints.

```
at org.springframework.aot.hint.SimpleTypeReference.of(SimpleTypeReference.java:47)	
	at org.springframework.aot.hint.TypeReference.of(TypeReference.java:85)	
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:215)	
	at java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:215)	
	at java.util.Iterator.forEachRemaining(Iterator.java:133)	
	at java.util.Spliterators$IteratorSpliterator.forEachRemaining(Spliterators.java:1939)	
	at java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:570)	
	at java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:560)	
	at java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:153)	
	at java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:176)	
	at java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:265)	
	at java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:636)	
	at org.springframework.hateoas.aot.AotUtils.registerTypesForReflection(AotUtils.java:109)
```

This is ultimately caused by a change in behavior when running on Java 24. With earlier versions, the `registerTypesForReflection` uses a scanner that uses a `SimpleAnnotationMetadataReader`. This scanner always returns `null` for `getSuperClassName()` results from `package-info` classes. It appears that `ClassFileClassMetadata` returns `Object.class`.

This seems like a possible bug in the new class file Java API, but I think we should add a workaround in our code as well.