### PR TITLE
Apply unused `io.spring.javaformat plugin`

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,11 +1,17 @@
 plugins {
 	id 'java-gradle-plugin'
 	id 'checkstyle'
+	id 'io.spring.javaformat' version "${javaFormatVersion}"
 }
 
 repositories {
 	mavenCentral()
 	gradlePluginPortal()
+}
+
+tasks.named('compileJava') {
+	dependsOn 'format'
+	mustRunAfter 'format'
 }
 
 ext {

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 assertjVersion=3.27.3
-javaFormatVersion=0.0.43
+javaFormatVersion=0.0.47
 junitVersion=5.12.2

--- a/buildSrc/src/main/java/org/springframework/build/CheckstyleConventions.java
+++ b/buildSrc/src/main/java/org/springframework/build/CheckstyleConventions.java
@@ -53,9 +53,11 @@ public class CheckstyleConventions {
 			checkstyle.setToolVersion("10.25.0");
 			checkstyle.getConfigDirectory().set(project.getRootProject().file("src/checkstyle"));
 			String version = SpringJavaFormatPlugin.class.getPackage().getImplementationVersion();
-			DependencySet checkstyleDependencies = project.getConfigurations().getByName("checkstyle").getDependencies();
-			checkstyleDependencies.add(
-					project.getDependencies().create("io.spring.javaformat:spring-javaformat-checkstyle:" + version));
+			DependencySet checkstyleDependencies = project.getConfigurations()
+				.getByName("checkstyle")
+				.getDependencies();
+			checkstyleDependencies
+				.add(project.getDependencies().create("io.spring.javaformat:spring-javaformat-checkstyle:" + version));
 		});
 	}
 
