### PR TITLE
Fix: Allow session update when session ID already exists even if max …

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/server/session/InMemoryWebSessionStore.java
+++ b/spring-web/src/main/java/org/springframework/web/server/session/InMemoryWebSessionStore.java
@@ -281,7 +281,7 @@ public class InMemoryWebSessionStore implements WebSessionStore {
 		private void checkMaxSessionsLimit() {
 			if (sessions.size() >= maxSessions) {
 				expiredSessionChecker.removeExpiredSessions(clock.instant());
-				if (sessions.size() >= maxSessions) {
+				if (sessions.size() >= maxSessions && !sessions.containsKey(this.getId())) {
 					throw new IllegalStateException("Max sessions limit reached: " + sessions.size());
 				}
 			}


### PR DESCRIPTION
Previously, when saving a session, the system did not check whether the session ID already existed. As a result, even if the session being saved was an update to an existing one, it was incorrectly treated as a new session, and a "maximum sessions exceeded" error was triggered.

This fix ensures that if a session with the same ID already exists, it will be updated rather than counted as a new session, thereby preventing unnecessary session limit violations.