### PR TITLE
Inconsistent Transaction and TransactionSynchronizationManager Attributes with Nested Transactions in Multi-Transaction Manager Environment

### DIFF
--- a/spring-tx/src/main/java/org/springframework/transaction/support/AbstractPlatformTransactionManager.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/support/AbstractPlatformTransactionManager.java
@@ -416,7 +416,8 @@ public abstract class AbstractPlatformTransactionManager
 						"isolation level will effectively be ignored: " + def);
 			}
 			boolean newSynchronization = (getTransactionSynchronization() == SYNCHRONIZATION_ALWAYS);
-			return prepareTransactionStatus(def, null, true, newSynchronization, debugEnabled, null);
+			SuspendedResourcesHolder suspendedResources = suspend(null);
+			return prepareTransactionStatus(def, null, true, newSynchronization, debugEnabled, suspendedResources);
 		}
 	}
 

--- a/spring-tx/src/test/java/org/springframework/transaction/support/TransactionSupportTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/support/TransactionSupportTests.java
@@ -16,34 +16,23 @@
 
 package org.springframework.transaction.support;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.*;
+import org.springframework.transaction.testfixture.MockCallbackPreferringTransactionManager;
+import org.springframework.transaction.testfixture.TestTransactionExecutionListener;
+import org.springframework.util.ReflectionUtils;
+
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-
-import org.springframework.transaction.IllegalTransactionStateException;
-import org.springframework.transaction.PlatformTransactionManager;
-import org.springframework.transaction.TransactionDefinition;
-import org.springframework.transaction.TransactionStatus;
-import org.springframework.transaction.TransactionSystemException;
-import org.springframework.transaction.testfixture.MockCallbackPreferringTransactionManager;
-import org.springframework.transaction.testfixture.TestTransactionExecutionListener;
-import org.springframework.util.ReflectionUtils;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
-import static org.assertj.core.api.Assertions.assertThatRuntimeException;
-import static org.springframework.transaction.TransactionDefinition.ISOLATION_REPEATABLE_READ;
-import static org.springframework.transaction.TransactionDefinition.ISOLATION_SERIALIZABLE;
-import static org.springframework.transaction.TransactionDefinition.PROPAGATION_MANDATORY;
-import static org.springframework.transaction.TransactionDefinition.PROPAGATION_REQUIRED;
-import static org.springframework.transaction.TransactionDefinition.PROPAGATION_SUPPORTS;
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.transaction.TransactionDefinition.*;
+import static org.springframework.transaction.support.AbstractPlatformTransactionManager.SYNCHRONIZATION_ALWAYS;
 import static org.springframework.transaction.support.AbstractPlatformTransactionManager.SYNCHRONIZATION_ON_ACTUAL_TRANSACTION;
 import static org.springframework.transaction.support.DefaultTransactionDefinition.PREFIX_ISOLATION;
 import static org.springframework.transaction.support.DefaultTransactionDefinition.PREFIX_PROPAGATION;
