### PR TITLE
Add getter for `OverflowStrategy` in `ConcurrentWebSocketSessionDecorator`

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/handler/ConcurrentWebSocketSessionDecorator.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/handler/ConcurrentWebSocketSessionDecorator.java
@@ -275,6 +275,13 @@ public class ConcurrentWebSocketSessionDecorator extends WebSocketSessionDecorat
 		}
 	}
 
+	/**
+	 * Return the configured overflow strategy.
+	 * @since 6.3
+	 */
+	public OverflowStrategy getOverflowStrategy() {
+		return this.overflowStrategy;
+	}
 
 	@Override
 	public String toString() {

--- a/spring-websocket/src/test/java/org/springframework/web/socket/handler/ConcurrentWebSocketSessionDecoratorTests.java
+++ b/spring-websocket/src/test/java/org/springframework/web/socket/handler/ConcurrentWebSocketSessionDecoratorTests.java
@@ -215,4 +215,14 @@ class ConcurrentWebSocketSessionDecoratorTests {
 		assertThat(latch.await(5, TimeUnit.SECONDS)).isTrue();
 	}
 
+	@Test
+	void configuredProperties() {
+		TestWebSocketSession session = new TestWebSocketSession();
+		ConcurrentWebSocketSessionDecorator sessionDecorator = new ConcurrentWebSocketSessionDecorator(session, 42, 43, OverflowStrategy.DROP);
+
+		assertThat(sessionDecorator.getSendTimeLimit()).isEqualTo(42);
+		assertThat(sessionDecorator.getBufferSizeLimit()).isEqualTo(43);
+		assertThat(sessionDecorator.getOverflowStrategy()).isEqualTo(OverflowStrategy.DROP);
+	}
+
 }


### PR DESCRIPTION
This pull requests adds a getter for the configured overflow strategy of class `ConcurrentWebSocketSessionDecorator`.

The PR also includes a unit tests to assert all configurable properties.

I added the getter so that I can easily verify the configured overflow strategy in unit tests of my app.