### PR TITLE
Use String.replace in MetadataEncoder

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/rsocket/MetadataEncoder.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/rsocket/MetadataEncoder.java
@@ -106,8 +106,7 @@ final class MetadataEncoder {
 		Matcher matcher = VARS_PATTERN.matcher(route);
 		while (matcher.find()) {
 			Assert.isTrue(index < routeVars.length, () -> "No value for variable '" + matcher.group(1) + "'");
-			String value = routeVars[index].toString();
-			value = value.contains(".") ? value.replaceAll("\\.", "%2E") : value;
+			String value = routeVars[index].toString().replace(".", "%2E");
 			matcher.appendReplacement(sb, value);
 			index++;
 		}


### PR DESCRIPTION
Use String.replace instead of replaceAll in MetadataEncoder; since Java 9, String.replace no longer uses a regex, while replaceAll does. The use case here of replacing a single character does not require a regex.

Note: I was tired of seeing this 5-year old [blog](https://medium.com/javarevisited/micro-optimizations-in-java-string-replaceall-c6d0edf2ef6) that discusses the issue and points to this exact line of code and decided to just fix it.