@@ -76,6 +65,58 @@ class TransactionSupportTests {
 
 		assertThatExceptionOfType(IllegalTransactionStateException.class)
 				.isThrownBy(() -> tm.getTransaction(new DefaultTransactionDefinition(PROPAGATION_MANDATORY)));
+	}
+
+	@Test
+	void noExistingTransactionWithExistingAnotherTransactionManager() {
+		AbstractPlatformTransactionManager tm1 = new TestTransactionManager(false, true);
+		tm1.setTransactionSynchronization(SYNCHRONIZATION_ALWAYS);
+
+		DefaultTransactionDefinition txDef1 =
+				new DefaultTransactionDefinition(PROPAGATION_REQUIRED);
+		txDef1.setName("tx1");
+		txDef1.setReadOnly(false);
+		txDef1.setIsolationLevel(ISOLATION_READ_COMMITTED);
+
+		DefaultTransactionStatus txStatus1 = (DefaultTransactionStatus)tm1.getTransaction(txDef1);
+
+		// assert for txStatus1 and TransactionSynchronizationManager property
+		assertThat(txStatus1.hasTransaction()).as("Must have transaction").isTrue();
+		assertThat(txStatus1.isNewTransaction()).as("Must be new transaction").isTrue();
+		assertThat(TransactionSynchronizationManager.isCurrentTransactionReadOnly())
+				.as("Transaction1 Must be readOnly false")
+				.isEqualTo(txStatus1.isReadOnly());
+		assertThat(TransactionSynchronizationManager.getCurrentTransactionName())
+				.as("TransactionSynchronizationManager have correct transaction name")
+						.isEqualTo(txStatus1.getTransactionName());
+		assertThat(TransactionSynchronizationManager.getCurrentTransactionIsolationLevel())
+				.as("isolation level must be default").isNull();
+		assertThat(TransactionSynchronizationManager.isSynchronizationActive()).isTrue();
+
+		// Setting another trnasaction manager
+		AbstractPlatformTransactionManager tm2 = new TestTransactionManager(false, true);
+		tm2.setTransactionSynchronization(SYNCHRONIZATION_ALWAYS);
+
+		// Opening a new transaction before `transaction 1` commits.
+		DefaultTransactionDefinition txDef2 =
+				new DefaultTransactionDefinition(PROPAGATION_SUPPORTS);
+		txDef2.setReadOnly(true);
+		txDef2.setIsolationLevel(ISOLATION_REPEATABLE_READ);
+		txDef2.setName("tx2");
+
+		// assert for txStatus1 and TransactionSynchronizationManager property
+		DefaultTransactionStatus txStatus2 = (DefaultTransactionStatus)
+				tm2.getTransaction(txDef2);
+		assertThat(TransactionSynchronizationManager.isActualTransactionActive()).as("Must not have transaction")
+				.isEqualTo(txStatus2.hasTransaction());
+		assertThat(TransactionSynchronizationManager.isCurrentTransactionReadOnly()).as("Must be readOnly true")
+				.isEqualTo(txStatus2.isReadOnly());
+		assertThat(TransactionSynchronizationManager.getCurrentTransactionIsolationLevel())
+				.as("isolation level must be Repeatable Read")
+				.isEqualTo(ISOLATION_REPEATABLE_READ);
+		assertThat(TransactionSynchronizationManager.isSynchronizationActive()).isTrue();
+
+		TransactionSynchronizationManager.clearSynchronization();
 	}
 
 	@Test

--- a/spring-tx/src/test/java/org/springframework/transaction/support/TransactionSupportTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/support/TransactionSupportTests.java
@@ -16,22 +16,36 @@
 
 package org.springframework.transaction.support;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.springframework.transaction.*;
-import org.springframework.transaction.testfixture.MockCallbackPreferringTransactionManager;
-import org.springframework.transaction.testfixture.TestTransactionExecutionListener;
-import org.springframework.util.ReflectionUtils;
-
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.springframework.transaction.TransactionDefinition.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.transaction.IllegalTransactionStateException;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.TransactionSystemException;
+import org.springframework.transaction.testfixture.MockCallbackPreferringTransactionManager;
+import org.springframework.transaction.testfixture.TestTransactionExecutionListener;
+import org.springframework.util.ReflectionUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatRuntimeException;
+import static org.springframework.transaction.TransactionDefinition.ISOLATION_READ_COMMITTED;
+import static org.springframework.transaction.TransactionDefinition.ISOLATION_REPEATABLE_READ;
+import static org.springframework.transaction.TransactionDefinition.ISOLATION_SERIALIZABLE;
+import static org.springframework.transaction.TransactionDefinition.PROPAGATION_MANDATORY;
+import static org.springframework.transaction.TransactionDefinition.PROPAGATION_REQUIRED;
+import static org.springframework.transaction.TransactionDefinition.PROPAGATION_SUPPORTS;
+
 import static org.springframework.transaction.support.AbstractPlatformTransactionManager.SYNCHRONIZATION_ALWAYS;
 import static org.springframework.transaction.support.AbstractPlatformTransactionManager.SYNCHRONIZATION_ON_ACTUAL_TRANSACTION;
 import static org.springframework.transaction.support.DefaultTransactionDefinition.PREFIX_ISOLATION;


