### PR TITLE
Refactor: Replace unnecessary else block with early return for improved readability

### DIFF
--- a/buildSrc/src/main/java/org/springframework/build/architecture/ArchitectureCheck.java
+++ b/buildSrc/src/main/java/org/springframework/build/architecture/ArchitectureCheck.java
@@ -94,9 +94,7 @@ public abstract class ArchitectureCheck extends DefaultTask {
 					StandardOpenOption.TRUNCATE_EXISTING);
 			throw new GradleException("Architecture check failed. See '" + outputFile + "' for details.");
 		}
-		else {
-			outputFile.createNewFile();
-		}
+		outputFile.createNewFile();
 	}
 
 	public void setClasses(FileCollection classes) {

--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/AbstractAspectJAdvice.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/AbstractAspectJAdvice.java
@@ -300,17 +300,16 @@ public abstract class AbstractAspectJAdvice implements Advice, AspectJPrecedence
 		// name could be a variable or a type...
 		if (isVariableName(name)) {
 			this.returningName = name;
+			return;
 		}
-		else {
-			// assume a type
-			try {
-				this.discoveredReturningType = ClassUtils.forName(name, getAspectClassLoader());
-			}
-			catch (Throwable ex) {
-				throw new IllegalArgumentException("Returning name '" + name +
-						"' is neither a valid argument name nor the fully-qualified " +
-						"name of a Java type on the classpath. Root cause: " + ex);
-			}
+		// assume a type
+		try {
+			this.discoveredReturningType = ClassUtils.forName(name, getAspectClassLoader());
+		}
+		catch (Throwable ex) {
+			throw new IllegalArgumentException("Returning name '" + name +
+					"' is neither a valid argument name nor the fully-qualified " +
+					"name of a Java type on the classpath. Root cause: " + ex);
 		}
 	}
 
@@ -334,17 +333,16 @@ public abstract class AbstractAspectJAdvice implements Advice, AspectJPrecedence
 		// name could be a variable or a type...
 		if (isVariableName(name)) {
 			this.throwingName = name;
+			return;
 		}
-		else {
-			// assume a type
-			try {
-				this.discoveredThrowingType = ClassUtils.forName(name, getAspectClassLoader());
-			}
-			catch (Throwable ex) {
-				throw new IllegalArgumentException("Throwing name '" + name +
-						"' is neither a valid argument name nor the fully-qualified " +
-						"name of a Java type on the classpath. Root cause: " + ex);
-			}
+		// assume a type
+		try {
+			this.discoveredThrowingType = ClassUtils.forName(name, getAspectClassLoader());
+		}
+		catch (Throwable ex) {
+			throw new IllegalArgumentException("Throwing name '" + name +
+					"' is neither a valid argument name nor the fully-qualified " +
+					"name of a Java type on the classpath. Root cause: " + ex);
 		}
 	}
 
@@ -397,9 +395,7 @@ public abstract class AbstractAspectJAdvice implements Advice, AspectJPrecedence
 			this.joinPointArgumentIndex = 0;
 			return true;
 		}
-		else {
-			return false;
-		}
+		return false;
 	}
 
 	private boolean maybeBindProceedingJoinPoint(Class<?> candidateParameterType) {
@@ -410,9 +406,7 @@ public abstract class AbstractAspectJAdvice implements Advice, AspectJPrecedence
 			this.joinPointArgumentIndex = 0;
 			return true;
 		}
-		else {
-			return false;
-		}
+		return false;
 	}
 
 	protected boolean supportsProceedingJoinPoint() {
@@ -424,9 +418,7 @@ public abstract class AbstractAspectJAdvice implements Advice, AspectJPrecedence
 			this.joinPointStaticPartArgumentIndex = 0;
 			return true;
 		}
-		else {
-			return false;
-		}
+		return false;
 	}
 
 	private void bindArgumentsByName(int numArgumentsExpectingToBind) {

--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJAdviceParameterNameDiscoverer.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJAdviceParameterNameDiscoverer.java
@@ -258,24 +258,18 @@ public class AspectJAdviceParameterNameDiscoverer implements ParameterNameDiscov
 			if (this.raiseExceptions) {
 				throw ex;
 			}
-			else {
-				return null;
-			}
+			return null;
 		}
 
 		if (this.numberOfRemainingUnboundArguments == 0) {
 			return this.parameterNameBindings;
 		}
