### PR TITLE
`PropertySourcesPlaceholderConfigurer` no longer uses `ConversionService` from `Environment`

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/support/PropertySourcesPlaceholderConfigurer.java
+++ b/spring-context/src/main/java/org/springframework/context/support/PropertySourcesPlaceholderConfigurer.java
@@ -172,6 +172,10 @@ public class PropertySourcesPlaceholderConfigurer extends PlaceholderConfigurerS
 	protected void processProperties(ConfigurableListableBeanFactory beanFactoryToProcess,
 			ConfigurablePropertyResolver propertyResolver) throws BeansException {
 
+		if(this.environment instanceof ApplicationServletEnvironment) {
+			propertyResolver.setConversionService(((ApplicationServletEnvironment) this.environment).getConversionService());
+		}
+		
 		propertyResolver.setPlaceholderPrefix(this.placeholderPrefix);
 		propertyResolver.setPlaceholderSuffix(this.placeholderSuffix);
 		propertyResolver.setValueSeparator(this.valueSeparator);


### PR DESCRIPTION
I noticed an issue with PropertySourcesPlaceholderConfigurer moving from spring framework 6.2.6 to 6.2.7.

Basically there is a new propertyResolver being created but it is not setting the environments configured conversion service. In the context of spring boot this could cause some issues if custom converters are registered as the propertyResolver if it doesn't have a conversion service set then uses the default and would not include any registered custom converters with the environment.

I don't think this PR is the exact correct fix and I didn't add any tests but this did resolve the issue with the propertyResolver having the environments conversion service. I figured this would be the best way to show the problem and how to fix it. If I have more time I can do a proper PR but might need some guidance if the fix is not in the right place.

If you look at PropertySourcesPlaceholderConfigurer in spring 6.2.6 you will see that the environments conversion service is set on the propertyResolver.