@@ -63,8 +65,9 @@ public class CheckstyleConventions {
 		project.getPlugins().apply(NoHttpPlugin.class);
 		NoHttpExtension noHttp = project.getExtensions().getByType(NoHttpExtension.class);
 		noHttp.setAllowlistFile(project.file("src/nohttp/allowlist.lines"));
-		noHttp.getSource().exclude("**/test-output/**", "**/.settings/**", "**/.classpath",
-				"**/.project", "**/.gradle/**", "**/node_modules/**", "**/spring-jcl/**", "buildSrc/build/**");
+		noHttp.getSource()
+			.exclude("**/test-output/**", "**/.settings/**", "**/.classpath", "**/.project", "**/.gradle/**",
+					"**/node_modules/**", "**/spring-jcl/**", "buildSrc/build/**");
 		List<String> buildFolders = List.of("bin", "build", "out");
 		project.allprojects(subproject -> {
 			Path rootPath = project.getRootDir().toPath();

--- a/buildSrc/src/main/java/org/springframework/build/ConventionsPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/build/ConventionsPlugin.java
@@ -27,11 +27,12 @@ import org.springframework.build.architecture.ArchitecturePlugin;
  * Plugin to apply conventions to projects that are part of Spring Framework's build.
  * Conventions are applied in response to various plugins being applied.
  *
- * <p>When the {@link JavaBasePlugin} is applied, the conventions in {@link CheckstyleConventions},
- * {@link TestConventions} and {@link JavaConventions} are applied.
- * The {@link ArchitecturePlugin} plugin is also applied.
- * When the {@link KotlinBasePlugin} is applied, the conventions in {@link KotlinConventions}
- * are applied.
+ * <p>
+ * When the {@link JavaBasePlugin} is applied, the conventions in
+ * {@link CheckstyleConventions}, {@link TestConventions} and {@link JavaConventions} are
+ * applied. The {@link ArchitecturePlugin} plugin is also applied. When the
+ * {@link KotlinBasePlugin} is applied, the conventions in {@link KotlinConventions} are
+ * applied.
  *
  * @author Brian Clozel
  */

--- a/buildSrc/src/main/java/org/springframework/build/JavaConventions.java
+++ b/buildSrc/src/main/java/org/springframework/build/JavaConventions.java
@@ -42,30 +42,26 @@ public class JavaConventions {
 
 	/**
 	 * The Java version we should use as the JVM baseline for building the project.
-	 * <p>NOTE: If you update this value, you should also update the value used in
-	 * the {@code javadoc} task in {@code framework-api.gradle}.
+	 * <p>
+	 * NOTE: If you update this value, you should also update the value used in the
+	 * {@code javadoc} task in {@code framework-api.gradle}.
 	 */
 	private static final JavaLanguageVersion DEFAULT_LANGUAGE_VERSION = JavaLanguageVersion.of(24);
 
 	/**
-	 * The Java version we should use as the baseline for the compiled bytecode
-	 * (the "-release" compiler argument).
+	 * The Java version we should use as the baseline for the compiled bytecode (the
+	 * "-release" compiler argument).
 	 */
 	private static final JavaLanguageVersion DEFAULT_RELEASE_VERSION = JavaLanguageVersion.of(17);
 
 	static {
-		List<String> commonCompilerArgs = List.of(
-				"-Xlint:serial", "-Xlint:cast", "-Xlint:classfile", "-Xlint:dep-ann",
-				"-Xlint:divzero", "-Xlint:empty", "-Xlint:finally", "-Xlint:overrides",
-				"-Xlint:path", "-Xlint:processing", "-Xlint:static", "-Xlint:try", "-Xlint:-options",
-				"-parameters"
-		);
+		List<String> commonCompilerArgs = List.of("-Xlint:serial", "-Xlint:cast", "-Xlint:classfile", "-Xlint:dep-ann",
+				"-Xlint:divzero", "-Xlint:empty", "-Xlint:finally", "-Xlint:overrides", "-Xlint:path",
+				"-Xlint:processing", "-Xlint:static", "-Xlint:try", "-Xlint:-options", "-parameters");
 		COMPILER_ARGS = new ArrayList<>();
 		COMPILER_ARGS.addAll(commonCompilerArgs);
-		COMPILER_ARGS.addAll(List.of(
-				"-Xlint:varargs", "-Xlint:fallthrough", "-Xlint:rawtypes", "-Xlint:deprecation",
-				"-Xlint:unchecked", "-Werror"
-		));
+		COMPILER_ARGS.addAll(List.of("-Xlint:varargs", "-Xlint:fallthrough", "-Xlint:rawtypes", "-Xlint:deprecation",
+				"-Xlint:unchecked", "-Werror"));
 		TEST_COMPILER_ARGS = new ArrayList<>();
 		TEST_COMPILER_ARGS.addAll(commonCompilerArgs);
 		TEST_COMPILER_ARGS.addAll(List.of("-Xlint:-varargs", "-Xlint:-fallthrough", "-Xlint:-rawtypes",
@@ -96,21 +92,23 @@ public class JavaConventions {
 	 */
 	private void applyJavaCompileConventions(Project project) {
 		project.afterEvaluate(p -> {
-			p.getTasks().withType(JavaCompile.class)
-					.matching(compileTask -> compileTask.getName().startsWith(JavaPlugin.COMPILE_JAVA_TASK_NAME))
-					.forEach(compileTask -> {
-						compileTask.getOptions().setCompilerArgs(COMPILER_ARGS);
-						compileTask.getOptions().setEncoding("UTF-8");
-						setJavaRelease(compileTask);
-					});
-			p.getTasks().withType(JavaCompile.class)
-					.matching(compileTask -> compileTask.getName().startsWith(JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME)
-							|| compileTask.getName().equals("compileTestFixturesJava"))
-					.forEach(compileTask -> {
-						compileTask.getOptions().setCompilerArgs(TEST_COMPILER_ARGS);
-						compileTask.getOptions().setEncoding("UTF-8");
-						setJavaRelease(compileTask);
-					});
+			p.getTasks()
+				.withType(JavaCompile.class)
+				.matching(compileTask -> compileTask.getName().startsWith(JavaPlugin.COMPILE_JAVA_TASK_NAME))
+				.forEach(compileTask -> {
+					compileTask.getOptions().setCompilerArgs(COMPILER_ARGS);
+					compileTask.getOptions().setEncoding("UTF-8");
+					setJavaRelease(compileTask);
+				});
+			p.getTasks()
+				.withType(JavaCompile.class)
+				.matching(compileTask -> compileTask.getName().startsWith(JavaPlugin.COMPILE_TEST_JAVA_TASK_NAME)
+						|| compileTask.getName().equals("compileTestFixturesJava"))
+				.forEach(compileTask -> {
+					compileTask.getOptions().setCompilerArgs(TEST_COMPILER_ARGS);
+					compileTask.getOptions().setEncoding("UTF-8");
+					setJavaRelease(compileTask);
+				});
 
 		});
 	}
@@ -123,7 +121,7 @@ public class JavaConventions {
 		int defaultVersion = DEFAULT_RELEASE_VERSION.asInt();
 		int releaseVersion = defaultVersion;
 		int compilerVersion = task.getJavaCompiler().get().getMetadata().getLanguageVersion().asInt();
-		for (int version = defaultVersion ; version <= compilerVersion ; version++) {
+		for (int version = defaultVersion; version <= compilerVersion; version++) {
 			if (task.getName().contains("Java" + version)) {
 				releaseVersion = version;
 				break;

--- a/buildSrc/src/main/java/org/springframework/build/KotlinConventions.java
+++ b/buildSrc/src/main/java/org/springframework/build/KotlinConventions.java
@@ -28,8 +28,9 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile;
 public class KotlinConventions {
 
 	void apply(Project project) {
-		project.getPlugins().withId("org.jetbrains.kotlin.jvm",
-				(plugin) -> project.getTasks().withType(KotlinCompile.class, this::configure));
+		project.getPlugins()
+			.withId("org.jetbrains.kotlin.jvm",
+					(plugin) -> project.getTasks().withType(KotlinCompile.class, this::configure));
 	}
 
 	private void configure(KotlinCompile compile) {
@@ -39,11 +40,14 @@ public class KotlinConventions {
 			options.getJvmTarget().set(JvmTarget.JVM_17);
 			options.getJavaParameters().set(true);
 			options.getAllWarningsAsErrors().set(true);
-			options.getFreeCompilerArgs().addAll(
-					"-Xsuppress-version-warnings",
-					"-Xjsr305=strict", // For dependencies using JSR 305
-					"-opt-in=kotlin.RequiresOptIn",
-					"-Xjdk-release=17" // Needed due to https://youtrack.jetbrains.com/issue/KT-49746
+			options.getFreeCompilerArgs()
+				.addAll("-Xsuppress-version-warnings", "-Xjsr305=strict", // For
+																			// dependencies
+																			// using JSR
+																			// 305
+						"-opt-in=kotlin.RequiresOptIn", "-Xjdk-release=17" // Needed due
+																			// to
+																			// https://youtrack.jetbrains.com/issue/KT-49746
 			);
 		});
 	}

--- a/buildSrc/src/main/java/org/springframework/build/SpringFrameworkExtension.java
+++ b/buildSrc/src/main/java/org/springframework/build/SpringFrameworkExtension.java
@@ -31,10 +31,13 @@ public class SpringFrameworkExtension {
 
 	public SpringFrameworkExtension(Project project) {
 		this.enableJavaPreviewFeatures = project.getObjects().property(Boolean.class);
-		project.getTasks().withType(JavaCompile.class).configureEach(javaCompile ->
-				javaCompile.getOptions().getCompilerArgumentProviders().add(asArgumentProvider()));
-		project.getTasks().withType(Test.class).configureEach(test ->
-				test.getJvmArgumentProviders().add(asArgumentProvider()));
+		project.getTasks()
+			.withType(JavaCompile.class)
+			.configureEach(
+					javaCompile -> javaCompile.getOptions().getCompilerArgumentProviders().add(asArgumentProvider()));
+		project.getTasks()
+			.withType(Test.class)
+			.configureEach(test -> test.getJvmArgumentProviders().add(asArgumentProvider()));
 
 	}
 
@@ -50,4 +53,5 @@ public class SpringFrameworkExtension {
 			return Collections.emptyList();
 		};
 	}
+
 }

--- a/buildSrc/src/main/java/org/springframework/build/TestConventions.java
+++ b/buildSrc/src/main/java/org/springframework/build/TestConventions.java
@@ -30,8 +30,8 @@ import org.gradle.testretry.TestRetryTaskExtension;
  * Conventions that are applied in the presence of the {@link JavaBasePlugin}. When the
  * plugin is applied:
  * <ul>
- * <li>The {@link TestRetryPlugin Test Retry} plugin is applied so that flaky tests
- * are retried 3 times when running on the CI server.
+ * <li>The {@link TestRetryPlugin Test Retry} plugin is applied so that flaky tests are
+ * retried 3 times when running on the CI server.
  * </ul>
  *
  * @author Brian Clozel
@@ -45,11 +45,10 @@ class TestConventions {
 	}
 
 	private void configureTestConventions(Project project) {
-		project.getTasks().withType(Test.class,
-				test -> {
-					configureTests(project, test);
-					configureTestRetryPlugin(project, test);
-				});
+		project.getTasks().withType(Test.class, test -> {
+			configureTests(project, test);
+			configureTestRetryPlugin(project, test);
+		});
 	}
 
 	private void configureTests(Project project, Test test) {
@@ -60,18 +59,12 @@ class TestConventions {
 			}
 		});
 		test.include("**/*Tests.class", "**/*Test.class");
-		test.setSystemProperties(Map.of(
-				"java.awt.headless", "true",
-				"io.netty.leakDetection.level", "paranoid"
-		));
+		test.setSystemProperties(Map.of("java.awt.headless", "true", "io.netty.leakDetection.level", "paranoid"));
 		if (project.hasProperty("testGroups")) {
 			test.systemProperty("testGroups", project.getProperties().get("testGroups"));
 		}
-		test.jvmArgs(
-				"--add-opens=java.base/java.lang=ALL-UNNAMED",
-				"--add-opens=java.base/java.util=ALL-UNNAMED",
-				"-Xshare:off"
-		);
+		test.jvmArgs("--add-opens=java.base/java.lang=ALL-UNNAMED", "--add-opens=java.base/java.util=ALL-UNNAMED",
+				"-Xshare:off");
 	}
 
 	private void configureTestRetryPlugin(Project project, Test test) {

--- a/buildSrc/src/main/java/org/springframework/build/architecture/ArchitectureCheck.java
+++ b/buildSrc/src/main/java/org/springframework/build/architecture/ArchitectureCheck.java
@@ -64,10 +64,8 @@ public abstract class ArchitectureCheck extends DefaultTask {
 	public ArchitectureCheck() {
 		getOutputDirectory().convention(getProject().getLayout().getBuildDirectory().dir(getName()));
 		getProhibitObjectsRequireNonNull().convention(true);
-		getRules().addAll(packageInfoShouldBeNullMarked(),
-				classesShouldNotImportForbiddenTypes(),
-				javaClassesShouldNotImportKotlinAnnotations(),
-				allPackagesShouldBeFreeOfTangles(),
+		getRules().addAll(packageInfoShouldBeNullMarked(), classesShouldNotImportForbiddenTypes(),
+				javaClassesShouldNotImportKotlinAnnotations(), allPackagesShouldBeFreeOfTangles(),
 				noClassesShouldCallStringToLowerCaseWithoutLocale(),
 				noClassesShouldCallStringToUpperCaseWithoutLocale());
 		getRuleDescriptions().set(getRules().map((rules) -> rules.stream().map(ArchRule::getDescription).toList()));
@@ -76,12 +74,12 @@ public abstract class ArchitectureCheck extends DefaultTask {
 	@TaskAction
 	void checkArchitecture() throws IOException {
 		JavaClasses javaClasses = new ClassFileImporter()
-				.importPaths(this.classes.getFiles().stream().map(File::toPath).toList());
+			.importPaths(this.classes.getFiles().stream().map(File::toPath).toList());
 		List<EvaluationResult> violations = getRules().get()
-				.stream()
-				.map((rule) -> rule.evaluate(javaClasses))
-				.filter(EvaluationResult::hasViolation)
-				.toList();
+			.stream()
+			.map((rule) -> rule.evaluate(javaClasses))
+			.filter(EvaluationResult::hasViolation)
+			.toList();
 		File outputFile = getOutputDirectory().file("failure-report.txt").get().getAsFile();
 		outputFile.getParentFile().mkdirs();
 		if (!violations.isEmpty()) {
@@ -134,4 +132,5 @@ public abstract class ArchitectureCheck extends DefaultTask {
 	// The rules themselves can't be an input as they aren't serializable so we use
 	// their descriptions instead
 	abstract ListProperty<String> getRuleDescriptions();
+
 }

--- a/buildSrc/src/main/java/org/springframework/build/architecture/ArchitecturePlugin.java
+++ b/buildSrc/src/main/java/org/springframework/build/architecture/ArchitecturePlugin.java
@@ -48,15 +48,14 @@ public class ArchitecturePlugin implements Plugin<Project> {
 				continue;
 			}
 			TaskProvider<ArchitectureCheck> checkArchitecture = project.getTasks()
-					.register(taskName(sourceSet), ArchitectureCheck.class,
-							(task) -> {
-								task.setClasses(sourceSet.getOutput().getClassesDirs());
-								task.getResourcesDirectory().set(sourceSet.getOutput().getResourcesDir());
-								task.dependsOn(sourceSet.getProcessResourcesTaskName());
-								task.setDescription("Checks the architecture of the classes of the " + sourceSet.getName()
-										+ " source set.");
-								task.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
-							});
+				.register(taskName(sourceSet), ArchitectureCheck.class, (task) -> {
+					task.setClasses(sourceSet.getOutput().getClassesDirs());
+					task.getResourcesDirectory().set(sourceSet.getOutput().getResourcesDir());
+					task.dependsOn(sourceSet.getProcessResourcesTaskName());
+					task.setDescription(
+							"Checks the architecture of the classes of the " + sourceSet.getName() + " source set.");
+					task.setGroup(LifecycleBasePlugin.VERIFICATION_GROUP);
+				});
 			architectureChecks.add(checkArchitecture);
 		}
 		if (!architectureChecks.isEmpty()) {
@@ -66,8 +65,7 @@ public class ArchitecturePlugin implements Plugin<Project> {
 	}
 
 	private static String taskName(SourceSet sourceSet) {
-		return "checkArchitecture"
-				+ sourceSet.getName().substring(0, 1).toUpperCase()
+		return "checkArchitecture" + sourceSet.getName().substring(0, 1).toUpperCase()
 				+ sourceSet.getName().substring(1);
 	}
 

--- a/buildSrc/src/main/java/org/springframework/build/architecture/ArchitectureRules.java
+++ b/buildSrc/src/main/java/org/springframework/build/architecture/ArchitectureRules.java
@@ -28,64 +28,61 @@ import java.util.List;
 abstract class ArchitectureRules {
 
 	static ArchRule allPackagesShouldBeFreeOfTangles() {
-		return SlicesRuleDefinition.slices()
-				.assignedFrom(new SpringSlices()).should().beFreeOfCycles();
+		return SlicesRuleDefinition.slices().assignedFrom(new SpringSlices()).should().beFreeOfCycles();
 	}
 
 	static ArchRule noClassesShouldCallStringToLowerCaseWithoutLocale() {
 		return ArchRuleDefinition.noClasses()
-				.should()
-				.callMethod(String.class, "toLowerCase")
-				.because("String.toLowerCase(Locale.ROOT) should be used instead");
+			.should()
+			.callMethod(String.class, "toLowerCase")
+			.because("String.toLowerCase(Locale.ROOT) should be used instead");
 	}
 
 	static ArchRule noClassesShouldCallStringToUpperCaseWithoutLocale() {
 		return ArchRuleDefinition.noClasses()
-				.should()
-				.callMethod(String.class, "toUpperCase")
-				.because("String.toUpperCase(Locale.ROOT) should be used instead");
+			.should()
+			.callMethod(String.class, "toUpperCase")
+			.because("String.toUpperCase(Locale.ROOT) should be used instead");
 	}
 
 	static ArchRule packageInfoShouldBeNullMarked() {
 		return ArchRuleDefinition.classes()
-				.that().haveSimpleName("package-info")
-				.should().beAnnotatedWith("org.jspecify.annotations.NullMarked")
-				.allowEmptyShould(true);
+			.that()
+			.haveSimpleName("package-info")
+			.should()
+			.beAnnotatedWith("org.jspecify.annotations.NullMarked")
+			.allowEmptyShould(true);
 	}
 
 	static ArchRule classesShouldNotImportForbiddenTypes() {
 		return ArchRuleDefinition.noClasses()
-				.should().dependOnClassesThat()
-				.haveFullyQualifiedName("reactor.core.support.Assert")
-				.orShould().dependOnClassesThat()
-				.haveFullyQualifiedName("org.slf4j.LoggerFactory")
-				.orShould().dependOnClassesThat()
-				.haveFullyQualifiedName("org.springframework.lang.NonNull")
-				.orShould().dependOnClassesThat()
-				.haveFullyQualifiedName("org.springframework.lang.Nullable");
+			.should()
+			.dependOnClassesThat()
+			.haveFullyQualifiedName("reactor.core.support.Assert")
+			.orShould()
+			.dependOnClassesThat()
+			.haveFullyQualifiedName("org.slf4j.LoggerFactory")
+			.orShould()
+			.dependOnClassesThat()
+			.haveFullyQualifiedName("org.springframework.lang.NonNull")
+			.orShould()
+			.dependOnClassesThat()
+			.haveFullyQualifiedName("org.springframework.lang.Nullable");
 	}
 
 	static ArchRule javaClassesShouldNotImportKotlinAnnotations() {
-		return ArchRuleDefinition.noClasses()
-				.that(new DescribedPredicate<JavaClass>("is not a Kotlin class") {
-						  @Override
-						  public boolean test(JavaClass javaClass) {
-							  return javaClass.getSourceCodeLocation()
-									  .getSourceFileName().endsWith(".java");
-						  }
-					  }
-				)
-				.should().dependOnClassesThat()
-				.resideInAnyPackage("org.jetbrains.annotations..")
-				.allowEmptyShould(true);
+		return ArchRuleDefinition.noClasses().that(new DescribedPredicate<JavaClass>("is not a Kotlin class") {
+			@Override
+			public boolean test(JavaClass javaClass) {
+				return javaClass.getSourceCodeLocation().getSourceFileName().endsWith(".java");
+			}
+		}).should().dependOnClassesThat().resideInAnyPackage("org.jetbrains.annotations..").allowEmptyShould(true);
 	}
 
 	static class SpringSlices implements SliceAssignment {
 
-		private final List<String> ignoredPackages = List.of("org.springframework.asm",
-				"org.springframework.cglib",
-				"org.springframework.javapoet",
-				"org.springframework.objenesis");
+		private final List<String> ignoredPackages = List.of("org.springframework.asm", "org.springframework.cglib",
+				"org.springframework.javapoet", "org.springframework.objenesis");
 
 		@Override
 		public SliceIdentifier getIdentifierOf(JavaClass javaClass) {
@@ -103,5 +100,7 @@ abstract class ArchitectureRules {
 		public String getDescription() {
 			return "Spring Framework Slices";
 		}
+
 	}
+
 }

--- a/buildSrc/src/main/java/org/springframework/build/dev/LocalDevelopmentPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/build/dev/LocalDevelopmentPlugin.java
@@ -21,7 +21,8 @@ import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaBasePlugin;
 
 /**
- * {@link Plugin} that skips documentation tasks when the {@code "-PskipDocs"} property is defined.
+ * {@link Plugin} that skips documentation tasks when the {@code "-PskipDocs"} property is
+ * defined.
  *
  * @author Brian Clozel
  */
@@ -40,10 +41,10 @@ public class LocalDevelopmentPlugin implements Plugin<Project> {
 	private void skipDocumentationTasks(Project project) {
 		project.afterEvaluate(p -> {
 			p.getTasks().matching(task -> {
-						return JavaBasePlugin.DOCUMENTATION_GROUP.equals(task.getGroup())
-								|| "distribution".equals(task.getGroup());
-					})
-					.forEach(task -> task.setEnabled(false));
+				return JavaBasePlugin.DOCUMENTATION_GROUP.equals(task.getGroup())
+						|| "distribution".equals(task.getGroup());
+			}).forEach(task -> task.setEnabled(false));
 		});
 	}
+
 }

--- a/buildSrc/src/main/java/org/springframework/build/hint/RuntimeHintsAgentArgumentProvider.java
+++ b/buildSrc/src/main/java/org/springframework/build/hint/RuntimeHintsAgentArgumentProvider.java
@@ -32,17 +32,18 @@ public interface RuntimeHintsAgentArgumentProvider extends CommandLineArgumentPr
 	@Classpath
 	ConfigurableFileCollection getAgentJar();
 
-    @Input
-    SetProperty<String> getIncludedPackages();
+	@Input
+	SetProperty<String> getIncludedPackages();
 
-    @Input
-    SetProperty<String> getExcludedPackages();
+	@Input
+	SetProperty<String> getExcludedPackages();
 
-    @Override
-    default Iterable<String> asArguments() {
-        StringBuilder packages = new StringBuilder();
-        getIncludedPackages().get().forEach(packageName -> packages.append('+').append(packageName).append(','));
-        getExcludedPackages().get().forEach(packageName -> packages.append('-').append(packageName).append(','));
-        return Collections.singleton("-javaagent:" + getAgentJar().getSingleFile() + "=" + packages);
-    }
+	@Override
+	default Iterable<String> asArguments() {
+		StringBuilder packages = new StringBuilder();
+		getIncludedPackages().get().forEach(packageName -> packages.append('+').append(packageName).append(','));
+		getExcludedPackages().get().forEach(packageName -> packages.append('-').append(packageName).append(','));
+		return Collections.singleton("-javaagent:" + getAgentJar().getSingleFile() + "=" + packages);
+	}
+
 }

--- a/buildSrc/src/main/java/org/springframework/build/hint/RuntimeHintsAgentExtension.java
+++ b/buildSrc/src/main/java/org/springframework/build/hint/RuntimeHintsAgentExtension.java
@@ -20,6 +20,7 @@ import org.gradle.api.provider.SetProperty;
 
 /**
  * Entry point to the DSL extension for the {@link RuntimeHintsAgentPlugin} Gradle plugin.
+ *
  * @author Brian Clozel
  */
 public interface RuntimeHintsAgentExtension {
@@ -27,4 +28,5 @@ public interface RuntimeHintsAgentExtension {
 	SetProperty<String> getIncludedPackages();
 
 	SetProperty<String> getExcludedPackages();
+
 }

--- a/buildSrc/src/main/java/org/springframework/build/hint/RuntimeHintsAgentPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/build/hint/RuntimeHintsAgentPlugin.java
@@ -42,9 +42,10 @@ import java.util.Collections;
 public class RuntimeHintsAgentPlugin implements Plugin<Project> {
 
 	public static final String RUNTIMEHINTS_TEST_TASK = "runtimeHintsTest";
-	private static final String EXTENSION_NAME = "runtimeHintsAgent";
-	private static final String CONFIGURATION_NAME = "testRuntimeHintsAgentJar";
 
+	private static final String EXTENSION_NAME = "runtimeHintsAgent";
+
+	private static final String CONFIGURATION_NAME = "testRuntimeHintsAgentJar";
 
 	@Override
 	public void apply(Project project) {
@@ -70,15 +71,17 @@ public class RuntimeHintsAgentPlugin implements Plugin<Project> {
 	}
 
 	private static RuntimeHintsAgentExtension createRuntimeHintsAgentExtension(Project project) {
-		RuntimeHintsAgentExtension agentExtension = project.getExtensions().create(EXTENSION_NAME, RuntimeHintsAgentExtension.class);
+		RuntimeHintsAgentExtension agentExtension = project.getExtensions()
+			.create(EXTENSION_NAME, RuntimeHintsAgentExtension.class);
 		agentExtension.getIncludedPackages().convention(Collections.singleton("org.springframework"));
 		agentExtension.getExcludedPackages().convention(Collections.emptySet());
 		return agentExtension;
 	}
 
-	private static RuntimeHintsAgentArgumentProvider createRuntimeHintsAgentArgumentProvider(
-			Project project, RuntimeHintsAgentExtension agentExtension) {
-		RuntimeHintsAgentArgumentProvider agentArgumentProvider = project.getObjects().newInstance(RuntimeHintsAgentArgumentProvider.class);
+	private static RuntimeHintsAgentArgumentProvider createRuntimeHintsAgentArgumentProvider(Project project,
+			RuntimeHintsAgentExtension agentExtension) {
+		RuntimeHintsAgentArgumentProvider agentArgumentProvider = project.getObjects()
+			.newInstance(RuntimeHintsAgentArgumentProvider.class);
 		agentArgumentProvider.getAgentJar().from(createRuntimeHintsAgentConfiguration(project));
 		agentArgumentProvider.getIncludedPackages().set(agentExtension.getIncludedPackages());
 		agentArgumentProvider.getExcludedPackages().set(agentExtension.getExcludedPackages());
@@ -90,12 +93,18 @@ public class RuntimeHintsAgentPlugin implements Plugin<Project> {
 			configuration.setCanBeConsumed(false);
 			configuration.setTransitive(false); // Only the built artifact is required
 			configuration.attributes(attributes -> {
-				attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, project.getObjects().named(Bundling.class, Bundling.EXTERNAL));
-				attributes.attribute(Category.CATEGORY_ATTRIBUTE, project.getObjects().named(Category.class, Category.LIBRARY));
-				attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE, project.getObjects().named(LibraryElements.class, LibraryElements.JAR));
-				attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE, Integer.valueOf(JavaVersion.current().getMajorVersion()));
-				attributes.attribute(Usage.USAGE_ATTRIBUTE, project.getObjects().named(Usage.class, Usage.JAVA_RUNTIME));
+				attributes.attribute(Bundling.BUNDLING_ATTRIBUTE,
+						project.getObjects().named(Bundling.class, Bundling.EXTERNAL));
+				attributes.attribute(Category.CATEGORY_ATTRIBUTE,
+						project.getObjects().named(Category.class, Category.LIBRARY));
+				attributes.attribute(LibraryElements.LIBRARY_ELEMENTS_ATTRIBUTE,
+						project.getObjects().named(LibraryElements.class, LibraryElements.JAR));
+				attributes.attribute(TargetJvmVersion.TARGET_JVM_VERSION_ATTRIBUTE,
+						Integer.valueOf(JavaVersion.current().getMajorVersion()));
+				attributes.attribute(Usage.USAGE_ATTRIBUTE,
+						project.getObjects().named(Usage.class, Usage.JAVA_RUNTIME));
 			});
 		});
 	}
+
 }

--- a/buildSrc/src/main/java/org/springframework/build/multirelease/MultiReleaseJarPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/build/multirelease/MultiReleaseJarPlugin.java
@@ -30,8 +30,8 @@ import org.gradle.api.tasks.TaskContainer;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 
 /**
- * A plugin which adds support for building multi-release jars
- * with Gradle.
+ * A plugin which adds support for building multi-release jars with Gradle.
+ *
  * @author Cedric Champeau
  * @author Brian Clozel
  * @see <a href="https://github.com/melix/mrjar-gradle-plugin">original project</a>
@@ -51,11 +51,8 @@ public class MultiReleaseJarPlugin implements Plugin<Project> {
 		TaskContainer tasks = project.getTasks();
 		DependencyHandler dependencies = project.getDependencies();
 		ObjectFactory objects = project.getObjects();
-		extensions.create("multiRelease", MultiReleaseExtension.class,
-				javaPluginExtension.getSourceSets(),
-				configurations,
-				tasks,
-				dependencies,
-				objects);
+		extensions.create("multiRelease", MultiReleaseExtension.class, javaPluginExtension.getSourceSets(),
+				configurations, tasks, dependencies, objects);
 	}
+
 }

--- a/buildSrc/src/main/java/org/springframework/build/optional/OptionalDependenciesPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/build/optional/OptionalDependenciesPlugin.java
@@ -26,8 +26,8 @@ import org.gradle.api.tasks.SourceSetContainer;
 /**
  * A {@code Plugin} that adds support for Maven-style optional dependencies. Creates a new
  * {@code optional} configuration. The {@code optional} configuration is part of the
- * project's compile and runtime classpaths but does not affect the classpath of
- * dependent projects.
+ * project's compile and runtime classpaths but does not affect the classpath of dependent
+ * projects.
  *
  * @author Andy Wilkinson
  */
@@ -44,11 +44,16 @@ public class OptionalDependenciesPlugin implements Plugin<Project> {
 		optional.setCanBeConsumed(false);
 		optional.setCanBeResolved(false);
 		project.getPlugins().withType(JavaBasePlugin.class, (javaBasePlugin) -> {
-			SourceSetContainer sourceSets = project.getExtensions().getByType(JavaPluginExtension.class)
-					.getSourceSets();
+			SourceSetContainer sourceSets = project.getExtensions()
+				.getByType(JavaPluginExtension.class)
+				.getSourceSets();
 			sourceSets.all((sourceSet) -> {
-				project.getConfigurations().getByName(sourceSet.getCompileClasspathConfigurationName()).extendsFrom(optional);
-				project.getConfigurations().getByName(sourceSet.getRuntimeClasspathConfigurationName()).extendsFrom(optional);
+				project.getConfigurations()
+					.getByName(sourceSet.getCompileClasspathConfigurationName())
+					.extendsFrom(optional);
+				project.getConfigurations()
+					.getByName(sourceSet.getRuntimeClasspathConfigurationName())
+					.extendsFrom(optional);
 			});
 		});
 	}

--- a/buildSrc/src/main/java/org/springframework/build/shadow/ShadowSource.java
+++ b/buildSrc/src/main/java/org/springframework/build/shadow/ShadowSource.java
@@ -57,7 +57,6 @@ public class ShadowSource extends DefaultTask {
 
 	private final List<Relocation> relocations = new ArrayList<>();
 
-
 	@Classpath
 	@Optional
 	public List<Configuration> getConfigurations() {
@@ -105,8 +104,9 @@ public class ShadowSource extends DefaultTask {
 
 	private Set<ComponentArtifactsResult> resolveSourceArtifacts(DependencyResult dependency) {
 		ModuleComponentSelector componentSelector = (ModuleComponentSelector) dependency.getRequested();
-		ArtifactResolutionQuery query = getProject().getDependencies().createArtifactResolutionQuery()
-				.forModule(componentSelector.getGroup(), componentSelector.getModule(), componentSelector.getVersion());
+		ArtifactResolutionQuery query = getProject().getDependencies()
+			.createArtifactResolutionQuery()
+			.forModule(componentSelector.getGroup(), componentSelector.getModule(), componentSelector.getVersion());
 		return executeQuery(query).getResolvedComponents();
 	}
 
@@ -145,7 +145,6 @@ public class ShadowSource extends DefaultTask {
 		return getProject().zipTree(sourceJar);
 	}
 
-
 	/**
 	 * A single relocation.
 	 */
@@ -159,14 +158,12 @@ public class ShadowSource extends DefaultTask {
 
 		private final String pathDestination;
 
-
 		Relocation(String pattern, String destination) {
 			this.pattern = pattern;
 			this.pathPattern = pattern.replace('.', '/');
 			this.destination = destination;
 			this.pathDestination = destination.replace('.', '/');
 		}
-
 
 		@Input
 		public String getPattern() {

--- a/buildSrc/src/test/java/org/springframework/build/multirelease/MultiReleaseJarPluginTests.java
+++ b/buildSrc/src/test/java/org/springframework/build/multirelease/MultiReleaseJarPluginTests.java
@@ -88,7 +88,7 @@ public class MultiReleaseJarPluginTests {
 
 		BuildResult buildResult = runGradle("printReleaseVersion");
 		assertThat(buildResult.getOutput()).contains("compileJava21Java releaseVersion: 21")
-				.contains("compileJava21TestJava releaseVersion: 21");
+			.contains("compileJava21TestJava releaseVersion: 21");
 	}
 
 	@Test
@@ -112,7 +112,7 @@ public class MultiReleaseJarPluginTests {
 			assertThat(mainAttributes.getValue("Multi-Release")).isEqualTo("true");
 
 			assertThat(jar.entries().asIterator()).toIterable()
-					.anyMatch(entry -> entry.getName().equals("META-INF/versions/17/Main.class"));
+				.anyMatch(entry -> entry.getName().equals("META-INF/versions/17/Main.class"));
 		}
 	}
 

--- a/spring-context/src/main/java/org/springframework/scripting/config/ScriptBeanDefinitionParser.java
+++ b/spring-context/src/main/java/org/springframework/scripting/config/ScriptBeanDefinitionParser.java
@@ -184,7 +184,7 @@ class ScriptBeanDefinitionParser extends AbstractBeanDefinitionParser {
 		ConstructorArgumentValues cav = bd.getConstructorArgumentValues();
 		int constructorArgNum = 0;
 		if (StringUtils.hasLength(engine)) {
-			cav.addIndexedArgumentValue(constructorArgNum++, engine);
+			cav.addIndexedArgumentValue(constructorArgNum++   , engine);
 		}
 		cav.addIndexedArgumentValue(constructorArgNum++, value);
 		if (element.hasAttribute(SCRIPT_INTERFACES_ATTRIBUTE)) {


### PR DESCRIPTION


execute: `gradle format`

build is not fixing itself, impose burden on contributor, despite having auto fix solution in place but not activated, leaking quality and compliance.

```

* What went wrong:
Execution failed for task ':buildSrc:checkFormatMain'.
> Formatting violations found in the following files:
   * src/main/java/org/springframework/build/hint/RuntimeHintsAgentArgumentProvider.java
   * src/main/java/org/springframework/build/hint/RuntimeHintsAgentExtension.java
   * src/main/java/org/springframework/build/hint/RuntimeHintsAgentPlugin.java
   * src/main/java/org/springframework/build/KotlinConventions.java
   * src/main/java/org/springframework/build/ConventionsPlugin.java
   * src/main/java/org/springframework/build/shadow/ShadowSource.java
   * src/main/java/org/springframework/build/TestConventions.java
   * src/main/java/org/springframework/build/optional/OptionalDependenciesPlugin.java
   * src/main/java/org/springframework/build/architecture/ArchitectureCheck.java
   * src/main/java/org/springframework/build/architecture/ArchitecturePlugin.java
   * src/main/java/org/springframework/build/architecture/ArchitectureRules.java
   * src/main/java/org/springframework/build/SpringFrameworkExtension.java
   * src/main/java/org/springframework/build/CheckstyleConventions.java
   * src/main/java/org/springframework/build/JavaConventions.java
   * src/main/java/org/springframework/build/dev/LocalDevelopmentPlugin.java
   * src/main/java/org/springframework/build/multirelease/MultiReleaseJarPlugin.java
   * src/main/java/org/springframework/build/multirelease/MultiReleaseExtension.java
  
  Run `format` to fix.
```