### PR TITLE
Make `targetBeanName` field in AbstractBeanFactoryBasedTargetSource `protected` to avoid exceptions in logging and `toString()`

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/target/AbstractBeanFactoryBasedTargetSource.java
+++ b/spring-aop/src/main/java/org/springframework/aop/target/AbstractBeanFactoryBasedTargetSource.java
@@ -95,6 +95,17 @@ public abstract class AbstractBeanFactoryBasedTargetSource implements TargetSour
 	}
 
 	/**
+ 	* Return the name of the target bean in the factory.
+ 	* If the configuration has not been completed yet, null can be returned
+ 	* If it's just for obtaining simple basic information, using it is very friendly.
+ 	* For example, toString().However, if strict non-null judgment is required,
+ 	* please use {@link #getTargetBeanName}
+ 	*/
+	public String getPlainTargetBeanName() {
+		return this.targetBeanName;
+	}
+	
+	/**
 	 * Specify the target class explicitly, to avoid any kind of access to the
 	 * target bean (for example, to avoid initialization of a FactoryBean instance).
 	 * <p>Default is to detect the type automatically, through a {@code getType}

--- a/spring-aop/src/main/java/org/springframework/aop/target/AbstractBeanFactoryBasedTargetSource.java
+++ b/spring-aop/src/main/java/org/springframework/aop/target/AbstractBeanFactoryBasedTargetSource.java
@@ -60,7 +60,7 @@ public abstract class AbstractBeanFactoryBasedTargetSource implements TargetSour
 	protected final transient Log logger = LogFactory.getLog(getClass());
 
 	/** Name of the target bean we will create on each invocation. */
-	private @Nullable String targetBeanName;
+	protected @Nullable String targetBeanName;
 
 	/** Class of the target. */
 	private volatile @Nullable Class<?> targetClass;
@@ -91,17 +91,6 @@ public abstract class AbstractBeanFactoryBasedTargetSource implements TargetSour
 	 */
 	public String getTargetBeanName() {
 		Assert.state(this.targetBeanName != null, "Target bean name not set");
-		return this.targetBeanName;
-	}
-
-	/**
- 	* Return the name of the target bean in the factory.
- 	* If the configuration has not been completed yet, null can be returned
- 	* If it's just for obtaining simple basic information, using it is very friendly.
- 	* For example, toString().However, if strict non-null judgment is required,
- 	* please use {@link #getTargetBeanName}
- 	*/
-	public String getPlainTargetBeanName() {
 		return this.targetBeanName;
 	}
 	

--- a/spring-aop/src/main/java/org/springframework/aop/target/AbstractPrototypeBasedTargetSource.java
+++ b/spring-aop/src/main/java/org/springframework/aop/target/AbstractPrototypeBasedTargetSource.java
@@ -54,7 +54,7 @@ public abstract class AbstractPrototypeBasedTargetSource extends AbstractBeanFac
 		if (!beanFactory.isPrototype(getTargetBeanName())) {
 			throw new BeanDefinitionStoreException(
 					"Cannot use prototype-based TargetSource against non-prototype bean with name '" +
-					getPlainTargetBeanName() + "': instances would not be independent");
+					this.targetBeanName + "': instances would not be independent");
 		}
 	}
 
@@ -64,7 +64,7 @@ public abstract class AbstractPrototypeBasedTargetSource extends AbstractBeanFac
 	 */
 	protected Object newPrototypeInstance() throws BeansException {
 		if (logger.isDebugEnabled()) {
-			logger.debug("Creating new instance of bean '" + getPlainTargetBeanName() + "'");
+			logger.debug("Creating new instance of bean '" + this.targetBeanName + "'");
 		}
 		return getBeanFactory().getBean(getTargetBeanName());
 	}
@@ -75,7 +75,7 @@ public abstract class AbstractPrototypeBasedTargetSource extends AbstractBeanFac
 	 */
 	protected void destroyPrototypeInstance(Object target) {
 		if (logger.isDebugEnabled()) {
-			logger.debug("Destroying instance of bean '" + getPlainTargetBeanName() + "'");
+			logger.debug("Destroying instance of bean '" + this.targetBeanName + "'");
 		}
 		if (getBeanFactory() instanceof ConfigurableBeanFactory cbf) {
 			cbf.destroyBean(getTargetBeanName(), target);
@@ -85,7 +85,7 @@ public abstract class AbstractPrototypeBasedTargetSource extends AbstractBeanFac
 				disposableBean.destroy();
 			}
 			catch (Throwable ex) {
-				logger.warn("Destroy method on bean with name '" + getPlainTargetBeanName() + "' threw an exception", ex);
+				logger.warn("Destroy method on bean with name '" + this.targetBeanName + "' threw an exception", ex);
 			}
 		}
 	}

