### PR TITLE
Support `@RequestBody` in interface method when computing "consumes" condition

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestMappingHandlerMapping.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestMappingHandlerMapping.java
@@ -19,7 +19,6 @@ package org.springframework.web.reactive.result.method.annotation;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -30,7 +29,9 @@ import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.context.EmbeddedValueResolverAware;
+import org.springframework.core.MethodParameter;
 import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.annotation.AnnotatedMethod;
 import org.springframework.core.annotation.MergedAnnotation;
 import org.springframework.core.annotation.MergedAnnotationPredicates;
 import org.springframework.core.annotation.MergedAnnotations;
@@ -372,13 +373,17 @@ public class RequestMappingHandlerMapping extends RequestMappingInfoHandlerMappi
 
 	private void updateConsumesCondition(RequestMappingInfo info, Method method) {
 		ConsumesRequestCondition condition = info.getConsumesCondition();
-		if (!condition.isEmpty()) {
-			for (Parameter parameter : method.getParameters()) {
-				MergedAnnotation<RequestBody> annot = MergedAnnotations.from(parameter).get(RequestBody.class);
-				if (annot.isPresent()) {
-					condition.setBodyRequired(annot.getBoolean("required"));
-					break;
-				}
+		if (condition.isEmpty()) {
+			return;
+		}
+
+		AnnotatedMethod annotatedMethod = new AnnotatedMethod(method);
+
+		for (MethodParameter parameter : annotatedMethod.getMethodParameters()) {
+			RequestBody requestBody = parameter.getParameterAnnotation(RequestBody.class);
+			if (requestBody != null) {
+				condition.setBodyRequired(requestBody.required());
+				break;
 			}
 		}
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMapping.java
@@ -19,7 +19,6 @@ package org.springframework.web.servlet.mvc.method.annotation;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -31,7 +30,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.context.EmbeddedValueResolverAware;
+import org.springframework.core.MethodParameter;
 import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.annotation.AnnotatedMethod;
 import org.springframework.core.annotation.MergedAnnotation;
 import org.springframework.core.annotation.MergedAnnotationPredicates;
 import org.springframework.core.annotation.MergedAnnotations;
@@ -410,13 +411,17 @@ public class RequestMappingHandlerMapping extends RequestMappingInfoHandlerMappi
 
 	private void updateConsumesCondition(RequestMappingInfo info, Method method) {
 		ConsumesRequestCondition condition = info.getConsumesCondition();
-		if (!condition.isEmpty()) {
-			for (Parameter parameter : method.getParameters()) {
-				MergedAnnotation<RequestBody> annot = MergedAnnotations.from(parameter).get(RequestBody.class);
-				if (annot.isPresent()) {
-					condition.setBodyRequired(annot.getBoolean("required"));
-					break;
-				}
+		if (condition.isEmpty()) {
+			return;
+		}
+
+		AnnotatedMethod annotatedMethod = new AnnotatedMethod(method);
+
+		for (MethodParameter parameter : annotatedMethod.getMethodParameters()) {
+			RequestBody requestBody = parameter.getParameterAnnotation(RequestBody.class);
+			if (requestBody != null) {
+				condition.setBodyRequired(requestBody.required());
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
### Problem

Spring currently ignores `@RequestBody` annotations declared on interface methods when computing the `ConsumesCondition`. As a result, the `required = false` flag is not respected, and requests without a body and without a Content-Type fail to match the mapping — even though null should be allowed.

This leads to situations where e.g. `application/json` is unnecessarily enforced in the ConsumesCondition, despite `@RequestBody(required = false)` being declared (e.g., on an interface method).

### Solution

This change switches to using `AnnotatedMethod` for inspecting method parameters, which ensures that annotations from both interface and implementation methods are considered. This allows Spring to correctly determine whether a request body is required and to avoid enforcing a Content-Type match when required = false.

### Tests

Includes tests verifying correct behavior for:

- Interface methods with `@RequestBody(required = false)`
- Implementations that override with `required = true`
