### PR TITLE
Use `ExceptionTypeFilter` to filter includes and excludes for retry policies

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/retry/DefaultRetryPolicy.java
+++ b/spring-core/src/main/java/org/springframework/core/retry/DefaultRetryPolicy.java
@@ -22,6 +22,7 @@ import java.util.function.Predicate;
 
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.util.ExceptionTypeFilter;
 import org.springframework.util.backoff.BackOff;
 
 /**
@@ -29,6 +30,7 @@ import org.springframework.util.backoff.BackOff;
  *
  * @author Sam Brannen
  * @author Mahmoud Ben Hassine
+ * @author Mengqi Xu
  * @since 7.0
  */
 class DefaultRetryPolicy implements RetryPolicy {
@@ -55,26 +57,10 @@ class DefaultRetryPolicy implements RetryPolicy {
 
 	@Override
 	public boolean shouldRetry(Throwable throwable) {
-		if (!this.excludes.isEmpty()) {
-			for (Class<? extends Throwable> excludedType : this.excludes) {
-				if (excludedType.isInstance(throwable)) {
-					return false;
-				}
-			}
-		}
-		if (!this.includes.isEmpty()) {
-			boolean included = false;
-			for (Class<? extends Throwable> includedType : this.includes) {
-				if (includedType.isInstance(throwable)) {
-					included = true;
-					break;
-				}
-			}
-			if (!included) {
-				return false;
-			}
-		}
-		return this.predicate == null || this.predicate.test(throwable);
+		ExceptionTypeFilter exceptionTypeFilter = new ExceptionTypeFilter(this.includes,
+				this.excludes, true);
+		return exceptionTypeFilter.match(throwable.getClass()) &&
+				(this.predicate == null || this.predicate.test(throwable));
 	}
 
 	@Override


### PR DESCRIPTION
It's easy to filter `Throwable` with `ExceptionTypeFilter`. Otherwise, we would have to handle inclusions and exclusions everywhere.