### PR TITLE
Fix typos in API versioning

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/accept/DefaultApiVersionStrategy.java
+++ b/spring-web/src/main/java/org/springframework/web/accept/DefaultApiVersionStrategy.java
@@ -49,8 +49,8 @@ public class DefaultApiVersionStrategy implements ApiVersionStrategy {
 	/**
 	 * Create an instance.
 	 * @param versionResolvers one or more resolvers to try; the first non-null
-	 * value returned by any resolver becomes the resolved used
-	 * @param versionParser parser for to raw version values
+	 * value returned by any resolver becomes the value used
+	 * @param versionParser parser for raw version values
 	 * @param versionRequired whether a version is required; if a request
 	 * does not have a version, and a {@code defaultVersion} is not specified,
 	 * validation fails with {@link MissingApiVersionException}

--- a/spring-web/src/main/java/org/springframework/web/accept/SemanticApiVersionParser.java
+++ b/spring-web/src/main/java/org/springframework/web/accept/SemanticApiVersionParser.java
@@ -22,8 +22,8 @@ import java.util.regex.Pattern;
 import org.springframework.util.Assert;
 
 /**
- * Parser for semantic API versioning with  a major, minor, and patch values.
- * For example "1", "1.0", "1.2", "1.2.0", "1.2.3". Leading, non-integer
+ * Parser for semantic API versioning with major, minor, and patch values.
+ * For example, "1", "1.0", "1.2", "1.2.0", "1.2.3". Leading, non-integer
  * characters, as in "v1.0", are skipped.
  *
  * @author Rossen Stoyanchev
@@ -31,7 +31,7 @@ import org.springframework.util.Assert;
  */
 public class SemanticApiVersionParser implements ApiVersionParser<SemanticApiVersionParser.Version> {
 
-	private static final Pattern semantinVersionPattern = Pattern.compile("^(\\d+)(\\.(\\d+))?(\\.(\\d+))?$");
+	private static final Pattern semanticVersionPattern = Pattern.compile("^(\\d+)(\\.(\\d+))?(\\.(\\d+))?$");
 
 
 	@Override
@@ -40,7 +40,7 @@ public class SemanticApiVersionParser implements ApiVersionParser<SemanticApiVer
 
 		version = skipNonDigits(version);
 
-		Matcher matcher = semantinVersionPattern.matcher(version);
+		Matcher matcher = semanticVersionPattern.matcher(version);
 		Assert.state(matcher.matches(), "Invalid API version format");
 
 		String major = matcher.group(1);


### PR DESCRIPTION
Fixes a few small typos I noticed when exploring the new API versioning code. 