### PR TITLE
Add support for list value resolution from YAML block-style in `Environment.getProperty()`

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/env/MapPropertySource.java
+++ b/spring-core/src/main/java/org/springframework/core/env/MapPropertySource.java
@@ -16,6 +16,8 @@
 
 package org.springframework.core.env;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
@@ -29,6 +31,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Chris Beams
  * @author Juergen Hoeller
+ * @author Nabil Fawwaz Elqayyim
  * @since 3.1
  * @see PropertiesPropertySource
  */
@@ -44,10 +47,43 @@ public class MapPropertySource extends EnumerablePropertySource<Map<String, Obje
 		super(name, source);
 	}
 
-
+	/**
+	 * Returns the value associated with the given property name.
+	 * <p>
+	 * First, this method checks for an exact match in the underlying {@code source} map.
+	 * If not found, it attempts to reconstruct a {@link List} from sequentially indexed keys
+	 * (e.g. {@code name[0]}, {@code name[1]}, ...), stopping at the first missing index.
+	 * <p>
+	 * Values that implement {@link CharSequence} are converted to plain {@link String} instances.
+	 * @param name the property name to resolve
+	 * @return the resolved value, or {@code null} if not found
+	 */
 	@Override
 	public @Nullable Object getProperty(String name) {
-		return this.source.get(name);
+		Object directMatch = this.source.get(name);
+
+		if (directMatch != null) {
+			return directMatch;
+		}
+
+		List<Object> collectedValues = new ArrayList<>();
+		for (int index = 0; ; index++) {
+			String indexedKey = name + "[" + index + "]";
+			if (!this.source.containsKey(indexedKey)) {
+				break;
+			}
+
+			Object rawIndexedValue = this.source.get(indexedKey);
+
+			if (rawIndexedValue instanceof CharSequence cs) {
+				collectedValues.add(cs.toString());
+			}
+			else {
+				collectedValues.add(rawIndexedValue);
+			}
+		}
+
+		return collectedValues.isEmpty() ? null : collectedValues;
 	}
 
 	@Override


### PR DESCRIPTION
## Overview

This PR enables `Environment.getProperty()` to retrieve **list values** defined using YAML block-style notation, aligning its behavior with the already-supported inline style.

Previously, this method supported only inline list syntax (`key: i,like,fish`) but failed when the YAML used block-style notation:

```yaml
key:
  - i
  - like
  - fish
 ```

As a result, calling:
```java
List<String> values = environment.getProperty("key", (Class<List<String>>) List.class);
```

would return **`null`** for block-style YAML. The issue is tracked in [GitHub issue #35179](https://github.com/spring-projects/spring-framework/issues/35179).

Spring’s Environment.getProperty() currently supports retrieving List<String> values only when defined as a comma-separated string. YAML block-style list definitions, which are semantically equivalent, are ignored.

✅ YAML Supported (Inline):
```yaml
first:
  second: i,like,fish
```
This works as expected:
```java
List<String> values = environment.getProperty("first.second", List.class);
```

❌ YAML Not Supported (Block-style):
```yaml
first:
  second:
    - i
    - like
    - fish
```

This returns **`null`**  for the same code:
```java
List<String> values = environment.getProperty("first.second", List.class); 
```

## The Solution
This PR enhances property resolution logic to support indexed keys such as:
```groovy
first.second[0]=i
first.second[1]=love
first.second[2]=spring
```
This format corresponds to block-style YAML and is now properly aggregated into a List when calling:
```java
environment.getProperty("first.second", List.class);
```

Internally, `PropertySource#getProperty()` is updated to collect indexed entries into a list when a direct match is not found.

## Test Coverage

This fix is verified by the following test cases:

```java
@Test
void returnsListOfStringsFromIndexedKeys() { ... }

@Test
void returnsListOfMixedTypesFromIndexedKeys() { ... }

@Test
void returnsListOfIntegersFromIndexedKeys() { ... }

@Test
void returnsNullWhenNoDirectMatchAndNoIndexedKeys() { ... }
```

These tests ensure list values can be resolved from indexed keys when using Environment.getProperty().

## Related Issue
- Fixes: [#35179](https://github.com/spring-projects/spring-framework/issues/35179)

---
- [x] I have read the [Spring Framework contribution guidelines](https://github.com/spring-projects/spring-framework/blob/main/CONTRIBUTING.adoc)
- [x] The fix is verified by a test cases
- [x] I included a Signed-off-by trailer in the commit
- [x] I avoided unrelated formatting changes
- [x] I added myself as the author where applicable