### PR TITLE
use `try-with-resources` statement

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/mail/javamail/JavaMailSenderImpl.java
+++ b/spring-context-support/src/main/java/org/springframework/mail/javamail/JavaMailSenderImpl.java
@@ -342,14 +342,7 @@ public class JavaMailSenderImpl implements JavaMailSender {
 	 * for. Throws a {@link MessagingException} if the connection attempt failed.
 	 */
 	public void testConnection() throws MessagingException {
-		Transport transport = null;
-		try {
-			transport = connectTransport();
-		}
-		finally {
-			if (transport != null) {
-				transport.close();
-			}
+		try (Transport ignored = connectTransport()) {
 		}
 	}
 

--- a/spring-core/src/main/java/org/springframework/cglib/core/DuplicatesPredicate.java
+++ b/spring-core/src/main/java/org/springframework/cglib/core/DuplicatesPredicate.java
@@ -89,14 +89,12 @@ public class DuplicatesPredicate implements Predicate {
             continue;
           }
           InputStream is = cl.getResourceAsStream(c.getName().replace('.', '/') + ".class");
-          if (is == null) {
-            continue;
-          }
-          try {
-            new ClassReader(is).accept(finder, ClassReader.SKIP_FRAMES | ClassReader.SKIP_DEBUG);
-          } finally {
-            is.close();
-          }
+			try (is) {
+				if (is == null) {
+					continue;
+				}
+				new ClassReader(is).accept(finder, ClassReader.SKIP_FRAMES | ClassReader.SKIP_DEBUG);
+			}
         } catch (IOException ignored) {
         }
       }

--- a/spring-core/src/main/java/org/springframework/cglib/proxy/BridgeMethodResolver.java
+++ b/spring-core/src/main/java/org/springframework/cglib/proxy/BridgeMethodResolver.java
@@ -63,16 +63,14 @@ class BridgeMethodResolver {
             Set bridges = (Set) entry.getValue();
             try {
                 InputStream is = classLoader.getResourceAsStream(owner.getName().replace('.', '/') + ".class");
-                if (is == null) {
-                    return resolved;
-                }
-                try {
-                    new ClassReader(is)
-                            .accept(new BridgedFinder(bridges, resolved),
-                                    ClassReader.SKIP_FRAMES | ClassReader.SKIP_DEBUG);
-                } finally {
-                    is.close();
-                }
+				try (is) {
+					if (is == null) {
+						return resolved;
+					}
+					new ClassReader(is)
+							.accept(new BridgedFinder(bridges, resolved),
+									ClassReader.SKIP_FRAMES | ClassReader.SKIP_DEBUG);
+				}
             } catch (IOException ignored) {}
         }
         return resolved;

--- a/spring-core/src/main/java/org/springframework/cglib/transform/AbstractClassLoader.java
+++ b/spring-core/src/main/java/org/springframework/cglib/transform/AbstractClassLoader.java
@@ -61,20 +61,16 @@ abstract public class AbstractClassLoader extends ClassLoader {
                        name.replace('.','/') + ".class"
                   );
 
-           if (is == null) {
+			try (is) {
+				if (is == null) {
 
-              throw new ClassNotFoundException(name);
+					throw new ClassNotFoundException(name);
 
-           }
-           try {
+				}
 
-              r = new ClassReader(is);
+				r = new ClassReader(is);
 
-           } finally {
-
-              is.close();
-
-           }
+			}
         } catch (IOException e) {
             throw new ClassNotFoundException(name + ":" + e.getMessage());
         }

