### PR TITLE
Allow any @Transactional propagation for @TransactionalEventListener with BEFORE_COMMIT phase

### DIFF
--- a/spring-tx/src/test/java/org/springframework/transaction/event/TransactionalApplicationListenerMethodAdapterTests.java
+++ b/spring-tx/src/test/java/org/springframework/transaction/event/TransactionalApplicationListenerMethodAdapterTests.java
@@ -158,6 +158,13 @@ class TransactionalApplicationListenerMethodAdapterTests {
 	}
 
 	@Test
+	void withTransactionalAnnotationBeforeCommit() {
+		RestrictedTransactionalEventListenerFactory factory = new RestrictedTransactionalEventListenerFactory();
+		Method m = ReflectionUtils.findMethod(SampleEvents.class, "withTransactionalAnnotationBeforeCommit", String.class);
+		assertThatNoException().isThrownBy(() -> factory.createApplicationListener("test", SampleEvents.class, m));
+	}
+
+	@Test
 	void withTransactionalAnnotationOnEnclosingClass() {
 		RestrictedTransactionalEventListenerFactory factory = new RestrictedTransactionalEventListenerFactory();
 		Method m = ReflectionUtils.findMethod(SampleEvents.SampleEventsWithTransactionalAnnotation.class, "defaultPhase", String.class);
@@ -275,6 +282,11 @@ class TransactionalApplicationListenerMethodAdapterTests {
 		@TransactionalEventListener
 		@Async @Transactional(propagation = Propagation.REQUIRES_NEW)
 		public void withAsyncTransactionalAnnotation(String data) {
+		}
+
+		@TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+		@Transactional
+		public void withTransactionalAnnotationBeforeCommit(String data) {
 		}
 
 		@Transactional


### PR DESCRIPTION
Following discussions in #30679 and #31414, validation was added to restrict `@TransactionalEventListener` to only use `@Transactional(propagation = Propagation.REQUIRES_NEW)` or `@Transactional(propagation = Propagation.NOT_SUPPORTED)`.

However, this validation is unnecessary when the `@TransactionalEventListener` phase is `BEFORE_COMMIT` (excluding propagation `NEVER`). While removing the `@Transactional` would solve the issue, this creates unnecessary friction when upgrading Spring versions.