### PR TITLE
Remove redundant value from `illegalClasses` for `IllegalImportCheck`

### DIFF
--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -107,7 +107,7 @@
 			<property name="id" value="bannedImports"/>
 			<property name="regexp" value="true"/>
 			<property name="illegalClasses"
-				value="^reactor\.core\.support\.Assert,^org\.slf4j\.LoggerFactory,^(?!org\.jspecify|\.annotations).*(NonNull|Nullable),^org\.jetbrains\.annotations\.Nullable$"/>
+				value="^reactor\.core\.support\.Assert,^org\.slf4j\.LoggerFactory,^(?!org\.jspecify|\.annotations).*(NonNull|Nullable)"/>
 		</module>
 		<module name="com.puppycrawl.tools.checkstyle.checks.imports.IllegalImportCheck">
 			<property name="id" value="bannedJUnit3Imports"/>


### PR DESCRIPTION
## Overview

This PR removes redundant value from `illegalClasses` for `IllegalImportCheck` as it seems to be covered by `^(?!org\.jspecify|\.annotations).*(NonNull|Nullable)` already.

## Related Issues

- #35114