### PR TITLE
Add WebAsyncTask<V> to supported return types table in return-types.adoc

### DIFF
--- a/framework-docs/modules/ROOT/pages/web/webmvc/mvc-controller/ann-methods/return-types.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc/mvc-controller/ann-methods/return-types.adoc
@@ -77,6 +77,9 @@ supported for all return values.
 | Produce any of the above return values asynchronously in a Spring MVC-managed thread.
   See xref:web/webmvc/mvc-ann-async.adoc[Asynchronous Requests] and xref:web/webmvc/mvc-ann-async.adoc#mvc-ann-async-callable[`Callable`].
 
+| `WebAsyncTask<V>`
+| This is a holder for a `Callable` which allows you to set a custom asynchronous request timeout value and a custom  `AsyncTaskExecutor` if you want the `Callable` to be executed by a different `AsyncTaskExecutor` than the one used by default by Spring MVC.
+
 | `ListenableFuture<V>`,
   `java.util.concurrent.CompletionStage<V>`,
   `java.util.concurrent.CompletableFuture<V>`


### PR DESCRIPTION
This update adds  WebAsyncTask<V> return type to the table showing all the return types supported by @Controller class's methods.
It helps ensure the documentation reflects all officially supported async return types, improving clarity for developers using Spring MVC's asynchronous processing features.