### PR TITLE
Polish DataBufferInputStream.skip()

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/buffer/DataBufferInputStream.java
+++ b/spring-core/src/main/java/org/springframework/core/io/buffer/DataBufferInputStream.java
@@ -124,7 +124,7 @@ final class DataBufferInputStream extends InputStream {
 			return 0L;
 		}
 		int skipped = Math.min(available(), n > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) n);
-		this.dataBuffer.readPosition(Math.min(this.end, this.dataBuffer.readPosition() + skipped));
+		this.dataBuffer.readPosition(this.dataBuffer.readPosition() + skipped);
 		return skipped;
 	}
 


### PR DESCRIPTION
The removed `Math.min()` seems to be redundant due to the above `Math.min()`.

See gh-34799