--- a/spring-core/src/main/java/org/springframework/core/io/AbstractResource.java
+++ b/spring-core/src/main/java/org/springframework/core/io/AbstractResource.java
@@ -153,8 +153,7 @@ public abstract class AbstractResource implements Resource {
 	 */
 	@Override
 	public long contentLength() throws IOException {
-		InputStream is = getInputStream();
-		try {
+		try (InputStream is = getInputStream()) {
 			long size = 0;
 			byte[] buf = new byte[256];
 			int read;
@@ -162,14 +161,6 @@ public abstract class AbstractResource implements Resource {
 				size += read;
 			}
 			return size;
-		}
-		finally {
-			try {
-				is.close();
-			}
-			catch (IOException ex) {
-				debug(() -> "Could not close content-length InputStream for " + getDescription(), ex);
-			}
 		}
 	}
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/embedded/AbstractEmbeddedDatabaseConfigurer.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/embedded/AbstractEmbeddedDatabaseConfigurer.java
@@ -40,30 +40,14 @@ abstract class AbstractEmbeddedDatabaseConfigurer implements EmbeddedDatabaseCon
 
 	@Override
 	public void shutdown(DataSource dataSource, String databaseName) {
-		Connection con = null;
-		try {
-			con = dataSource.getConnection();
+		try (Connection con = dataSource.getConnection()) {
 			if (con != null) {
 				try (Statement stmt = con.createStatement()) {
 					stmt.execute("SHUTDOWN");
 				}
 			}
-		}
-		catch (SQLException ex) {
+		} catch (SQLException ex) {
 			logger.info("Could not shut down embedded database", ex);
-		}
-		finally {
-			if (con != null) {
-				try {
-					con.close();
-				}
-				catch (SQLException ex) {
-					logger.debug("Could not close JDBC Connection on shutdown", ex);
-				}
-				catch (Throwable ex) {
-					logger.debug("Unexpected exception on closing JDBC Connection", ex);
-				}
-			}
 		}
 	}
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
@@ -253,8 +253,7 @@ public abstract class ScriptUtils {
 					blockCommentEndDelimiter, statements);
 
 			int stmtNumber = 0;
-			Statement stmt = connection.createStatement();
-			try {
+			try (Statement stmt = connection.createStatement()) {
 				for (String statement : statements) {
 					stmtNumber++;
 					try {
@@ -270,27 +269,19 @@ public abstract class ScriptUtils {
 								warningToLog = warningToLog.getNextWarning();
 							}
 						}
-					}
-					catch (SQLException ex) {
+					} catch (SQLException ex) {
 						boolean dropStatement = StringUtils.startsWithIgnoreCase(statement.trim(), "drop");
 						if (continueOnError || (dropStatement && ignoreFailedDrops)) {
 							if (logger.isDebugEnabled()) {
 								logger.debug(ScriptStatementFailedException.buildErrorMessage(statement, stmtNumber, resource), ex);
 							}
-						}
-						else {
+						} else {
 							throw new ScriptStatementFailedException(statement, stmtNumber, resource, ex);
 						}
 					}
 				}
-			}
-			finally {
-				try {
-					stmt.close();
-				}
-				catch (Throwable ex) {
-					logger.trace("Could not close JDBC Statement", ex);
-				}
+			} catch (Throwable ex) {
+				logger.trace("Could not close JDBC Statement", ex);
 			}
 
 			long elapsedTime = System.currentTimeMillis() - startTime;

--- a/spring-orm/src/test/java/org/springframework/orm/jpa/hibernate/HibernateMultiEntityManagerFactoryIntegrationTests.java
+++ b/spring-orm/src/test/java/org/springframework/orm/jpa/hibernate/HibernateMultiEntityManagerFactoryIntegrationTests.java
@@ -58,13 +58,9 @@ class HibernateMultiEntityManagerFactoryIntegrationTests extends AbstractContain
 
 	@Test
 	void testEntityManagerFactory2() {
-		EntityManager em = this.entityManagerFactory2.createEntityManager();
-		try {
+		try (EntityManager em = this.entityManagerFactory2.createEntityManager()) {
 			assertThatIllegalArgumentException().isThrownBy(() ->
 					em.createQuery("select tb from TestBean"));
-		}
-		finally {
-			em.close();
 		}
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/converter/ResourceHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/ResourceHttpMessageConverter.java
@@ -152,22 +152,16 @@ public class ResourceHttpMessageConverter extends AbstractHttpMessageConverter<R
 		// We cannot use try-with-resources here for the InputStream, since we have
 		// custom handling of the close() method in a finally-block.
 		try {
-			InputStream in = resource.getInputStream();
-			try {
-				OutputStream out = outputMessage.getBody();
-				in.transferTo(out);
-				out.flush();
-			}
-			catch (NullPointerException ex) {
-				// ignore, see SPR-13620
-			}
-			finally {
+			try (InputStream in = resource.getInputStream()) {
 				try {
-					in.close();
+					OutputStream out = outputMessage.getBody();
+					in.transferTo(out);
+					out.flush();
+				} catch (NullPointerException ex) {
+					// ignore, see SPR-13620
 				}
-				catch (Throwable ex) {
-					// ignore, see SPR-12999
-				}
+			} catch (Throwable ex) {
+				// ignore, see SPR-12999
 			}
 		}
 		catch (FileNotFoundException ex) {

--- a/spring-web/src/main/java/org/springframework/http/converter/ResourceRegionHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/ResourceRegionHttpMessageConverter.java
@@ -173,19 +173,11 @@ public class ResourceRegionHttpMessageConverter extends AbstractGenericHttpMessa
 		responseHeaders.add("Content-Range", "bytes " + start + '-' + end + '/' + resourceLength);
 		responseHeaders.setContentLength(rangeLength);
 
-		InputStream in = region.getResource().getInputStream();
 		// We cannot use try-with-resources here for the InputStream, since we have
 		// custom handling of the close() method in a finally-block.
-		try {
+		try (InputStream in = region.getResource().getInputStream()) {
 			StreamUtils.copyRange(in, outputMessage.getBody(), start, end);
-		}
-		finally {
-			try {
-				in.close();
-			}
-			catch (IOException ex) {
-				// ignore
-			}
+		} catch (IOException ignored) {
 		}
 	}
 


### PR DESCRIPTION
Java 7 introduced the try-with-resources statement. This statement ensures that each resource is closed at the end of the statement. It avoids the need of explicitly closing the resources in a finally block. Additionally exceptions are better handled: If an exception occurred both in the try block and finally block, then the exception from the try block was suppressed. With the try-with-resources statement, the exception thrown from the try-block is preserved.

- https://github.com/openrewrite/rewrite-static-analysis/issues/591
- https://pmd.github.io/pmd/pmd_rules_java_bestpractices.html#usetrywithresources
- https://www.baeldung.com/java-try-with-resources
- https://github.com/apache/maven/pull/2426
- https://github.com/quarkusio/quarkus/pull/48364


<img width="904" alt="image" src="https://github.com/user-attachments/assets/f98b5ff8-92cd-4e8d-a2fc-f8fe77703ebd" />

