### PR TITLE
Allow explicitly declared null in providedArgs when no argument resolver matches

### DIFF
--- a/spring-test/src/test/java/org/springframework/test/web/servlet/samples/standalone/ExceptionHandlerTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/samples/standalone/ExceptionHandlerTests.java
@@ -29,6 +29,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.HandlerMethod;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
@@ -62,6 +63,14 @@ public class ExceptionHandlerTests {
 				.andExpect(status().isOk())
 				.andExpect(forwardedUrl("globalErrorView"));
 		}
+
+		@Test
+		void nullHandlerMethod() throws Exception {
+			standaloneSetup(new PersonController()).setControllerAdvice(new GlobalExceptionHandler()).build()
+				.perform(get("/invalid"))
+				.andExpect(status().isOk())
+				.andExpect(forwardedUrl("null handlerMethod exception"));
+		}
 	}
 
 
@@ -91,6 +100,14 @@ public class ExceptionHandlerTests {
 		@ExceptionHandler
 		String handleException(IllegalStateException exception) {
 			return "globalErrorView";
+		}
+
+		@ExceptionHandler(Exception.class)
+		String handleAllExceptions(IllegalStateException exception, HandlerMethod handlerMethod) {
+			if (handlerMethod == null) {
+				return "null handlerMethod exception";
+			}
+			return "simulated exception";
 		}
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/method/support/InvocableHandlerMethod.java
+++ b/spring-web/src/main/java/org/springframework/web/method/support/InvocableHandlerMethod.java
@@ -218,6 +218,10 @@ public class InvocableHandlerMethod extends HandlerMethod {
 				continue;
 			}
 			if (!this.resolvers.supportsParameter(parameter)) {
+				if (isParameterDeclaredButNull(parameter, providedArgs)) {
+					args[i] = null;
+					continue;
+				}
 				throw new IllegalStateException(formatArgumentError(parameter, "No suitable resolver"));
 			}
 			try {
@@ -235,6 +239,27 @@ public class InvocableHandlerMethod extends HandlerMethod {
 			}
 		}
 		return args;
+	}
+
+	/**
+	 * If there is null in providedArgs and the paramType does not have any non-null value matching, then consider null to be explicit.
+	 */
+	private boolean isParameterDeclaredButNull(MethodParameter parameter, @Nullable Object[] providedArgs) {
+		if (providedArgs == null) {
+			return false;
+		}
+		Class<?> paramType = parameter.getParameterType();
+		boolean hasNull = false;
+		for (Object arg : providedArgs) {
+			if (arg == null) {
+				hasNull = true;
+				continue;
+			}
+			if (paramType.isAssignableFrom(arg.getClass())) {
+				return false;
+			}
+		}
+		return hasNull;
 	}
 
 	/**

--- a/spring-web/src/main/java/org/springframework/web/method/support/InvocableHandlerMethod.java
+++ b/spring-web/src/main/java/org/springframework/web/method/support/InvocableHandlerMethod.java
@@ -245,7 +245,7 @@ public class InvocableHandlerMethod extends HandlerMethod {
 	 * If there is null in providedArgs and the paramType does not have any non-null value matching, then consider null to be explicit.
 	 */
 	private boolean isParameterDeclaredButNull(MethodParameter parameter, @Nullable Object[] providedArgs) {
-		if (providedArgs == null) {
+		if (ObjectUtils.isEmpty(providedArgs)) {
 			return false;
 		}
 		Class<?> paramType = parameter.getParameterType();


### PR DESCRIPTION
### Overview

This PR addresses an issue where `InvocableHandlerMethod#getMethodArgumentValues` throws an `IllegalStateException`
when a method parameter is not supported by any `HandlerMethodArgumentResolver` and `null` is explicitly provided in `providedArgs`.

### What this PR does

- Adds a fallback check via `isParameterDeclaredButNull(...)` to tolerate explicit `null` values
- Ensures that null in `providedArgs` is interpreted as a deliberate argument, avoiding spurious resolution failures

### Why this is useful

In practice, this improves error handler behavior, especially for `@ExceptionHandler` where the HandlerMethod can be `null`.

### Related issue

Fixes [#35067](https://github.com/spring-projects/spring-framework/issues/35067)