### PR TITLE
Add missing `@Nullable` to `MethodInvoker::setArguments` parameter

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/MethodInvoker.java
+++ b/spring-core/src/main/java/org/springframework/util/MethodInvoker.java
@@ -127,7 +127,7 @@ public class MethodInvoker {
 	 * Set arguments for the method invocation. If this property is not set,
 	 * or the Object array is of length 0, a method with no arguments is assumed.
 	 */
-	public void setArguments(@Nullable Object... arguments) {
+	public void setArguments(@Nullable Object @Nullable ... arguments) {
 		this.arguments = arguments;
 	}
 


### PR DESCRIPTION
Prior to this change, the nullness of the `MethodInvoker::setArguments` parameter targeted the array component only, which means that an invocation like `setArguments((Object[]) null)` was forbidden.

However, [the Javadoc](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/util/MethodInvoker.html#setArguments(java.lang.Object...)) mentions:

> **If this property is not set**, or the Object array is of length 0, a method with no arguments is assumed.

The way I interpret the part in bold is that passing a `null` array should be permitted, allowing the property to be unset.

Therefore, `@Nullable` is now added to allow a given array to be `null`.

This emerged during the work on spring-projects/spring-batch#4864.