### PR TITLE
HttpService group adapters could not be instantiated in a native image

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/support/RestClientHttpServiceGroupAdapterRuntimeHints.java
+++ b/spring-web/src/main/java/org/springframework/web/client/support/RestClientHttpServiceGroupAdapterRuntimeHints.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.client.support;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
+
+/**
+ * A {@link RuntimeHintsRegistrar} implementation that adds hints for {@link RestClientHttpServiceGroupAdapter}.
+ *
+ * @author Olga Maciaszek-Sharma
+ * @since 7.0
+ */
+public class RestClientHttpServiceGroupAdapterRuntimeHints implements RuntimeHintsRegistrar {
+
+	@Override
+	public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
+		hints.reflection()
+				.registerType(TypeReference.of(RestClientHttpServiceGroupAdapter.class),
+						MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS);
+	}
+}

--- a/spring-web/src/main/resources/META-INF/spring/aot.factories
+++ b/spring-web/src/main/resources/META-INF/spring/aot.factories
@@ -3,7 +3,8 @@ org.springframework.http.HttpMimeTypesRuntimeHints,\
 org.springframework.http.codec.CodecConfigurerRuntimeHints,\
 org.springframework.http.converter.json.JacksonModulesRuntimeHints,\
 org.springframework.http.converter.json.ProblemDetailRuntimeHints,\
-org.springframework.web.util.WebUtilRuntimeHints
+org.springframework.web.util.WebUtilRuntimeHints,\
+org.springframework.web.client.support.RestClientHttpServiceGroupAdapterRuntimeHints
 
 org.springframework.beans.factory.aot.BeanRegistrationAotProcessor=\
 org.springframework.web.service.annotation.HttpExchangeBeanRegistrationAotProcessor,\

--- a/spring-web/src/test/java/org/springframework/web/client/support/RestClientHttpServiceGroupAdapterRuntimeHintsRegistrarTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/support/RestClientHttpServiceGroupAdapterRuntimeHintsRegistrarTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.client.support;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+import org.springframework.core.io.support.SpringFactoriesLoader;
+import org.springframework.util.ClassUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link RestClientHttpServiceGroupAdapterRuntimeHints}.
+ *
+ * @author Olga Maciaszek-Sharma
+ */
+class RestClientHttpServiceGroupAdapterRuntimeHintsRegistrarTests {
+
+	private RuntimeHints hints;
+
+	@BeforeEach
+	void setUp() {
+		this.hints = new RuntimeHints();
+		SpringFactoriesLoader.forResourceLocation("META-INF/spring/aot.factories")
+				.load(RuntimeHintsRegistrar.class)
+				.forEach(registrar ->
+						registrar.registerHints(this.hints, ClassUtils.getDefaultClassLoader()));
+	}
+
+	@Test
+	void shouldRegisterHintsForAdapter() {
+		assertThat(RuntimeHintsPredicates.reflection()
+				.onType(RestClientHttpServiceGroupAdapter.class)
+				.withMemberCategory(MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS))
+				.accepts(this.hints);
+
+	}
+
+}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/support/WebClientHttpServiceGroupAdapterRuntimeHints.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/support/WebClientHttpServiceGroupAdapterRuntimeHints.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.function.client.support;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.TypeReference;
+
+/**
+ * A {@link RuntimeHintsRegistrar} implementation that adds hints for {@link WebClientHttpServiceGroupAdapter}.
+ *
+ * @author Olga Maciaszek-Sharma
+ * @since 7.0
+ */
+public class WebClientHttpServiceGroupAdapterRuntimeHints implements RuntimeHintsRegistrar {
+
+	@Override
+	public void registerHints(RuntimeHints hints, @Nullable ClassLoader classLoader) {
+		hints.reflection()
+				.registerType(TypeReference.of(WebClientHttpServiceGroupAdapter.class),
+						MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS);
+	}
+}

--- a/spring-webflux/src/main/resources/META-INF/spring/aot.factories
+++ b/spring-webflux/src/main/resources/META-INF/spring/aot.factories
@@ -1,0 +1,2 @@
+org.springframework.aot.hint.RuntimeHintsRegistrar= \
+org.springframework.web.reactive.function.client.support.WebClientHttpServiceGroupAdapterRuntimeHints

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/support/WebClientHttpServiceGroupAdapterRuntimeHintsTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/support/WebClientHttpServiceGroupAdapterRuntimeHintsTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2002-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.reactive.function.client.support;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.RuntimeHintsRegistrar;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+import org.springframework.core.io.support.SpringFactoriesLoader;
+import org.springframework.util.ClassUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link WebClientHttpServiceGroupAdapterRuntimeHints}.
+ *
+ * @author Olga Maciaszek-Sharma
+ */
+class WebClientHttpServiceGroupAdapterRuntimeHintsTests {
+
+	private RuntimeHints hints;
+
+	@BeforeEach
+	void setUp() {
+		this.hints = new RuntimeHints();
+		SpringFactoriesLoader.forResourceLocation("META-INF/spring/aot.factories")
+				.load(RuntimeHintsRegistrar.class)
+				.forEach(registrar ->
+						registrar.registerHints(this.hints, ClassUtils.getDefaultClassLoader()));
+	}
+
+	@Test
+	void shouldRegisterHintsForAdapter() {
+		assertThat(RuntimeHintsPredicates.reflection()
+				.onType(WebClientHttpServiceGroupAdapter.class)
+				.withMemberCategory(MemberCategory.INVOKE_PUBLIC_CONSTRUCTORS))
+				.accepts(this.hints);
+
+	}
+
+}


### PR DESCRIPTION
Fixes startup issue while running Interface Client apps with native images.

Reproducer: https://github.com/OlgaMaciaszek/testjars-demo/tree/import-http-services-upgraded