### PR TITLE
Apply gh-34856 to MockClientHttpRequest in testfixture package

### DIFF
--- a/spring-web/src/testFixtures/java/org/springframework/web/testfixture/http/client/MockClientHttpRequest.java
+++ b/spring-web/src/testFixtures/java/org/springframework/web/testfixture/http/client/MockClientHttpRequest.java
@@ -104,7 +104,7 @@ public class MockClientHttpRequest extends MockHttpOutputMessage implements Clie
 
 	/**
 	 * Set the {@link ClientHttpResponse} to be used as the result of executing
-	 * the this request.
+	 * this request.
 	 * @see #execute()
 	 */
 	public void setResponse(ClientHttpResponse clientHttpResponse) {


### PR DESCRIPTION
This PR applies the changes made in gh-34856 to the `MockClientHttpRequest` in the `testfixture` package.