### PR TITLE
Make `ProblemDetailJacksonXmlMixin` compatible with Jackson 3

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/json/ProblemDetailJacksonXmlMixin.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/ProblemDetailJacksonXmlMixin.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.annotation.JsonRootName;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import org.jspecify.annotations.Nullable;
 
@@ -40,36 +40,43 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
  * <a href="https://github.com/FasterXML/jackson-dataformat-xml/issues/355">FasterXML/jackson-dataformat-xml#355</a>.
  *
  * @author Rossen Stoyanchev
+ * @author Sebastien Deleuze
  * @since 6.0.5
  */
 @JsonInclude(NON_EMPTY)
 @JacksonXmlRootElement(localName = "problem", namespace = ProblemDetailJacksonXmlMixin.NAMESPACE)
+@JsonRootName(value = "problem", namespace = ProblemDetailJacksonXmlMixin.NAMESPACE)
 public interface ProblemDetailJacksonXmlMixin {
 
 	/** RFC 7807 (obsoleted by RFC 9457) namespace. */
 	String NAMESPACE = "urn:ietf:rfc:7807";
 
 
-	@JacksonXmlProperty(namespace = NAMESPACE)
+	@com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty(namespace = NAMESPACE)
+	@tools.jackson.dataformat.xml.annotation.JacksonXmlProperty(namespace = NAMESPACE)
 	URI getType();
 
-	@JacksonXmlProperty(namespace = NAMESPACE)
+	@com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty(namespace = NAMESPACE)
+	@tools.jackson.dataformat.xml.annotation.JacksonXmlProperty(namespace = NAMESPACE)
 	String getTitle();
 
-	@JacksonXmlProperty(namespace = NAMESPACE)
+	@com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty(namespace = NAMESPACE)
+	@tools.jackson.dataformat.xml.annotation.JacksonXmlProperty(namespace = NAMESPACE)
 	int getStatus();
 
-	@JacksonXmlProperty(namespace = NAMESPACE)
+	@com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty(namespace = NAMESPACE)
+	@tools.jackson.dataformat.xml.annotation.JacksonXmlProperty(namespace = NAMESPACE)
 	String getDetail();
 
-	@JacksonXmlProperty(namespace = NAMESPACE)
+	@com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty(namespace = NAMESPACE)
+	@tools.jackson.dataformat.xml.annotation.JacksonXmlProperty(namespace = NAMESPACE)
 	URI getInstance();
 
 	@JsonAnySetter
 	void setProperty(String name, @Nullable Object value);
 
 	@JsonAnyGetter
-	@JacksonXmlProperty(namespace = NAMESPACE)
+	@com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty(namespace = NAMESPACE)
 	Map<String, Object> getProperties();
 
 }

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyMethodProcessorTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyMethodProcessorTests.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonView;
 import org.jspecify.annotations.Nullable;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
 import org.xmlunit.assertj.XmlAssert;
@@ -413,7 +412,6 @@ class RequestResponseBodyMethodProcessorTests {
 	}
 
 	@Test
-	@Disabled("https://github.com/FasterXML/jackson-dataformat-xml/issues/757")
 	void problemDetailWhenProblemXmlRequested() throws Exception {
 		this.servletRequest.addHeader("Accept", MediaType.APPLICATION_PROBLEM_XML_VALUE);
 		testProblemDetailMediaType(MediaType.APPLICATION_PROBLEM_XML_VALUE);


### PR DESCRIPTION
As a follow-up to #33798 and https://github.com/FasterXML/jackson-dataformat-xml/issues/757#issuecomment-2884064584, this PR intends to make `ProblemDetailJacksonXmlMixin` compatible with Jackson 3.

@rstoyanchev Could you please check if the proposed solution is fine or not? I am unsure given the Javadoc comment mentioning that due to https://github.com/FasterXML/jackson-dataformat-xml/issues/355, `@JsonRootName` can't be used. But in Jackson 3, `JacksonXmlRootElement` is deprecated and the tests are green with Jackson 3 + `@JsonRootName`, so I would need your feedback to know if this can be merged or not. I will refine the potentially outdated Javadoc based on your feedback.