### PR TITLE
Fix exception name in ModelAttribute docs

### DIFF
--- a/framework-docs/modules/ROOT/pages/web/webmvc/mvc-controller/ann-methods/modelattrib-method-args.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc/mvc-controller/ann-methods/modelattrib-method-args.adoc
@@ -243,7 +243,7 @@ Kotlin::
 ======
 
 If there is no `BindingResult` parameter after the `@ModelAttribute`, then
-`MethodArgumentNotValueException` is raised with the validation errors. However, if method
+a `MethodArgumentNotValidException` is raised with the validation errors. However, if method
 validation applies because other parameters have `@jakarta.validation.Constraint` annotations,
 then `HandlerMethodValidationException` is raised instead. For more details, see the section
 xref:web/webmvc/mvc-controller/ann-validation.adoc[Validation].


### PR DESCRIPTION
I am not aware of any `MethodArgumentNotValueException` therefore I'm confident that [`MethodArgumentNotValidException`](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/bind/MethodArgumentNotValidException.html) is correct.

Thanks 👍 