-		else {
-			if (this.raiseExceptions) {
-				throw new IllegalStateException("Failed to bind all argument names: " +
-						this.numberOfRemainingUnboundArguments + " argument(s) could not be bound");
-			}
-			else {
-				// convention for failing is to return null, allowing participation in a chain of responsibility
-				return null;
-			}
+		if (this.raiseExceptions) {
+			throw new IllegalStateException("Failed to bind all argument names: " +
+					this.numberOfRemainingUnboundArguments + " argument(s) could not be bound");
 		}
+		// convention for failing is to return null, allowing participation in a chain of responsibility
+		return null;
 	}
 
 	/**

--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJAfterReturningAdvice.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJAfterReturningAdvice.java
@@ -103,9 +103,7 @@ public class AspectJAfterReturningAdvice extends AbstractAspectJAdvice
 		else if (Object.class == type && void.class == method.getReturnType()) {
 			return true;
 		}
-		else {
-			return ClassUtils.isAssignable(type, method.getReturnType());
-		}
+		return ClassUtils.isAssignable(type, method.getReturnType());
 	}
 
 }

--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJExpressionPointcut.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJExpressionPointcut.java
@@ -315,18 +315,16 @@ public class AspectJExpressionPointcut extends AbstractExpressionPointcut
 		else if (shadowMatch.neverMatches()) {
 			return false;
 		}
-		else {
-			// the maybe case
-			if (hasIntroductions) {
-				return true;
-			}
-			// A match test returned maybe - if there are any subtype sensitive variables
-			// involved in the test (this, target, at_this, at_target, at_annotation) then
-			// we say this is not a match as in Spring there will never be a different
-			// runtime subtype.
-			RuntimeTestWalker walker = getRuntimeTestWalker(shadowMatch);
-			return (!walker.testsSubtypeSensitiveVars() || walker.testTargetInstanceOfResidue(targetClass));
+		// the maybe case
+		if (hasIntroductions) {
+			return true;
 		}
+		// A match test returned maybe - if there are any subtype sensitive variables
+		// involved in the test (this, target, at_this, at_target, at_annotation) then
+		// we say this is not a match as in Spring there will never be a different
+		// runtime subtype.
+		RuntimeTestWalker walker = getRuntimeTestWalker(shadowMatch);
+		return (!walker.testsSubtypeSensitiveVars() || walker.testTargetInstanceOfResidue(targetClass));
 	}
 
 	@Override

--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJPointcutAdvisor.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/AspectJPointcutAdvisor.java
@@ -61,9 +61,7 @@ public class AspectJPointcutAdvisor implements PointcutAdvisor, Ordered {
 		if (this.order != null) {
 			return this.order;
 		}
-		else {
-			return this.advice.getOrder();
-		}
+        return this.advice.getOrder();
 	}
 
 	@Override

--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/annotation/AnnotationAwareAspectJAutoProxyCreator.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/annotation/AnnotationAwareAspectJAutoProxyCreator.java
@@ -119,14 +119,12 @@ public class AnnotationAwareAspectJAutoProxyCreator extends AspectJAwareAdvisorA
 		if (this.includePatterns == null) {
 			return true;
 		}
-		else {
-			for (Pattern pattern : this.includePatterns) {
-				if (pattern.matcher(beanName).matches()) {
-					return true;
-				}
+		for (Pattern pattern : this.includePatterns) {
+			if (pattern.matcher(beanName).matches()) {
+				return true;
 			}
-			return false;
 		}
+		return false;
 	}
 
 

--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/autoproxy/AspectJAwareAdvisorAutoProxyCreator.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/autoproxy/AspectJAwareAdvisorAutoProxyCreator.java
@@ -84,9 +84,7 @@ public class AspectJAwareAdvisorAutoProxyCreator extends AbstractAdvisorAutoProx
 			}
 			return result;
 		}
-		else {
-			return super.sortAdvisors(advisors);
-		}
+        return super.sortAdvisors(advisors);
 	}
 
 	/**

--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/autoproxy/AspectJPrecedenceComparator.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/autoproxy/AspectJPrecedenceComparator.java
@@ -102,9 +102,7 @@ class AspectJPrecedenceComparator implements Comparator<Advisor> {
 			else if (adviceDeclarationOrderDelta == 0) {
 				return SAME_PRECEDENCE;
 			}
-			else {
-				return HIGHER_PRECEDENCE;
-			}
+			return HIGHER_PRECEDENCE;
 		}
 		else {
 			// the advice declared first has higher precedence

--- a/spring-aop/src/main/java/org/springframework/aop/config/ConfigBeanDefinitionParser.java
+++ b/spring-aop/src/main/java/org/springframework/aop/config/ConfigBeanDefinitionParser.java
@@ -262,11 +262,9 @@ class ConfigBeanDefinitionParser implements BeanDefinitionParser {
 		if (!(aNode instanceof Element)) {
 			return false;
 		}
-		else {
-			String name = parserContext.getDelegate().getLocalName(aNode);
-			return (BEFORE.equals(name) || AFTER.equals(name) || AFTER_RETURNING_ELEMENT.equals(name) ||
-					AFTER_THROWING_ELEMENT.equals(name) || AROUND.equals(name));
-		}
+		String name = parserContext.getDelegate().getLocalName(aNode);
+		return (BEFORE.equals(name) || AFTER.equals(name) || AFTER_RETURNING_ELEMENT.equals(name) ||
+				AFTER_THROWING_ELEMENT.equals(name) || AROUND.equals(name));
 	}
 
 	/**
@@ -475,12 +473,10 @@ class ConfigBeanDefinitionParser implements BeanDefinitionParser {
 			}
 			return pointcutRef;
 		}
-		else {
-			parserContext.getReaderContext().error(
-					"Must define one of 'pointcut' or 'pointcut-ref' on <advisor> tag.",
-					element, this.parseState.snapshot());
-			return null;
-		}
+		parserContext.getReaderContext().error(
+				"Must define one of 'pointcut' or 'pointcut-ref' on <advisor> tag.",
+				element, this.parseState.snapshot());
+		return null;
 	}
 
 	/**

--- a/spring-aop/src/main/java/org/springframework/aop/config/SimpleBeanFactoryAwareAspectInstanceFactory.java
+++ b/spring-aop/src/main/java/org/springframework/aop/config/SimpleBeanFactoryAwareAspectInstanceFactory.java
@@ -72,9 +72,7 @@ public class SimpleBeanFactoryAwareAspectInstanceFactory implements AspectInstan
 		if (this.beanFactory instanceof ConfigurableBeanFactory cbf) {
 			return cbf.getBeanClassLoader();
 		}
-		else {
-			return ClassUtils.getDefaultClassLoader();
-		}
+        return ClassUtils.getDefaultClassLoader();
 	}
 
 	@Override

--- a/spring-tx/src/main/java/org/springframework/dao/support/PersistenceExceptionTranslationInterceptor.java
+++ b/spring-tx/src/main/java/org/springframework/dao/support/PersistenceExceptionTranslationInterceptor.java
@@ -139,23 +139,21 @@ public class PersistenceExceptionTranslationInterceptor
 			if (!this.alwaysTranslate && ReflectionUtils.declaresException(mi.getMethod(), ex.getClass())) {
 				throw ex;
 			}
-			else {
-				PersistenceExceptionTranslator translator = this.persistenceExceptionTranslator;
-				if (translator == null) {
-					Assert.state(this.beanFactory != null,
-							"Cannot use PersistenceExceptionTranslator autodetection without ListableBeanFactory");
-					try {
-						translator = detectPersistenceExceptionTranslators(this.beanFactory);
-					}
-					catch (BeanCreationNotAllowedException ex2) {
-						// Cannot create PersistenceExceptionTranslator bean on shutdown:
-						// fall back to rethrowing original exception without translation
-						throw ex;
-					}
-					this.persistenceExceptionTranslator = translator;
+			PersistenceExceptionTranslator translator = this.persistenceExceptionTranslator;
+			if (translator == null) {
+				Assert.state(this.beanFactory != null,
+						"Cannot use PersistenceExceptionTranslator autodetection without ListableBeanFactory");
+				try {
+					translator = detectPersistenceExceptionTranslators(this.beanFactory);
 				}
-				throw DataAccessUtils.translateIfNecessary(ex, translator);
+				catch (BeanCreationNotAllowedException ex2) {
+					// Cannot create PersistenceExceptionTranslator bean on shutdown:
+					// fall back to rethrowing original exception without translation
+					throw ex;
+				}
+				this.persistenceExceptionTranslator = translator;
 			}
+			throw DataAccessUtils.translateIfNecessary(ex, translator);
 		}
 	}
 

--- a/spring-tx/src/main/java/org/springframework/transaction/annotation/Ejb3TransactionAnnotationParser.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/annotation/Ejb3TransactionAnnotationParser.java
@@ -49,9 +49,7 @@ public class Ejb3TransactionAnnotationParser implements TransactionAnnotationPar
 		if (ann != null) {
 			return parseTransactionAnnotation(ann);
 		}
-		else {
-			return null;
-		}
+		return null;
 	}
 
 	public TransactionAttribute parseTransactionAnnotation(jakarta.ejb.TransactionAttribute ann) {

--- a/spring-tx/src/main/java/org/springframework/transaction/annotation/JtaTransactionAnnotationParser.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/annotation/JtaTransactionAnnotationParser.java
@@ -54,9 +54,7 @@ public class JtaTransactionAnnotationParser implements TransactionAnnotationPars
 		if (attributes != null) {
 			return parseTransactionAnnotation(attributes);
 		}
-		else {
-			return null;
-		}
+		return null;
 	}
 
 	public TransactionAttribute parseTransactionAnnotation(jakarta.transaction.Transactional ann) {

--- a/spring-tx/src/main/java/org/springframework/transaction/annotation/SpringTransactionAnnotationParser.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/annotation/SpringTransactionAnnotationParser.java
@@ -58,9 +58,7 @@ public class SpringTransactionAnnotationParser implements TransactionAnnotationP
 		if (attributes != null) {
 			return parseTransactionAnnotation(attributes);
 		}
-		else {
-			return null;
-		}
+		return null;
 	}
 
 	public TransactionAttribute parseTransactionAnnotation(Transactional ann) {

--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/AbstractFallbackTransactionAttributeSource.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/AbstractFallbackTransactionAttributeSource.java
@@ -118,24 +118,22 @@ public abstract class AbstractFallbackTransactionAttributeSource
 		if (cached != null) {
 			return (cached != NULL_TRANSACTION_ATTRIBUTE ? cached : null);
 		}
-		else {
-			TransactionAttribute txAttr = computeTransactionAttribute(method, targetClass);
-			if (txAttr != null) {
-				String methodIdentification = ClassUtils.getQualifiedMethodName(method, targetClass);
-				if (txAttr instanceof DefaultTransactionAttribute dta) {
-					dta.setDescriptor(methodIdentification);
-					dta.resolveAttributeStrings(this.embeddedValueResolver);
-				}
-				if (logger.isTraceEnabled()) {
-					logger.trace("Adding transactional method '" + methodIdentification + "' with attribute: " + txAttr);
-				}
-				this.attributeCache.put(cacheKey, txAttr);
+		TransactionAttribute txAttr = computeTransactionAttribute(method, targetClass);
+		if (txAttr != null) {
+			String methodIdentification = ClassUtils.getQualifiedMethodName(method, targetClass);
+			if (txAttr instanceof DefaultTransactionAttribute dta) {
+				dta.setDescriptor(methodIdentification);
+				dta.resolveAttributeStrings(this.embeddedValueResolver);
 			}
-			else if (cacheNull) {
-				this.attributeCache.put(cacheKey, NULL_TRANSACTION_ATTRIBUTE);
+			if (logger.isTraceEnabled()) {
+				logger.trace("Adding transactional method '" + methodIdentification + "' with attribute: " + txAttr);
 			}
-			return txAttr;
+			this.attributeCache.put(cacheKey, txAttr);
 		}
+		else if (cacheNull) {
+			this.attributeCache.put(cacheKey, NULL_TRANSACTION_ATTRIBUTE);
+		}
+		return txAttr;
 	}
 
 	/**

--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/MethodMapTransactionAttributeSource.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/MethodMapTransactionAttributeSource.java
@@ -222,14 +222,12 @@ public class MethodMapTransactionAttributeSource
 		if (this.eagerlyInitialized) {
 			return this.transactionAttributeMap.get(method);
 		}
-		else {
-			synchronized (this.transactionAttributeMap) {
-				if (!this.initialized) {
-					initMethodMap(this.methodMap);
-					this.initialized = true;
-				}
-				return this.transactionAttributeMap.get(method);
+		synchronized (this.transactionAttributeMap) {
+			if (!this.initialized) {
+				initMethodMap(this.methodMap);
+				this.initialized = true;
 			}
+			return this.transactionAttributeMap.get(method);
 		}
 	}
 

--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/TransactionProxyFactoryBean.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/TransactionProxyFactoryBean.java
@@ -195,10 +195,8 @@ public class TransactionProxyFactoryBean extends AbstractSingletonProxyFactoryBe
 		if (this.pointcut != null) {
 			return new DefaultPointcutAdvisor(this.pointcut, this.transactionInterceptor);
 		}
-		else {
-			// Rely on default pointcut.
-			return new TransactionAttributeSourceAdvisor(this.transactionInterceptor);
-		}
+        // Rely on default pointcut.
+        return new TransactionAttributeSourceAdvisor(this.transactionInterceptor);
 	}
 
 	/**

--- a/spring-tx/src/main/java/org/springframework/transaction/jta/JtaTransactionManager.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/jta/JtaTransactionManager.java
@@ -540,9 +540,7 @@ public class JtaTransactionManager extends AbstractPlatformTransactionManager
 		if (transactionManager instanceof UserTransaction ut) {
 			return ut;
 		}
-		else {
-			return new UserTransactionAdapter(transactionManager);
-		}
+		return new UserTransactionAdapter(transactionManager);
 	}
 
 	/**

--- a/spring-tx/src/main/java/org/springframework/transaction/reactive/TransactionSynchronizationManager.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/reactive/TransactionSynchronizationManager.java
@@ -234,12 +234,10 @@ public class TransactionSynchronizationManager {
 		if (synchs.isEmpty()) {
 			return Collections.emptyList();
 		}
-		else {
-			// Sort lazily here, not in registerSynchronization.
-			List<TransactionSynchronization> sortedSynchs = new ArrayList<>(synchs);
-			AnnotationAwareOrderComparator.sort(sortedSynchs);
-			return Collections.unmodifiableList(sortedSynchs);
-		}
+		// Sort lazily here, not in registerSynchronization.
+		List<TransactionSynchronization> sortedSynchs = new ArrayList<>(synchs);
+		AnnotationAwareOrderComparator.sort(sortedSynchs);
+		return Collections.unmodifiableList(sortedSynchs);
 	}
 
 	/**

--- a/spring-tx/src/main/java/org/springframework/transaction/reactive/TransactionSynchronizationUtils.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/reactive/TransactionSynchronizationUtils.java
@@ -128,9 +128,7 @@ abstract class TransactionSynchronizationUtils {
 			if (resource instanceof ScopedObject scopedObject) {
 				return scopedObject.getTargetObject();
 			}
-			else {
-				return resource;
-			}
+			return resource;
 		}
 	}
 

--- a/spring-tx/src/main/java/org/springframework/transaction/support/AbstractPlatformTransactionManager.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/support/AbstractPlatformTransactionManager.java
@@ -409,15 +409,13 @@ public abstract class AbstractPlatformTransactionManager
 				throw ex;
 			}
 		}
-		else {
-			// Create "empty" transaction: no actual transaction, but potentially synchronization.
-			if (def.getIsolationLevel() != TransactionDefinition.ISOLATION_DEFAULT && logger.isWarnEnabled()) {
-				logger.warn("Custom isolation level specified but no actual transaction initiated; " +
-						"isolation level will effectively be ignored: " + def);
-			}
-			boolean newSynchronization = (getTransactionSynchronization() == SYNCHRONIZATION_ALWAYS);
-			return prepareTransactionStatus(def, null, true, newSynchronization, debugEnabled, null);
+		// Create "empty" transaction: no actual transaction, but potentially synchronization.
+		if (def.getIsolationLevel() != TransactionDefinition.ISOLATION_DEFAULT && logger.isWarnEnabled()) {
+			logger.warn("Custom isolation level specified but no actual transaction initiated; " +
+					"isolation level will effectively be ignored: " + def);
 		}
+		boolean newSynchronization = (getTransactionSynchronization() == SYNCHRONIZATION_ALWAYS);
+		return prepareTransactionStatus(def, null, true, newSynchronization, debugEnabled, null);
 	}
 
 	/**
@@ -483,12 +481,10 @@ public abstract class AbstractPlatformTransactionManager
 				this.transactionExecutionListeners.forEach(listener -> listener.afterBegin(status, null));
 				return status;
 			}
-			else {
-				// Nested transaction through nested begin and commit/rollback calls.
-				// Usually only for JTA: Spring synchronization might get activated here
-				// in case of a pre-existing JTA transaction.
-				return startTransaction(definition, transaction, true, debugEnabled, null);
-			}
+			// Nested transaction through nested begin and commit/rollback calls.
+			// Usually only for JTA: Spring synchronization might get activated here
+			// in case of a pre-existing JTA transaction.
+			return startTransaction(definition, transaction, true, debugEnabled, null);
 		}
 
 		// PROPAGATION_REQUIRED, PROPAGATION_SUPPORTS, PROPAGATION_MANDATORY:
@@ -641,10 +637,8 @@ public abstract class AbstractPlatformTransactionManager
 			Object suspendedResources = doSuspend(transaction);
 			return new SuspendedResourcesHolder(suspendedResources);
 		}
-		else {
-			// Neither transaction nor synchronization active.
-			return null;
-		}
+		// Neither transaction nor synchronization active.
+		return null;
 	}
 
 	/**

--- a/spring-tx/src/main/java/org/springframework/transaction/support/SimpleTransactionScope.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/support/SimpleTransactionScope.java
@@ -68,9 +68,7 @@ public class SimpleTransactionScope implements Scope {
 			scopedObjects.destructionCallbacks.remove(name);
 			return scopedObjects.scopedInstances.remove(name);
 		}
-		else {
-			return null;
-		}
+		return null;
 	}
 
 	@Override

--- a/spring-tx/src/main/java/org/springframework/transaction/support/TransactionSynchronizationManager.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/support/TransactionSynchronizationManager.java
@@ -297,12 +297,10 @@ public abstract class TransactionSynchronizationManager {
 		else if (synchs.size() == 1) {
 			return Collections.singletonList(synchs.iterator().next());
 		}
-		else {
-			// Sort lazily here, not in registerSynchronization.
-			List<TransactionSynchronization> sortedSynchs = new ArrayList<>(synchs);
-			OrderComparator.sort(sortedSynchs);
-			return Collections.unmodifiableList(sortedSynchs);
-		}
+		// Sort lazily here, not in registerSynchronization.
+		List<TransactionSynchronization> sortedSynchs = new ArrayList<>(synchs);
+		OrderComparator.sort(sortedSynchs);
+		return Collections.unmodifiableList(sortedSynchs);
 	}
 
 	/**

--- a/spring-tx/src/main/java/org/springframework/transaction/support/TransactionSynchronizationUtils.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/support/TransactionSynchronizationUtils.java
@@ -218,9 +218,7 @@ public abstract class TransactionSynchronizationUtils {
 			if (resource instanceof ScopedObject scopedObject) {
 				return scopedObject.getTargetObject();
 			}
-			else {
-				return resource;
-			}
+			return resource;
 		}
 	}
 

--- a/spring-tx/src/main/java/org/springframework/transaction/support/TransactionTemplate.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/support/TransactionTemplate.java
@@ -130,25 +130,23 @@ public class TransactionTemplate extends DefaultTransactionDefinition
 		if (this.transactionManager instanceof CallbackPreferringPlatformTransactionManager cpptm) {
 			return cpptm.execute(this, action);
 		}
-		else {
-			TransactionStatus status = this.transactionManager.getTransaction(this);
-			T result;
-			try {
-				result = action.doInTransaction(status);
-			}
-			catch (RuntimeException | Error ex) {
-				// Transactional code threw application exception -> rollback
-				rollbackOnException(status, ex);
-				throw ex;
-			}
-			catch (Throwable ex) {
-				// Transactional code threw unexpected exception -> rollback
-				rollbackOnException(status, ex);
-				throw new UndeclaredThrowableException(ex, "TransactionCallback threw undeclared checked exception");
-			}
-			this.transactionManager.commit(status);
-			return result;
+		TransactionStatus status = this.transactionManager.getTransaction(this);
+		T result;
+		try {
+			result = action.doInTransaction(status);
 		}
+		catch (RuntimeException | Error ex) {
+			// Transactional code threw application exception -> rollback
+			rollbackOnException(status, ex);
+			throw ex;
+		}
+		catch (Throwable ex) {
+			// Transactional code threw unexpected exception -> rollback
+			rollbackOnException(status, ex);
+			throw new UndeclaredThrowableException(ex, "TransactionCallback threw undeclared checked exception");
+		}
+		this.transactionManager.commit(status);
+		return result;
 	}
 
 	/**


### PR DESCRIPTION
### Summary

This pull request refactors a conditional block by replacing the `else` clause with an early return. The goal is to simplify the control flow and improve code readability in accordance with common Spring Framework code style practices.

### Motivation

- Reduces unnecessary nesting by eliminating `else` after a return statement.
- Aligns with the guard clause pattern used throughout the Spring Framework.
- Improves clarity by handling exceptional or edge cases early, allowing the "happy path" to remain more readable.

### Before
```java
if (condition) {
    // logic
    return;
} else {
    // logic
    return;
}
```

### After
```java
if (condition) {
    // logic
    return;
}
// logic
```