### PR TITLE
Remove unnecessary thenReturn in R2dbcTransactionManager

### DIFF
--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/R2dbcTransactionManager.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/R2dbcTransactionManager.java
@@ -219,7 +219,7 @@ public class R2dbcTransactionManager extends AbstractReactiveTransactionManager 
 						if (txObject.isNewConnectionHolder()) {
 							synchronizationManager.bindResource(obtainConnectionFactory(), txObject.getConnectionHolder());
 						}
-					}).thenReturn(con).onErrorResume(ex -> {
+					}).onErrorResume(ex -> {
 						if (txObject.isNewConnectionHolder()) {
 							return ConnectionFactoryUtils.releaseConnection(con, obtainConnectionFactory())
 									.doOnTerminate(() -> txObject.setConnectionHolder(null, false))


### PR DESCRIPTION
The onErrorResume() method uses the con value, but this value is not data received from thenReturn(), and since it doesn't use the data after thenReturn() chaining but proceeds with then(), I determined it was unnecessary and removed it.
