### PR TITLE
Check that Deprecated annotations have a "since" attribute

### DIFF
--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -27,6 +27,7 @@
 		<module name="com.puppycrawl.tools.checkstyle.checks.annotation.MissingOverrideCheck"/>
 		<module name="com.puppycrawl.tools.checkstyle.checks.annotation.PackageAnnotationCheck"/>
 		<module name="com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationLocationCheck"/>
+		<module name="io.spring.javaformat.checkstyle.check.SpringDeprecatedCheck" />
 
 		<!-- Block Checks -->
 		<module name="com.puppycrawl.tools.checkstyle.checks.blocks.EmptyBlockCheck">


### PR DESCRIPTION
This PR enforces a new architecture rule. Methods and Types annotated with `@Deprecated` should always have a "since" attribute.

@rstoyanchev I'm sending this as a PR because you're looking at the #34942 PR.
Merging this right now would fail the build as it identified failures that might not be covered by the PR:

```
Architecture Violation [Priority: MEDIUM] - Rule 'methods that are declared in classes that reside outside of packages ['org.springframework.asm..', 'org.springframework.cglib..', 'org.springframework.javapoet..', 'org.springframework.objenesis..'] and are annotated with @Deprecated should be annotated with @Deprecated(since="..."' was violated (63 times):
Method <org.springframework.core.GenericTypeResolver.resolveParameterType(org.springframework.core.MethodParameter, java.lang.Class)> is not annotated with @Deprecated(since="..." in (GenericTypeResolver.java:66)
Method <org.springframework.core.MethodParameter.decreaseNestingLevel()> is not annotated with @Deprecated(since="..." in (MethodParameter.java:282)
Method <org.springframework.core.MethodParameter.forMethodOrConstructor(java.lang.Object, int)> is not annotated with @Deprecated(since="..." in (MethodParameter.java:765)
Method <org.springframework.core.MethodParameter.increaseNestingLevel()> is not annotated with @Deprecated(since="..." in (MethodParameter.java:271)
Method <org.springframework.core.MethodParameter.setContainingClass(java.lang.Class)> is not annotated with @Deprecated(since="..." in (MethodParameter.java:434)
Method <org.springframework.core.MethodParameter.setParameterType(java.lang.Class)> is not annotated with @Deprecated(since="..." in (MethodParameter.java:454)
Method <org.springframework.core.MethodParameter.setTypeIndexForCurrentLevel(int)> is not annotated with @Deprecated(since="..." in (MethodParameter.java:314)
Method <org.springframework.core.annotation.AnnotationUtils.findAnnotationDeclaringClass(java.lang.Class, java.lang.Class)> is not annotated with @Deprecated(since="..." in (AnnotationUtils.java:604)
Method <org.springframework.core.annotation.AnnotationUtils.findAnnotationDeclaringClassForTypes(java.util.List, java.lang.Class)> is not annotated with @Deprecated(since="..." in (AnnotationUtils.java:640)
Method <org.springframework.core.annotation.AnnotationUtils.getAnnotations(java.lang.reflect.AnnotatedElement)> is not annotated with @Deprecated(since="..." in (AnnotationUtils.java:271)
Method <org.springframework.core.annotation.AnnotationUtils.getAnnotations(java.lang.reflect.Method)> is not annotated with @Deprecated(since="..." in (AnnotationUtils.java:295)
Method <org.springframework.core.annotation.AnnotationUtils.getDeclaredRepeatableAnnotations(java.lang.reflect.AnnotatedElement, java.lang.Class)> is not annotated with @Deprecated(since="..." in (AnnotationUtils.java:416)
Method <org.springframework.core.annotation.AnnotationUtils.getDeclaredRepeatableAnnotations(java.lang.reflect.AnnotatedElement, java.lang.Class, java.lang.Class)> is not annotated with @Deprecated(since="..." in (AnnotationUtils.java:453)
Method <org.springframework.core.annotation.AnnotationUtils.getRepeatableAnnotations(java.lang.reflect.AnnotatedElement, java.lang.Class)> is not annotated with @Deprecated(since="..." in (AnnotationUtils.java:335)
Method <org.springframework.core.annotation.AnnotationUtils.getRepeatableAnnotations(java.lang.reflect.AnnotatedElement, java.lang.Class, java.lang.Class)> is not annotated with @Deprecated(since="..." in (AnnotationUtils.java:372)
Method <org.springframework.core.annotation.AnnotationUtils.isAnnotationInherited(java.lang.Class, java.lang.Class)> is not annotated with @Deprecated(since="..." in (AnnotationUtils.java:691)
Method <org.springframework.core.annotation.AnnotationUtils.isAnnotationMetaPresent(java.lang.Class, java.lang.Class)> is not annotated with @Deprecated(since="..." in (AnnotationUtils.java:711)
Method <org.springframework.core.codec.AbstractDataBufferDecoder.decodeDataBuffer(org.springframework.core.io.buffer.DataBuffer, org.springframework.core.ResolvableType, org.springframework.util.MimeType, java.util.Map)> is not annotated with @Deprecated(since="..." in (AbstractDataBufferDecoder.java:107)
Method <org.springframework.core.env.AbstractEnvironment.acceptsProfiles([Ljava.lang.String;)> is not annotated with @Deprecated(since="..." in (AbstractEnvironment.java:382)
Method <org.springframework.core.env.Environment.acceptsProfiles([Ljava.lang.String;)> is not annotated with @Deprecated(since="..." in (Environment.java:0)
Method <org.springframework.core.io.buffer.DataBufferWrapper.asByteBuffer()> is not annotated with @Deprecated(since="..." in (DataBufferWrapper.java:195)
Method <org.springframework.core.io.buffer.DataBufferWrapper.asByteBuffer(int, int)> is not annotated with @Deprecated(since="..." in (DataBufferWrapper.java:201)
Method <org.springframework.core.io.buffer.DataBufferWrapper.capacity(int)> is not annotated with @Deprecated(since="..." in (DataBufferWrapper.java:90)
Method <org.springframework.core.io.buffer.DataBufferWrapper.ensureCapacity(int)> is not annotated with @Deprecated(since="..." in (DataBufferWrapper.java:96)
Method <org.springframework.core.io.buffer.DataBufferWrapper.retainedSlice(int, int)> is not annotated with @Deprecated(since="..." in (DataBufferWrapper.java:184)
Method <org.springframework.core.io.buffer.DataBufferWrapper.slice(int, int)> is not annotated with @Deprecated(since="..." in (DataBufferWrapper.java:178)
Method <org.springframework.core.io.buffer.DataBufferWrapper.toByteBuffer()> is not annotated with @Deprecated(since="..." in (DataBufferWrapper.java:207)
Method <org.springframework.core.io.buffer.DataBufferWrapper.toByteBuffer(int, int)> is not annotated with @Deprecated(since="..." in (DataBufferWrapper.java:213)
Method <org.springframework.core.io.buffer.DefaultDataBuffer$SlicedDefaultDataBuffer.slice(int, int)> is not annotated with @Deprecated(since="..." in (DefaultDataBuffer.java:528)
Method <org.springframework.core.io.buffer.DefaultDataBuffer.asByteBuffer()> is not annotated with @Deprecated(since="..." in (DefaultDataBuffer.java:385)
Method <org.springframework.core.io.buffer.DefaultDataBuffer.asByteBuffer(int, int)> is not annotated with @Deprecated(since="..." in (DefaultDataBuffer.java:391)
Method <org.springframework.core.io.buffer.DefaultDataBuffer.capacity(int)> is not annotated with @Deprecated(since="..." in (DefaultDataBuffer.java:185)
Method <org.springframework.core.io.buffer.DefaultDataBuffer.slice(int, int)> is not annotated with @Deprecated(since="..." in (DefaultDataBuffer.java:345)
Method <org.springframework.core.io.buffer.DefaultDataBuffer.slice(int, int)> is not annotated with @Deprecated(since="..." in (DefaultDataBuffer.java:44)
Method <org.springframework.core.io.buffer.DefaultDataBuffer.toByteBuffer(int, int)> is not annotated with @Deprecated(since="..." in (DefaultDataBuffer.java:402)
Method <org.springframework.core.io.buffer.DefaultDataBufferFactory.allocateBuffer()> is not annotated with @Deprecated(since="..." in (DefaultDataBufferFactory.java:32)
Method <org.springframework.core.io.buffer.DefaultDataBufferFactory.allocateBuffer()> is not annotated with @Deprecated(since="..." in (DefaultDataBufferFactory.java:90)
Method <org.springframework.core.io.buffer.JettyDataBuffer.asByteBuffer()> is not annotated with @Deprecated(since="..." in (JettyDataBuffer.java:255)
Method <org.springframework.core.io.buffer.JettyDataBuffer.asByteBuffer(int, int)> is not annotated with @Deprecated(since="..." in (JettyDataBuffer.java:261)
Method <org.springframework.core.io.buffer.JettyDataBuffer.capacity(int)> is not annotated with @Deprecated(since="..." in (JettyDataBuffer.java:143)
Method <org.springframework.core.io.buffer.JettyDataBuffer.slice(int, int)> is not annotated with @Deprecated(since="..." in (JettyDataBuffer.java:230)
Method <org.springframework.core.io.buffer.JettyDataBuffer.toByteBuffer(int, int)> is not annotated with @Deprecated(since="..." in (JettyDataBuffer.java:267)
Method <org.springframework.core.io.buffer.JettyDataBufferFactory.allocateBuffer()> is not annotated with @Deprecated(since="..." in (JettyDataBufferFactory.java:31)
Method <org.springframework.core.io.buffer.JettyDataBufferFactory.allocateBuffer()> is not annotated with @Deprecated(since="..." in (JettyDataBufferFactory.java:70)
Method <org.springframework.core.io.buffer.NettyDataBuffer.asByteBuffer()> is not annotated with @Deprecated(since="..." in (NettyDataBuffer.java:290)
Method <org.springframework.core.io.buffer.NettyDataBuffer.asByteBuffer(int, int)> is not annotated with @Deprecated(since="..." in (NettyDataBuffer.java:296)
Method <org.springframework.core.io.buffer.NettyDataBuffer.capacity(int)> is not annotated with @Deprecated(since="..." in (NettyDataBuffer.java:140)
Method <org.springframework.core.io.buffer.NettyDataBuffer.capacity(int)> is not annotated with @Deprecated(since="..." in (NettyDataBuffer.java:40)
Method <org.springframework.core.io.buffer.NettyDataBuffer.retainedSlice(int, int)> is not annotated with @Deprecated(since="..." in (NettyDataBuffer.java:267)
Method <org.springframework.core.io.buffer.NettyDataBuffer.retainedSlice(int, int)> is not annotated with @Deprecated(since="..." in (NettyDataBuffer.java:40)
Method <org.springframework.core.io.buffer.NettyDataBuffer.slice(int, int)> is not annotated with @Deprecated(since="..." in (NettyDataBuffer.java:260)
Method <org.springframework.core.io.buffer.NettyDataBuffer.slice(int, int)> is not annotated with @Deprecated(since="..." in (NettyDataBuffer.java:40)
Method <org.springframework.core.io.buffer.NettyDataBuffer.toByteBuffer(int, int)> is not annotated with @Deprecated(since="..." in (NettyDataBuffer.java:302)
Method <org.springframework.core.io.buffer.NettyDataBufferFactory.allocateBuffer()> is not annotated with @Deprecated(since="..." in (NettyDataBufferFactory.java:39)
Method <org.springframework.core.io.buffer.NettyDataBufferFactory.allocateBuffer()> is not annotated with @Deprecated(since="..." in (NettyDataBufferFactory.java:66)
Method <org.springframework.core.task.AsyncTaskExecutor.execute(java.lang.Runnable, long)> is not annotated with @Deprecated(since="..." in (AsyncTaskExecutor.java:79)
Method <org.springframework.core.task.SimpleAsyncTaskExecutor.execute(java.lang.Runnable, long)> is not annotated with @Deprecated(since="..." in (SimpleAsyncTaskExecutor.java:270)
Method <org.springframework.util.ClassUtils.getInterfaceMethodIfPossible(java.lang.reflect.Method)> is not annotated with @Deprecated(since="..." in (ClassUtils.java:1393)
Method <org.springframework.util.ClassUtils.isCglibProxy(java.lang.Object)> is not annotated with @Deprecated(since="..." in (ClassUtils.java:947)
Method <org.springframework.util.ClassUtils.isCglibProxyClass(java.lang.Class)> is not annotated with @Deprecated(since="..." in (ClassUtils.java:959)
Method <org.springframework.util.ClassUtils.isCglibProxyClassName(java.lang.String)> is not annotated with @Deprecated(since="..." in (ClassUtils.java:971)
Method <org.springframework.util.SerializationUtils.deserialize([B)> is not annotated with @Deprecated(since="..." in (SerializationUtils.java:77)
Method <org.springframework.util.StringUtils.isEmpty(java.lang.Object)> is not annotated with @Deprecated(since="..." in (StringUtils.java:113)
Architecture Violation [Priority: MEDIUM] - Rule 'classes that reside outside of packages ['org.springframework.asm..', 'org.springframework.cglib..', 'org.springframework.javapoet..', 'org.springframework.objenesis..'] and are annotated with @Deprecated should be annotated with @Deprecated(since="..."' was violated (1 times):
Class <org.springframework.core.task.TaskTimeoutException> is not annotated with @Deprecated(since="..." in (TaskTimeoutException.java:0)

```