--- a/spring-aop/src/main/java/org/springframework/aop/target/AbstractPrototypeBasedTargetSource.java
+++ b/spring-aop/src/main/java/org/springframework/aop/target/AbstractPrototypeBasedTargetSource.java
@@ -54,7 +54,7 @@ public abstract class AbstractPrototypeBasedTargetSource extends AbstractBeanFac
 		if (!beanFactory.isPrototype(getTargetBeanName())) {
 			throw new BeanDefinitionStoreException(
 					"Cannot use prototype-based TargetSource against non-prototype bean with name '" +
-					getTargetBeanName() + "': instances would not be independent");
+					getPlainTargetBeanName() + "': instances would not be independent");
 		}
 	}
 
@@ -64,7 +64,7 @@ public abstract class AbstractPrototypeBasedTargetSource extends AbstractBeanFac
 	 */
 	protected Object newPrototypeInstance() throws BeansException {
 		if (logger.isDebugEnabled()) {
-			logger.debug("Creating new instance of bean '" + getTargetBeanName() + "'");
+			logger.debug("Creating new instance of bean '" + getPlainTargetBeanName() + "'");
 		}
 		return getBeanFactory().getBean(getTargetBeanName());
 	}
@@ -75,7 +75,7 @@ public abstract class AbstractPrototypeBasedTargetSource extends AbstractBeanFac
 	 */
 	protected void destroyPrototypeInstance(Object target) {
 		if (logger.isDebugEnabled()) {
-			logger.debug("Destroying instance of bean '" + getTargetBeanName() + "'");
+			logger.debug("Destroying instance of bean '" + getPlainTargetBeanName() + "'");
 		}
 		if (getBeanFactory() instanceof ConfigurableBeanFactory cbf) {
 			cbf.destroyBean(getTargetBeanName(), target);
@@ -85,7 +85,7 @@ public abstract class AbstractPrototypeBasedTargetSource extends AbstractBeanFac
 				disposableBean.destroy();
 			}
 			catch (Throwable ex) {
-				logger.warn("Destroy method on bean with name '" + getTargetBeanName() + "' threw an exception", ex);
+				logger.warn("Destroy method on bean with name '" + getPlainTargetBeanName() + "' threw an exception", ex);
 			}
 		}
 	}

--- a/spring-aop/src/main/java/org/springframework/aop/target/PrototypeTargetSource.java
+++ b/spring-aop/src/main/java/org/springframework/aop/target/PrototypeTargetSource.java
@@ -54,7 +54,7 @@ public class PrototypeTargetSource extends AbstractPrototypeBasedTargetSource {
 
 	@Override
 	public String toString() {
-		return "PrototypeTargetSource for target bean with name '" + getTargetBeanName() + "'";
+		return "PrototypeTargetSource for target bean with name '" + getPlainTargetBeanName() + "'";
 	}
 
 }

--- a/spring-aop/src/main/java/org/springframework/aop/target/PrototypeTargetSource.java
+++ b/spring-aop/src/main/java/org/springframework/aop/target/PrototypeTargetSource.java
@@ -54,7 +54,7 @@ public class PrototypeTargetSource extends AbstractPrototypeBasedTargetSource {
 
 	@Override
 	public String toString() {
-		return "PrototypeTargetSource for target bean with name '" + getPlainTargetBeanName() + "'";
+		return "PrototypeTargetSource for target bean with name '" + this.targetBeanName + "'";
 	}
 
 }

--- a/spring-aop/src/main/java/org/springframework/aop/target/ThreadLocalTargetSource.java
+++ b/spring-aop/src/main/java/org/springframework/aop/target/ThreadLocalTargetSource.java
@@ -61,7 +61,7 @@ public class ThreadLocalTargetSource extends AbstractPrototypeBasedTargetSource
 			new NamedThreadLocal<>("Thread-local instance of bean") {
 				@Override
 				public String toString() {
-					return super.toString() + " '" + getPlainTargetBeanName() + "'";
+					return super.toString() + " '" + this.targetBeanName + "'";
 				}
 			};
 
