### PR TITLE
Improve error handling for invalid path pattern combination in PathPattern.combine

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/pattern/PathPattern.java
+++ b/spring-web/src/main/java/org/springframework/web/util/pattern/PathPattern.java
@@ -397,6 +397,15 @@ public class PathPattern implements Comparable<PathPattern> {
 					this.patternString.substring(0, this.patternString.length() - 2),
 					pattern2string.patternString));
 		}
+		
+		if (this.patternString.endsWith("/*")) {
+			String base = this.patternString.substring(0, this.patternString.length() - 2);
+			if (pattern2string.patternString.contains("/")) {
+				throw new IllegalArgumentException("Cannot combine single-segment wildcard '/*' with multi-segment path '" +
+				pattern2string.patternString + "'");
+			}
+			return this.parser.parse(concat(base, "/" + pattern2string.patternString));
+		}
 
 		// /hotels + /booking => /hotels/booking
 		// /hotels + booking => /hotels/booking

--- a/spring-web/src/test/java/org/springframework/web/util/pattern/PathPatternTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/pattern/PathPatternTests.java
@@ -32,6 +32,7 @@ import org.springframework.web.util.pattern.PathPattern.PathRemainingMatchInfo;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Exercise matching of {@link PathPattern} objects.


### PR DESCRIPTION
Addresses #34986

Added an explicit check in PathPattern.combine() for cases where the base pattern ends with "/*" and the incoming pattern contains / (it is not a single segment).