### PR TITLE
Remove duplicate “rss” assertion in test

### DIFF
--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupportTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupportTests.java
@@ -224,7 +224,6 @@ class WebMvcConfigurationSupportTests {
 		assertThat(mediaTypeMappings)
 				.containsEntry("atom", MediaType.APPLICATION_ATOM_XML)
 				.containsEntry("rss", MediaType.APPLICATION_RSS_XML)
-				.containsEntry("rss", MediaType.APPLICATION_RSS_XML)
 				.containsEntry("xml", MediaType.APPLICATION_XML)
 				.containsEntry("json", MediaType.APPLICATION_JSON)
 				.containsEntry("smile", MediaType.valueOf("application/x-jackson-smile"))


### PR DESCRIPTION
There’s a redundant `.containsEntry("rss", MediaType.APPLICATION_RSS_XML)` in the test – everything else is correct.