@@ -86,7 +86,7 @@ public class ThreadLocalTargetSource extends AbstractPrototypeBasedTargetSource
 		Object target = this.targetInThread.get();
 		if (target == null) {
 			if (logger.isDebugEnabled()) {
-				logger.debug("No target for prototype '" + getPlainTargetBeanName() + "' bound to thread: " +
+				logger.debug("No target for prototype '" + this.targetBeanName + "' bound to thread: " +
 						"creating one and binding it to thread '" + Thread.currentThread().getName() + "'");
 			}
 			// Associate target with ThreadLocal.

--- a/spring-aop/src/main/java/org/springframework/aop/target/ThreadLocalTargetSource.java
+++ b/spring-aop/src/main/java/org/springframework/aop/target/ThreadLocalTargetSource.java
@@ -61,7 +61,7 @@ public class ThreadLocalTargetSource extends AbstractPrototypeBasedTargetSource
 			new NamedThreadLocal<>("Thread-local instance of bean") {
 				@Override
 				public String toString() {
-					return super.toString() + " '" + getTargetBeanName() + "'";
+					return super.toString() + " '" + getPlainTargetBeanName() + "'";
 				}
 			};
 
@@ -86,7 +86,7 @@ public class ThreadLocalTargetSource extends AbstractPrototypeBasedTargetSource
 		Object target = this.targetInThread.get();
 		if (target == null) {
 			if (logger.isDebugEnabled()) {
-				logger.debug("No target for prototype '" + getTargetBeanName() + "' bound to thread: " +
+				logger.debug("No target for prototype '" + getPlainTargetBeanName() + "' bound to thread: " +
 						"creating one and binding it to thread '" + Thread.currentThread().getName() + "'");
 			}
 			// Associate target with ThreadLocal.


### PR DESCRIPTION
Fix #35167 `AbstractBeanFactoryBasedTargetSourceCreator` getTargetSource method returns targetSource instance has yet to be completed TargetBeanName Settings, At this point, IDEA or an external tracking tool will call the toString() of targetSource, and toString() will call the getTargetBeanName() method. At this time, the assertion will throw an error.

# Analysis
The call chain is as follows：

- Container by `createBeanFactoryBasedTargetSource` method to obtain a targetSource instance，However, this instance has not completed the configuration Settings, such as setTargetBeanName and setBeanFactory.

- At this point, when IDEA calls targetSource to print the basic information of the object, it will call getTargetBeanName. At this time, targetBeanName==null. But there is an assertion here： `Assert.state(this.targetBeanName != null, "Target bean name not set")`, An error will be thrown at this point

[The Java® Language Specification](https://docs.oracle.com/javase/specs/jls/se24/html/jls-4.html#jls-4.3.1):**The method toString returns a String representation of the object**.  Therefore, after an object is instantiated, we should be able to call its toString() smoothly. So, according to the definition of the java specification, when we obtain the current property through the toString() method for display, it should be a simple get method directly obtaining the property, rather than undertaking logical judgment.  This violates the single responsibility of toString()

Similarly, we also have multiple loglogger.debug ("No target for prototype '" + getTargetBeanName()).Log recording itself should be a safe and side-effect-free operation. It must not disrupt the normal program flow. If log statements may throw exceptions, they may mask original errors, or even cause cascading failures
The following is the key code segment where the problem occurred:
```java
//   /aop/framework/autoproxy/targetAbstractBeanFactoryBasedTargetSourceCreator.java
@Override
	public final @Nullable TargetSource getTargetSource(Class<?> beanClass, String beanName) {
		AbstractBeanFactoryBasedTargetSource targetSource =
				createBeanFactoryBasedTargetSource(beanClass, beanName);
		if (targetSource == null) {
			return null;
		}

		if (logger.isDebugEnabled()) {
			logger.debug("Configuring AbstractBeanFactoryBasedTargetSource: " + targetSource);
		}

		DefaultListableBeanFactory internalBeanFactory = getInternalBeanFactoryForBean(beanName);

		// We need to override just this bean definition, as it may reference other beans
		// and we're happy to take the parent's definition for those.
		// Always use prototype scope if demanded.
		BeanDefinition bd = getConfigurableBeanFactory().getMergedBeanDefinition(beanName);
		GenericBeanDefinition bdCopy = new GenericBeanDefinition(bd);
		if (isPrototypeBased()) {
			bdCopy.setScope(BeanDefinition.SCOPE_PROTOTYPE);
		}
		internalBeanFactory.registerBeanDefinition(beanName, bdCopy);

		// Complete configuring the PrototypeTargetSource.
		targetSource.setTargetBeanName(beanName);
		targetSource.setBeanFactory(internalBeanFactory);

		return targetSource;
	}
```
```java
//  /aop/target /PrototypeTargetSource.java
@Override
	public String toString() {
		return "PrototypeTargetSource for target bean with name '" + getTargetBeanName() + "'";
	}
```

```java
//   org/springframework/aop/target /AbstractBeanFactoryBasedTargetSource.java
public String getTargetBeanName() {
		Assert.state(this.targetBeanName != null, "Target bean name not set");
		return this.targetBeanName;
	}
```
```java
//  org/springframework/aop/target /AbstractPrototypeBasedTargetSource.java
protected Object newPrototypeInstance() throws BeansException {
		if (logger.isDebugEnabled()) {
			logger.debug("Creating new instance of bean '" + getTargetBeanName() + "'");
		}
		return getBeanFactory().getBean(getTargetBeanName());
	}
```
# Solution
So in class AbstractBeanFactoryBasedTargetSourceCreator increase method named getPlainTargetBeanName (), 
```java
public String getPlainTargetBeanName() {
		return this.targetBeanName;
	}
```
This simple method is used to provide plain targetBeanName.toString() and both logger calls. When calling methods that require strict non-null judgment, use the original getTargetBeanName()


