### PR TITLE
Support StreamingHttpOutputMessage in RestClient

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/DefaultRestClient.java
+++ b/spring-web/src/main/java/org/springframework/web/client/DefaultRestClient.java
@@ -477,7 +477,14 @@ final class DefaultRestClient implements RestClient {
 
 		@Override
 		public RequestBodySpec body(StreamingHttpOutputMessage.Body body) {
-			this.body = request -> body.writeTo(request.getBody());
+			this.body = request -> {
+				if (request instanceof StreamingHttpOutputMessage streamingMessage) {
+					streamingMessage.setBody(body);
+				}
+				else {
+					body.writeTo(request.getBody());
+				}
+			};
 			return this;
 		}
 


### PR DESCRIPTION
This pull request ensures proper handling of `StreamingHttpOutputMessage`
when used with `RestClient`.

### Motivation

Currently, when a `StreamingHttpOutputMessage.Body` is passed to
`RestClient.body(...)`, the implementation internally calls
`body.writeTo(request.getBody())`.

However, in `AbstractStreamingClientHttpRequest`, the `getBody()` method
returns a `ByteArrayOutputStream`, and invoking it implicitly switches the
request into buffered mode. This breaks the expected behavior for streaming,
as the user might assume the data will be written directly to the underlying
network stream.

Instead, if the underlying request is an instance of
`StreamingHttpOutputMessage`, the framework should delegate directly to
`setBody(...)`, which properly supports non-buffered streaming.

### Changes

- Detects if the request is a `StreamingHttpOutputMessage`
- Calls `setBody(...)` instead of `getBody().write(...)`
- Preserves fallback behavior for non-streaming clients

### Test Coverage

A new integration test has been added to verify that streamed data is
correctly passed through the `RestClient` without being buffered.

This ensures that behavior is correct across different `ClientHttpRequestFactory`
implementations.