### PR TITLE
Allow update of existing `WebSession` after max sessions limit is reached

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/server/session/InMemoryWebSessionStore.java
+++ b/spring-web/src/main/java/org/springframework/web/server/session/InMemoryWebSessionStore.java
@@ -281,7 +281,7 @@ public class InMemoryWebSessionStore implements WebSessionStore {
 		private void checkMaxSessionsLimit() {
 			if (sessions.size() >= maxSessions) {
 				expiredSessionChecker.removeExpiredSessions(clock.instant());
-				if (sessions.size() >= maxSessions) {
+				if (sessions.size() >= maxSessions && !sessions.containsKey(this.getId())) {
 					throw new IllegalStateException("Max sessions limit reached: " + sessions.size());
 				}
 			}

--- a/spring-web/src/test/java/org/springframework/web/server/session/InMemoryWebSessionStoreTests.java
+++ b/spring-web/src/test/java/org/springframework/web/server/session/InMemoryWebSessionStoreTests.java
@@ -30,6 +30,7 @@ import org.springframework.web.server.WebSession;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import reactor.test.StepVerifier;
 
 /**
  * Tests for {@link InMemoryWebSessionStore}.
@@ -157,6 +158,25 @@ class InMemoryWebSessionStoreTests {
 		assertThatIllegalStateException().isThrownBy(
 				this::insertSession)
 			.withMessage("Max sessions limit reached: 10000");
+	}
+
+	@Test
+	void updateSession() {
+		WebSession oneWebSession = insertSession();
+
+		StepVerifier.create(oneWebSession.save())
+				.expectComplete()
+				.verify();
+	}
+
+	@Test
+	void updateSession_whenMaxSessionsReached() {
+		WebSession onceWebSession = insertSession();
+		IntStream.range(1, 10000).forEach(i -> insertSession());
+
+		StepVerifier.create(onceWebSession.save())
+				.expectComplete()
+				.verify();
 	}
 
 	private WebSession insertSession() {


### PR DESCRIPTION
Previously, when saving a session, the system did not check whether the session ID already existed. As a result, even if the session being saved was an update to an existing one, it was incorrectly treated as a new session, and a "maximum sessions exceeded" error was triggered.

This fix ensures that if a session with the same ID already exists, it will be updated rather than counted as a new session, thereby preventing unnecessary session limit violations.