### PR TITLE
Fix for parameter position Error that occurs when binding the same Collection multiple times in R2DBC DatabaseClient

### DIFF
--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/NamedParameterUtils.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/core/NamedParameterUtils.java
@@ -526,17 +526,19 @@ abstract class NamedParameterUtils {
 				return;
 			}
 			if (parameter.getValue() instanceof Collection collection) {
-				Iterator<Object> iterator = collection.iterator();
 				Iterator<BindMarker> markers = bindMarkers.iterator();
-				while (iterator.hasNext()) {
-					Object valueToBind = iterator.next();
-					if (valueToBind instanceof Object[] objects) {
-						for (Object object : objects) {
-							bind(target, markers, object);
+				while(markers.hasNext()){
+					Iterator<Object> iterator = collection.iterator();
+					while (iterator.hasNext()) {
+						Object valueToBind = iterator.next();
+						if (valueToBind instanceof Object[] objects) {
+							for (Object object : objects) {
+								bind(target, markers, object);
+							}
 						}
-					}
-					else {
-						bind(target, markers, valueToBind);
+						else {
+							bind(target, markers, valueToBind);
+						}
 					}
 				}
 			}

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/NamedParameterUtilsTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/core/NamedParameterUtilsTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.r2dbc.core;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -497,6 +498,66 @@ class NamedParameterUtilsTests {
 				.containsEntry(0, Parameters.in(String.class));
 	}
 
+	@Test
+	void multipleInParameterReferencesBindsMultiple(){
+		List<String> userIds = List.of("user1", "user2", "user3");
+		String sql = """
+				SELECT * FROM PERSON
+				WHERE name IN (:ids)
+				GROUP BY address
+
+				UNION
+
+				SELECT * FROM PERSON
+				WHERE name NOT IN (:ids)
+				""";
+
+		BindMarkersFactory factory = BindMarkersFactory.anonymous("?");
+
+		PreparedOperation<String> operation = NamedParameterUtils.substituteNamedParameters(
+				sql, factory, new MapBindParameterSource(
+						Collections.singletonMap("ids", Parameters.in(userIds))));
+
+		assertThat(operation.toQuery()).isEqualTo(
+				"""
+				SELECT * FROM PERSON
+				WHERE name IN (?, ?, ?)
+				GROUP BY address
+
+				UNION
+
+				SELECT * FROM PERSON
+				WHERE name NOT IN (?, ?, ?)
+						""");
+		final String[] expectedValues = {"user1", "user2", "user3", "user1", "user2", "user3"};
+		final int[] bindingCount = {0};
+		final boolean[] isBinding = new boolean[6];
+		final String[] bindingValue = new String[6];
+		operation.bindTo(new BindTarget() {
+
+			@Override
+			public void bind(String identifier, Object value) {
+				throw new UnsupportedOperationException();
+			}
+			@Override
+			public void bind(int index, Object value) {
+				bindingCount[0]++;
+				isBinding[index] = true;
+				bindingValue[index] = (String) value;
+			}
+			@Override
+			public void bindNull(String identifier, Class<?> type) {
+				throw new UnsupportedOperationException();
+			}
+			@Override
+			public void bindNull(int index, Class<?> type) {
+				throw new UnsupportedOperationException();
+			}
+		});
+		assertThat(bindingCount[0]).isEqualTo(6);
+		assertThat(isBinding).containsExactly(true, true, true, true, true, true);
+		assertThat(bindingValue).containsExactly(expectedValues);
+	}
 
 	private static String expand(ParsedSql sql) {
 		return NamedParameterUtils.substituteNamedParameters(sql, INDEXED_MARKERS,


### PR DESCRIPTION
While developing with R2DBC DatabaseClient, an error occurred with the message 'Parameter at position 3 is not set' during the process of binding a Collection multiple times.

[Example SQL]
```
SELECT * 
FROM PERSON
WHERE name IN (:ids)
GROUP BY address

UNION

SELECT * 
FROM PERSON
WHERE name NOT IN (:ids)
```
[Execute Code]
```java
    List<String> ids = List.of("1", "2", "3");

    return databaseClient.sql(query)
        .bind("ids", ids)
        .map((row, rowMetadata) -> row.get("name", String.class))
        .all();

```

[Exception]
```
java.lang.IllegalStateException: Parameter at position 3 is not set
```
When debugging the related code, we confirmed that while it was retrieving the marking and index information, it was replacing the Collection values with information that had only been marked once.

We modified the code that replaces Collections according to marking and index information to ensure it doesn't execute only once, and we've written related test code.

[Modified]
When binding a Collection multiple times, n `BindMarkers` are created for the collection, so we modified the code to repeat the marking process if there is remaining mark information for the collection, ensuring the binding process executes n times.

