### PR TITLE
Fix typo in exceptionVariableName in EmptyCatchBlockCheck

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/json/AbstractJsonContentAssert.java
+++ b/spring-test/src/main/java/org/springframework/test/json/AbstractJsonContentAssert.java
@@ -551,7 +551,7 @@ public abstract class AbstractJsonContentAssert<SELF extends AbstractJsonContent
 				read();
 				throw failure(new JsonPathNotExpected(this.json, this.path));
 			}
-			catch (PathNotFoundException ignore) {
+			catch (PathNotFoundException ignored) {
 			}
 		}
 

--- a/spring-web/src/main/java/org/springframework/http/codec/multipart/MultipartUtils.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/multipart/MultipartUtils.java
@@ -90,7 +90,7 @@ abstract class MultipartUtils {
 				channel.close();
 			}
 		}
-		catch (IOException ignore) {
+		catch (IOException ignored) {
 		}
 	}
 
@@ -98,7 +98,7 @@ abstract class MultipartUtils {
 		try {
 			Files.delete(file);
 		}
-		catch (IOException ignore) {
+		catch (IOException ignored) {
 		}
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/UndertowServerHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/UndertowServerHttpResponse.java
@@ -334,7 +334,7 @@ class UndertowServerHttpResponse extends AbstractListenerServerHttpResponse impl
 			try {
 				this.source.close();
 			}
-			catch (IOException ignore) {
+			catch (IOException ignored) {
 			}
 		}
 

--- a/spring-web/src/main/java/org/springframework/web/client/RestClientUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestClientUtils.java
@@ -39,7 +39,7 @@ abstract class RestClientUtils {
 		try {
 			return FileCopyUtils.copyToByteArray(message.getBody());
 		}
-		catch (IOException ignore) {
+		catch (IOException ignored) {
 		}
 		return new byte[0];
 	}

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -40,7 +40,7 @@
 		<module name="com.puppycrawl.tools.checkstyle.checks.blocks.NeedBracesCheck"/>
 		<module name="com.puppycrawl.tools.checkstyle.checks.blocks.AvoidNestedBlocksCheck"/>
 		<module name="com.puppycrawl.tools.checkstyle.checks.blocks.EmptyCatchBlockCheck">
-			<property name="exceptionVariableName" value="expected|ignore"/>
+			<property name="exceptionVariableName" value="expected|ignored"/>
 		</module>
 
 		<!-- Class Design -->


### PR DESCRIPTION
This PR fixes a typo in `exceptionVariableName` in `EmptyCatchBlockCheck`.

This PR also changes to use "ignored" for exception variable names instead of "ignore".

See gh-35047