### PR TITLE
Correct the default value of nestedTransactionAllowed in JpaTransactionManager javadoc

### DIFF
--- a/spring-orm/src/main/java/org/springframework/orm/jpa/JpaTransactionManager.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/JpaTransactionManager.java
@@ -98,9 +98,7 @@ import org.springframework.util.CollectionUtils;
  * context. You can manually set the flag to {@code false} if you want to disallow nested
  * transactions for JDBC access code which participates in JPA transactions (provided
  * that your JDBC driver supports Savepoints). <i>Note that JPA itself does not support
- * nested transactions! Furthermore, as most JPA providers (e.g., Hibernate)
- * do not support savepoints, {@code Propagation.NESTED} will not work and will typically
- * result in an exception. Hence, do not expect JPA access code to semantically
+ * nested transactions! Hence, do not expect JPA access code to semantically
  * participate in a nested transaction.</i>
  *
  * @author Juergen Hoeller

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/JpaTransactionManager.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/JpaTransactionManager.java
@@ -93,9 +93,9 @@ import org.springframework.util.CollectionUtils;
  *
  * <p>This transaction manager supports nested transactions via JDBC Savepoints.
  * The {@link #setNestedTransactionAllowed "nestedTransactionAllowed"} flag defaults
- * to {@code false} though, since nested transactions will just apply to the JDBC
+ * to {@code true} though, since nested transactions will just apply to the JDBC
  * Connection, not to the JPA EntityManager and its cached entity objects and related
- * context. You can manually set the flag to {@code true} if you want to use nested
+ * context. You can manually set the flag to {@code false} if you want to disallow nested
  * transactions for JDBC access code which participates in JPA transactions (provided
  * that your JDBC driver supports Savepoints). <i>Note that JPA itself does not support
  * nested transactions! Hence, do not expect JPA access code to semantically

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/JpaTransactionManager.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/JpaTransactionManager.java
@@ -93,12 +93,14 @@ import org.springframework.util.CollectionUtils;
  *
  * <p>This transaction manager supports nested transactions via JDBC Savepoints.
  * The {@link #setNestedTransactionAllowed "nestedTransactionAllowed"} flag defaults
- * to {@code true} though, since nested transactions will just apply to the JDBC
+ * to {@code true}, but nested transactions will just apply to the JDBC
  * Connection, not to the JPA EntityManager and its cached entity objects and related
  * context. You can manually set the flag to {@code false} if you want to disallow nested
  * transactions for JDBC access code which participates in JPA transactions (provided
  * that your JDBC driver supports Savepoints). <i>Note that JPA itself does not support
- * nested transactions! Hence, do not expect JPA access code to semantically
+ * nested transactions! Furthermore, as most JPA providers (e.g., Hibernate)
+ * do not support savepoints, {@code Propagation.NESTED} will not work and will typically
+ * result in an exception. Hence, do not expect JPA access code to semantically
  * participate in a nested transaction.</i>
  *
  * @author Juergen Hoeller


### PR DESCRIPTION
**Correct the default value of nestedTransactionAllowed in Javadoc**

* Changed the default value in the Javadoc from `false` to `true`
* For smoother wording, replaced **"though, since" to "but"** and **“use” with “disallow”**

The [Javadoc](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/orm/jpa/JpaTransactionManager.html) for JpaTransactionManager currently states that the nestedTransactionAllowed flag defaults to false. However, the default constructor has been setting this flag to true.

```java
/**
* Create a new JpaTransactionManager instance.
* <p>An EntityManagerFactory has to be set to be able to use it.
* @see #setEntityManagerFactory
*/
public JpaTransactionManager() {
    setNestedTransactionAllowed(true);
}
```

This PR updates the documentation to align with the actual behavior, ensuring consistency between the code and its Javadoc.

Let me know if you have any concerns or suggestions for further improvement.
Thank you for your time and consideration!