### PR TITLE
Update outdated JettyHttpHandlerAdapter example in reference documentation

### DIFF
--- a/framework-docs/modules/ROOT/pages/web/webflux/reactive-spring.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webflux/reactive-spring.adoc
@@ -176,36 +176,33 @@ Java::
 [source,java,indent=0,subs="verbatim,quotes"]
 ----
 	HttpHandler handler = ...
-	Servlet servlet = new JettyHttpHandlerAdapter(handler);
+	JettyCoreHttpHandlerAdapter adapter = new JettyCoreHttpHandlerAdapter(handler);
 
 	Server server = new Server();
-	ServletContextHandler contextHandler = new ServletContextHandler(server, "");
-	contextHandler.addServlet(new ServletHolder(servlet), "/");
-	contextHandler.start();
-
 	ServerConnector connector = new ServerConnector(server);
 	connector.setHost(host);
 	connector.setPort(port);
 	server.addConnector(connector);
+
+	server.setHandler(adapter);
 	server.start();
 ----
+NOTE: As of Spring Framework 6.2, `JettyHttpHandlerAdapter` has been deprecated in favor of `JettyCoreHttpHandlerAdapter` which provides better integration with Jetty 12.
 
 Kotlin::
 +
 [source,kotlin,indent=0,subs="verbatim,quotes"]
 ----
 	val handler: HttpHandler = ...
-	val servlet = JettyHttpHandlerAdapter(handler)
+	val adapter = JettyCoreHttpHandlerAdapter(handler)
 
 	val server = Server()
-	val contextHandler = ServletContextHandler(server, "")
-	contextHandler.addServlet(ServletHolder(servlet), "/")
-	contextHandler.start();
-
 	val connector = ServerConnector(server)
 	connector.host = host
 	connector.port = port
 	server.addConnector(connector)
+
+	server.setHandler(adapter)
 	server.start()
 ----
 ======
@@ -800,4 +797,3 @@ Kotlin::
 			.build()
 ----
 ======
-


### PR DESCRIPTION
This PR updates the outdated `JettyHttpHandlerAdapter` example in the reference documentation to use `JettyCoreHttpHandlerAdapter`, which is the recommended approach for Jetty 12+.

The change follows up on #33747 where `JettyHttpHandlerAdapter` was deprecated but the documentation was not updated.

## Changes
- Replace deprecated `JettyHttpHandlerAdapter` with `JettyCoreHttpHandlerAdapter` in both Java and Kotlin examples
- Simplify the server setup code to align with current best practices
- Add a note explaining the deprecation

Closes gh-34875