### PR TITLE
Fix `REPLY_CHANNEL` header check in `MessageHeaderAccessor`

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/support/MessageHeaderAccessor.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/support/MessageHeaderAccessor.java
@@ -331,7 +331,7 @@ public class MessageHeaderAccessor {
 	protected void verifyType(@Nullable String headerName, @Nullable Object headerValue) {
 		if (headerName != null && headerValue != null) {
 			if (MessageHeaders.ERROR_CHANNEL.equals(headerName) ||
-					MessageHeaders.REPLY_CHANNEL.endsWith(headerName)) {
+					MessageHeaders.REPLY_CHANNEL.equals(headerName)) {
 				if (!(headerValue instanceof MessageChannel || headerValue instanceof String)) {
 					throw new IllegalArgumentException(
 							"'" + headerName + "' header value must be a MessageChannel or String");

--- a/spring-messaging/src/test/java/org/springframework/messaging/support/MessageBuilderTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/support/MessageBuilderTests.java
@@ -34,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 /**
  * @author Mark Fisher
  * @author Rossen Stoyanchev
+ * @author Mengqi Xu
  */
 class MessageBuilderTests {
 
@@ -236,6 +237,23 @@ class MessageBuilderTests {
 		assertThat(message1.getHeaders().get("foo")).isEqualTo("bar1");
 		assertThat(message2.getHeaders().get("foo")).isEqualTo("bar2");
 		assertThat(message3.getHeaders().get("foo")).isEqualTo("bar3");
+	}
+
+	@Test
+	void buildReplyChannelHeaderMessage() {
+		MessageHeaderAccessor headerAccessor = new MessageHeaderAccessor();
+		MessageBuilder<?> messageBuilder = MessageBuilder.withPayload("payload").setHeaders(headerAccessor);
+
+		headerAccessor.setHeader("replyChannel", "foo");
+		Message<?> message1 = messageBuilder.build();
+
+		headerAccessor.setHeader("hannel", 0);
+		Message<?> message2 = messageBuilder.build();
+
+		assertThat(message1.getHeaders().get("replyChannel")).isEqualTo("foo");
+		assertThat(message2.getHeaders().get("hannel")).isEqualTo(0);
+
+		assertThatIllegalArgumentException().isThrownBy(() -> headerAccessor.setHeader("replyChannel", 0));
 	}
 
 }


### PR DESCRIPTION
Fix gh-34881.

When header name is `hannel` and header value is `0`. 
```java
headerAccessor.setHeader("hannel", 0);
```
It will throw `IllegalArgumentException` because `replyChannel` ends with `hannel` and header value is a integer.

