### PR TITLE
Fix typo in ProtobufHttpMessageConverterTests.canWrite()

### DIFF
--- a/spring-web/src/test/java/org/springframework/http/converter/protobuf/ProtobufHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/protobuf/ProtobufHttpMessageConverterTests.java
@@ -64,7 +64,7 @@ class ProtobufHttpMessageConverterTests {
 	void canWrite() {
 		assertThat(this.converter.canWrite(Msg.class, null)).isTrue();
 		assertThat(this.converter.canWrite(Msg.class, ProtobufHttpMessageConverter.PROTOBUF)).isTrue();
-		assertThat(this.converter.canRead(Msg.class, this.testPlusProtoMediaType)).isTrue();
+		assertThat(this.converter.canWrite(Msg.class, this.testPlusProtoMediaType)).isTrue();
 		assertThat(this.converter.canWrite(Msg.class, MediaType.APPLICATION_JSON)).isTrue();
 		assertThat(this.converter.canWrite(Msg.class, MediaType.TEXT_PLAIN)).isTrue();
 	}


### PR DESCRIPTION
This PR fixes a typo in the `ProtobufHttpMessageConverterTests.canWrite()`.

See gh-34645