### PR DESCRIPTION
Hi !

## situation

In a multi-transaction manager environment, when `@Transactional` annotations from different transaction managers are nested, the attributes of TransactionSynchronizationManager do not align with the current transaction if the inner `@Transactional` method has a propagation level of `SUPPORTS`, `NOT_SUPPORTS`, or `NEVER`.

Specifically, TransactionSynchronizationManager inherits the attributes (e.g., readOnly status) of the outer/parent's `other transaction manager`, rather than reflecting the characteristics of the "empty" or "non-participating" transaction created by the inner `@Transactional` method under these propagation settings. This leads to a mismatch between the expected transaction state and the state reported by TransactionSynchronizationManager.

### Steps to Reproduce
Consider the following simplified example:

```Java

class TransactionManager1 {

    private TransactionManager2 transactionManager2;

    @Transactional(transactionManager = "manager1", readOnly = true)
    public void transactionFirst() {
       transactionManager2.transactionSecond();
    }
}

class TransactionManager2 {

    // Assuming propagation is one of SUPPORTS, NOT_SUPPORTS, or NEVER implicitly or explicitly
    @Transactional(transactionManager = "manager2", readOnly = false, propagation = Propagation.SUPPORTS)
    public void transactionSecond() { // Changed method name for clarity based on example
        // Inside this method, TransactionSynchronizationManager.isCurrentTransactionReadOnly()
        // is expected to be 'false' (based on manager2's readOnly=false)
        // However, it currently returns 'true', inheriting from manager1.
        assert TransactionSynchronizationManager.isCurrentTransactionReadOnly() : "readOnly must be false";
    }
}
```

### Expected Behavior
When transactionSecond() is invoked, `TransactionSynchronizationManager.isCurrentTransactionReadOnly()` should accurately reflect the characteristics of the current transaction context established by manager2's @Transactional, irrespective of any parent transaction's attributes.

This is especially critical when the parent transaction originates from a different transaction manager. While it might seem that `PROPAGATION_SUPPORTS`, `PROPAGATION_NOT_SUPPORTED`, or `PROPAGATION_NEVER` shouldn't be affected as they don't create a new transaction, `@Transactional` attributes like readOnly can be set regardless of whether a physical transaction is actually active. Therefore, these attributes should be applied and reflected independently.

Indeed, if `@Transactional(transactionManager = "manager2", readOnly = false, propagation = Propagation.SUPPORTS)` were to execute without a parent transaction, `TransactionSynchronizationManager.isCurrentTransactionReadOnly()` would correctly return false. This demonstrates that `@Transactional` attributes should be precisely reflected, regardless of the presence of other transaction managers.

Therefore, whether `transactionFirst()` is invoked or `transactionSecond()` is called directly, `assert TransactionSynchronizationManager.isCurrentTransactionReadOnly()` should not throw an exception.

### Actual Behavior

However, when `transactionFirst()` is invoked, an `AssertionError` is thrown when `transactionSecond()` is called. Conversely, if `transactionSecond()` is invoked directly, no `AssertionError` occurs.

## Proposed Changes

In AbstractPlatformTransactionManager.getTransaction(Definition), we've added suspend logic at the very end of the method. This ensures that when a transaction context is established with propagations like `PROPAGATION_SUPPORTS`, `PROPAGATION_NOT_SUPPORTED`, or `PROPAGATION_NEVER`, any previously active transaction (potentially from another TransactionManager) is correctly suspended. This guarantees that TransactionSynchronizationManager accurately reflects the characteristics of the current transaction context, preventing inconsistencies in readOnly status and other attributes.

