### PR TITLE
fix: Preserve NULL Parameters in case of AOP Proxy

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/support/AopUtils.java
+++ b/spring-aop/src/main/java/org/springframework/aop/support/AopUtils.java
@@ -381,7 +381,7 @@ public abstract class AopUtils {
 			Continuation<?> continuation = (Continuation<?>) args[args.length -1];
 			Assert.state(continuation != null, "No Continuation available");
 			CoroutineContext context = continuation.getContext().minusKey(Job.Key);
-			return CoroutinesUtils.invokeSuspendingFunction(context, method, target, args);
+			return CoroutinesUtils.invokeSuspendingFunctionPreserveNulls(context, method, target, args);
 		}
 	}
 

--- a/spring-aop/src/test/kotlin/org/springframework/aop/support/AopUtilsKotlinTests.kt
+++ b/spring-aop/src/test/kotlin/org/springframework/aop/support/AopUtilsKotlinTests.kt
@@ -44,6 +44,17 @@ class AopUtilsKotlinTests {
 	}
 
 	@Test
+	fun `Invoking suspending function with null argument should not return default value`() {
+		val method = ReflectionUtils.findMethod(WithoutInterface::class.java, "handleWithDefaultParam",
+			String::class. java, Continuation::class.java)!!
+		val continuation = Continuation<Any>(CoroutineName("test")) { }
+		val result = AopUtils.invokeJoinpointUsingReflection(WithoutInterface(), method, arrayOf(null, continuation))
+		assertThat(result).isInstanceOfSatisfying(Mono::class.java) {
+			assertThat(it.block()).isEqualTo(null)
+		}
+	}
+
+	@Test
 	fun `Invoking suspending function on bridged method should return Mono`() {
 		val value = "foo"
 		val bridgedMethod = ReflectionUtils.findMethod(WithInterface::class.java, "handle", Object::class.java, Continuation::class.java)!!
@@ -62,6 +73,11 @@ class AopUtilsKotlinTests {
 
 	class WithoutInterface {
 		suspend fun handle(value: String): String {
+			delay(1)
+			return value
+		}
+
+		suspend fun handleWithDefaultParam(value: String? = "defaultVal") : String? {
 			delay(1)
 			return value
 		}

--- a/spring-core/src/main/java/org/springframework/core/CoroutinesUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/CoroutinesUtils.java
@@ -112,6 +112,35 @@ public abstract class CoroutinesUtils {
 	@SuppressWarnings({"DataFlowIssue", "NullAway"})
 	public static Publisher<?> invokeSuspendingFunction(
 			CoroutineContext context, Method method, @Nullable Object target, @Nullable Object... args) {
+		return invokeSuspendingFunctionCore(context, method, target, args, false);
+	}
+
+	/**
+	 * Invoke a suspending function and convert it to {@link Mono} or
+	 * {@link Flux}.
+	 * @param context the coroutine context to use
+	 * @param method the suspending function to invoke
+	 * @param target the target to invoke {@code method} on
+	 * @param args the function arguments. If the {@code Continuation} argument is specified as the last argument
+	 * (typically {@code null}), it is ignored.
+	 * @return the method invocation result as reactive stream
+	 * @throws IllegalArgumentException if {@code method} is not a suspending function
+	 * @since 6.0
+	 * This function preservers the null parameter passed in argument
+	 */
+	@SuppressWarnings({"DataFlowIssue", "NullAway"})
+	public static Publisher<?> invokeSuspendingFunctionPreserveNulls(
+			CoroutineContext context, Method method, @Nullable Object target, @Nullable Object... args) {
+		return invokeSuspendingFunctionCore(context, method, target, args, true);
+	}
+
+	private static Publisher<?> invokeSuspendingFunctionCore(
+			CoroutineContext context,
+			Method method,
+			@Nullable Object target,
+			@Nullable Object[] args,
+			boolean preserveNulls)
+	{
 
 		Assert.isTrue(KotlinDetector.isSuspendingFunction(method), "Method must be a suspending function");
 		KFunction<?> function = ReflectJvmMapping.getKotlinFunction(method);
@@ -120,26 +149,7 @@ public abstract class CoroutinesUtils {
 			KCallablesJvm.setAccessible(function, true);
 		}
 		Mono<Object> mono = MonoKt.mono(context, (scope, continuation) -> {
-					Map<KParameter, Object> argMap = CollectionUtils.newHashMap(args.length + 1);
-					int index = 0;
-					for (KParameter parameter : function.getParameters()) {
-						switch (parameter.getKind()) {
-							case INSTANCE -> argMap.put(parameter, target);
-							case VALUE, EXTENSION_RECEIVER -> {
-								Object arg = args[index];
-								if (!(parameter.isOptional() && arg == null)) {
-									KType type = parameter.getType();
-									if (!(type.isMarkedNullable() && arg == null) &&
-											type.getClassifier() instanceof KClass<?> kClass &&
-											KotlinDetector.isInlineClass(JvmClassMappingKt.getJavaClass(kClass))) {
-										arg = box(kClass, arg);
-									}
-									argMap.put(parameter, arg);
-								}
-								index++;
-							}
-						}
-					}
+					Map<KParameter, Object> argMap = buildArgMap(function, target, args, preserveNulls);
 					return KCallables.callSuspendBy(function, argMap, continuation);
 				})
 				.filter(result -> result != Unit.INSTANCE)
@@ -157,6 +167,40 @@ public abstract class CoroutinesUtils {
 		}
 		return mono;
 	}
+
+	private static Map<KParameter, Object> buildArgMap(
+			KFunction<?> function,
+			@Nullable Object target,
+			@Nullable Object[] args,
+			boolean preserveNulls) {
+
+		Map<KParameter, Object> argMap = CollectionUtils.newHashMap(args.length + 1);
+		int index = 0;
+
+		for (KParameter parameter : function.getParameters()) {
+			switch (parameter.getKind()) {
+				case INSTANCE -> argMap.put(parameter, target);
+				case VALUE, EXTENSION_RECEIVER -> {
+					Object arg = args[index];
+
+					if (!(parameter.isOptional() && arg == null)) {
+						KType type = parameter.getType();
+						if (!(type.isMarkedNullable() && arg == null) &&
+								type.getClassifier() instanceof KClass<?> kClass &&
+								KotlinDetector.isInlineClass(JvmClassMappingKt.getJavaClass(kClass))) {
+							arg = box(kClass, arg);
+						}
+						argMap.put(parameter, arg);
+					} else if(preserveNulls) {
+						argMap.put(parameter, arg);
+					}
+					index++;
+				}
+			}
+		}
+		return argMap;
+	}
+
 
 	private static Object box(KClass<?> kClass, @Nullable Object arg) {
 		KFunction<?> constructor = Objects.requireNonNull(KClasses.getPrimaryConstructor(kClass));

--- a/spring-core/src/test/kotlin/org/springframework/core/CoroutinesUtilsTests.kt
+++ b/spring-core/src/test/kotlin/org/springframework/core/CoroutinesUtilsTests.kt
@@ -94,6 +94,16 @@ class CoroutinesUtilsTests {
 	}
 
 	@Test
+	fun invokeSuspendingFunctionWithNullableParameterPreservesNull() {
+		val method = CoroutinesUtilsTests::class.java.getDeclaredMethod("suspendingFunctionWithOptionalParameterAndDefaultValue", String::class.java, Continuation::class.java)
+		val mono = CoroutinesUtils.invokeSuspendingFunctionPreserveNulls(Dispatchers.Unconfined, method, this, null, null) as Mono
+		runBlocking {
+			Assertions.assertThat(mono.awaitSingleOrNull()).isNull()
+		}
+	}
+
+
+	@Test
 	fun invokePrivateSuspendingFunction() {
 		val method = CoroutinesUtilsTests::class.java.getDeclaredMethod("privateSuspendingFunction", String::class.java, Continuation::class.java)
 		val publisher = CoroutinesUtils.invokeSuspendingFunction(method, this, "foo")
@@ -299,6 +309,12 @@ class CoroutinesUtilsTests {
 		delay(1)
 		return value
 	}
+
+	suspend fun suspendingFunctionWithOptionalParameterAndDefaultValue(value: String? = "foo"): String? {
+		delay(1)
+		return value
+	}
+
 
 	suspend fun suspendingFunctionWithMono(): Mono<String> {
 		delay(1)


### PR DESCRIPTION
I have seen a case where NULL argument is passed explicitly in the function call but it is taking default value instead. Below are the function signatures. 

```
@Repository
open class A{
    suspend fun test(a: Long? = -1){
      println(a)
    }
}
```

```
@Service
open class B {
      @Inject private val a : A

      runBlocking {
         a.test(null) //prints -1
         A().test(null) //prints null
      }
}
```
This is specific to suspending functions and optional parameters only. Upon checking the code, I have below findings. 

Below is the change introduced in spring-aop from version 6.0.21 to 6.1.1, Earlier we are directly invoking the method via reflection but now `CoroutinesUtils.invokeSuspendingFunction` is getting invoked which is filtering the NULL values. 

spring-aop change:
![image](https://github.com/user-attachments/assets/7557aef4-e87f-4d46-baf0-64ba990b3bda)


As a part of this PR, I have introduced one more method in `CoroutinesUtils` which preserves the NULL values passed in arguments. This is being invoked via AOP Only and keeping the other flow remains as it is. 

Let me know if you need any reproduction steps or additional feedback related to the code changes. I'm happy to contribute wherever I can.

