### PR TITLE
Upgrade to Netty v4.2.2.Final and Reactor 2025.0.0-SNAPSHOT

### DIFF
--- a/framework-platform/framework-platform.gradle
+++ b/framework-platform/framework-platform.gradle
@@ -9,8 +9,8 @@ javaPlatform {
 dependencies {
 	api(platform("com.fasterxml.jackson:jackson-bom:2.18.4"))
 	api(platform("io.micrometer:micrometer-bom:1.15.0"))
-	api(platform("io.netty:netty-bom:4.1.121.Final"))
-	api(platform("io.projectreactor:reactor-bom:2025.0.0-M3"))
+	api(platform("io.netty:netty-bom:4.2.2.Final"))
+	api(platform("io.projectreactor:reactor-bom:2025.0.0-SNAPSHOT"))
 	api(platform("io.rsocket:rsocket-bom:1.1.5"))
 	api(platform("org.apache.groovy:groovy-bom:4.0.26"))
 	api(platform("org.apache.logging.log4j:log4j-bom:3.0.0-beta3"))


### PR DESCRIPTION
Netty 4.2 is backwards compatible with Netty 4.1, however some of the functionality is deprecated and a new one is added. Here is the migration guide https://github.com/netty/netty/wiki/Netty-4.2-Migration-Guide

Reactor 2025.0.0-M4 and Reactor Netty 1.3.0-M4 releases are planned for next week. They will depend on Netty 4.2.2.Final