### PR TITLE
Add meta-annotations support for @RequestHeader in spring-web, and spring-webflux 

### DIFF
--- a/framework-docs/modules/ROOT/pages/web/webflux/controller/ann-methods/requestheader.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webflux/controller/ann-methods/requestheader.adoc
@@ -64,7 +64,8 @@ array or collection of strings or other types known to the type conversion syste
 example, a method parameter annotated with `@RequestHeader("Accept")` may be of type
 `String` but also of `String[]` or `List<String>`.
 
-We can further remove our dependency on Spring Web MVC by making `@RequestHeader` a meta-annotation on our own annotation. The next example demonstrates how we could do so on an annotation named `@LanguageRequestHeader`.
+We can use `@RequestHeader` as a meta-annotation, so you can create custom annotations for repeatedly used headers, like the `Accept-Language` header.
+The next example demonstrates how we could do this with an annotation named `@LanguageRequestHeader`:
 
 [tabs]
 ======
@@ -91,7 +92,7 @@ annotation class LanguageRequestHeader
 ----
 ======
 
-We have isolated our dependency on Spring MVC to a single file. Now that `@LanguageRequestHeader` has been specified, we can use it to signal to resolve our LanguageRequestHeader of the currently `Accept-Language` request header:
+Now that `@LanguageRequestHeader` has been specified, we can use it to signal Spring to resolve our `@LanguageRequestHeader` from the current `Accept-Language` request header:
 
 [tabs]
 ======
@@ -119,4 +120,4 @@ fun fetchProduct(@LanguageRequestHeader lang: String): Flux<Product> {
 ======
 
 
-TIP: We can replace the lang parameter type from `String` to `java.util.Locale` or to our own Language enum, and Spring will handle the conversion of the header value.
+TIP: We can replace the lang parameter type from `String` to `java.util.Locale` or to your own Language enum, and Spring will handle the conversion of the header value. You may need to implement the xref:core/validation/convert.adoc[`Converter`] interface and register it.

--- a/framework-docs/modules/ROOT/pages/web/webflux/controller/ann-methods/requestheader.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webflux/controller/ann-methods/requestheader.adoc
@@ -63,3 +63,60 @@ TIP: Built-in support is available for converting a comma-separated string into 
 array or collection of strings or other types known to the type conversion system. For
 example, a method parameter annotated with `@RequestHeader("Accept")` may be of type
 `String` but also of `String[]` or `List<String>`.
+
+We can further remove our dependency on Spring Web MVC by making `@RequestHeader` a meta-annotation on our own annotation. The next example demonstrates how we could do so on an annotation named `@LanguageRequestHeader`.
+
+[tabs]
+======
+Java::
++
+[source,java,indent=0,subs="verbatim,quotes"]
+----
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@RequestHeader(value = HttpHeaders.ACCEPT_LANGUAGE, defaultValue = "en")
+public @interface LanguageRequestHeader {}
+----
+
+Kotlin::
++
+[source,kotlin,indent=0,subs="verbatim,quotes"]
+----
+@Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.TYPE)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@RequestHeader(value = HttpHeaders.ACCEPT_LANGUAGE, defaultValue = "en")
+annotation class LanguageRequestHeader
+----
+======
+
+We have isolated our dependency on Spring MVC to a single file. Now that `@LanguageRequestHeader` has been specified, we can use it to signal to resolve our LanguageRequestHeader of the currently `Accept-Language` request header:
+
+[tabs]
+======
+Java::
++
+[source,java,indent=0,subs="verbatim,quotes"]
+----
+@GetMapping("/product")
+public Flux<Product> fetchProduct(@LanguageRequestHeader String lang) {
+
+	// .. fetch product and return them ...
+}
+----
+
+Kotlin::
++
+[source,kotlin,indent=0,subs="verbatim,quotes"]
+----
+@GetMapping("/product")
+fun fetchProduct(@LanguageRequestHeader lang: String): Flux<Product> {
+
+    // .. fetch product and return them ...
+}
+----
+======
+
+
+TIP: We can replace the lang parameter type from `String` to `java.util.Locale` or to our own Language enum, and Spring will handle the conversion of the header value.

--- a/framework-docs/modules/ROOT/pages/web/webmvc/mvc-controller/ann-methods/requestheader.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc/mvc-controller/ann-methods/requestheader.adoc
@@ -64,7 +64,9 @@ array or collection of strings or other types known to the type conversion syste
 example, a method parameter annotated with `@RequestHeader("Accept")` can be of type
 `String` but also `String[]` or `List<String>`.
 
-We can further remove our dependency on Spring Web MVC by making `@RequestHeader` a meta-annotation on our own annotation. The next example demonstrates how we could do so on an annotation named `@LanguageRequestHeader`.
+
+We can use `@RequestHeader` as a meta-annotation, so you can create custom annotations for repeatedly used headers, like the `Accept-Language` header.
+The next example demonstrates how we could do this with an annotation named `@LanguageRequestHeader`:
 
 [tabs]
 ======
@@ -91,7 +93,7 @@ annotation class LanguageRequestHeader
 ----
 ======
 
-We have isolated our dependency on Spring MVC to a single file. Now that `@LanguageRequestHeader` has been specified, we can use it to signal to resolve our LanguageRequestHeader of the currently `Accept-Language` request header:
+Now that `@LanguageRequestHeader` has been specified, we can use it to signal Spring to resolve our `@LanguageRequestHeader` from the current `Accept-Language` request header:
 
 [tabs]
 ======
@@ -119,4 +121,4 @@ fun fetchProduct(@LanguageRequestHeader lang: String): List<Product> {
 ======
 
 
-TIP: We can replace the lang parameter type from `String` to `java.util.Locale` or to our own Language enum, and Spring will handle the conversion of the header value.
+TIP: We can replace the lang parameter type from `String` to `java.util.Locale` or to your own Language enum, and Spring will handle the conversion of the header value. You may need to implement the xref:core/validation/convert.adoc[`Converter`] interface and register it.

--- a/framework-docs/modules/ROOT/pages/web/webmvc/mvc-controller/ann-methods/requestheader.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc/mvc-controller/ann-methods/requestheader.adoc
@@ -63,3 +63,60 @@ TIP: Built-in support is available for converting a comma-separated string into 
 array or collection of strings or other types known to the type conversion system. For
 example, a method parameter annotated with `@RequestHeader("Accept")` can be of type
 `String` but also `String[]` or `List<String>`.
+
+We can further remove our dependency on Spring Web MVC by making `@RequestHeader` a meta-annotation on our own annotation. The next example demonstrates how we could do so on an annotation named `@LanguageRequestHeader`.
+
+[tabs]
+======
+Java::
++
+[source,java,indent=0,subs="verbatim,quotes"]
+----
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@RequestHeader(value = HttpHeaders.ACCEPT_LANGUAGE, defaultValue = "en")
+public @interface LanguageRequestHeader {}
+----
+
+Kotlin::
++
+[source,kotlin,indent=0,subs="verbatim,quotes"]
+----
+@Target(AnnotationTarget.VALUE_PARAMETER, AnnotationTarget.TYPE)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@RequestHeader(value = HttpHeaders.ACCEPT_LANGUAGE, defaultValue = "en")
+annotation class LanguageRequestHeader
+----
+======
+
+We have isolated our dependency on Spring MVC to a single file. Now that `@LanguageRequestHeader` has been specified, we can use it to signal to resolve our LanguageRequestHeader of the currently `Accept-Language` request header:
+
+[tabs]
+======
+Java::
++
+[source,java,indent=0,subs="verbatim,quotes"]
+----
+@GetMapping("/product")
+public List<Product> fetchProduct(@LanguageRequestHeader String lang) {
+
+	// .. fetch product and return them ...
+}
+----
+
+Kotlin::
++
+[source,kotlin,indent=0,subs="verbatim,quotes"]
+----
+@GetMapping("/product")
+fun fetchProduct(@LanguageRequestHeader lang: String): List<Product> {
+
+    // .. fetch product and return them ...
+}
+----
+======
+
+
+TIP: We can replace the lang parameter type from `String` to `java.util.Locale` or to our own Language enum, and Spring will handle the conversion of the header value.

--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/RequestHeader.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/RequestHeader.java
@@ -41,7 +41,7 @@ import org.springframework.core.annotation.AliasFor;
  * @see RequestParam
  * @see CookieValue
  */
-@Target(ElementType.PARAMETER)
+@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface RequestHeader {

--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/RequestHeader.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/RequestHeader.java
@@ -37,7 +37,6 @@ import org.springframework.core.annotation.AliasFor;
  *
  * @author Juergen Hoeller
  * @author Sam Brannen
- * @author Zakaria Shahen
  * @since 3.0
  * @see RequestMapping
  * @see RequestParam

--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/RequestHeader.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/RequestHeader.java
@@ -27,7 +27,8 @@ import org.springframework.core.annotation.AliasFor;
 /**
  * Annotation which indicates that a method parameter should be bound to a web request header.
  *
- * <p>Supported for annotated handler methods in Spring MVC and Spring WebFlux.
+ * <p>Supported for declared as a meta-annotation or directly annotated handler methods
+ * in Spring MVC and Spring WebFlux.
  *
  * <p>If the method parameter is {@link java.util.Map Map&lt;String, String&gt;},
  * {@link org.springframework.util.MultiValueMap MultiValueMap&lt;String, String&gt;},
@@ -36,6 +37,7 @@ import org.springframework.core.annotation.AliasFor;
  *
  * @author Juergen Hoeller
  * @author Sam Brannen
+ * @author Zakaria Shahen
  * @since 3.0
  * @see RequestMapping
  * @see RequestParam

--- a/spring-web/src/main/java/org/springframework/web/method/annotation/HandlerMethodValidationException.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/HandlerMethodValidationException.java
@@ -155,7 +155,7 @@ public class HandlerMethodValidationException extends ResponseStatusException im
 				}
 				continue;
 			}
-			RequestHeader requestHeader = param.getParameterAnnotation(RequestHeader.class);
+			RequestHeader requestHeader = param.getParameterNestedAnnotation(RequestHeader.class);
 			if (requestHeader != null) {
 				visitor.requestHeader(requestHeader, result);
 				continue;

--- a/spring-web/src/main/java/org/springframework/web/method/annotation/RequestHeaderMethodArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/RequestHeaderMethodArgumentResolver.java
@@ -61,14 +61,14 @@ public class RequestHeaderMethodArgumentResolver extends AbstractNamedValueMetho
 
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {
-		return (parameter.hasParameterAnnotation(RequestHeader.class) &&
+		return (parameter.hasParameterNestedAnnotation(RequestHeader.class) &&
 				!Map.class.isAssignableFrom(parameter.nestedIfOptional().getNestedParameterType())) &&
 				!HttpHeaders.class.isAssignableFrom(parameter.nestedIfOptional().getNestedParameterType());
 	}
 
 	@Override
 	protected NamedValueInfo createNamedValueInfo(MethodParameter parameter) {
-		RequestHeader ann = parameter.getParameterAnnotation(RequestHeader.class);
+		RequestHeader ann = parameter.getParameterNestedAnnotation(RequestHeader.class);
 		Assert.state(ann != null, "No RequestHeader annotation");
 		return new RequestHeaderNamedValueInfo(ann);
 	}

--- a/spring-web/src/main/java/org/springframework/web/service/invoker/RequestHeaderArgumentResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/service/invoker/RequestHeaderArgumentResolver.java
@@ -60,7 +60,7 @@ public class RequestHeaderArgumentResolver extends AbstractNamedValueArgumentRes
 
 	@Override
 	protected @Nullable NamedValueInfo createNamedValueInfo(MethodParameter parameter) {
-		RequestHeader annot = parameter.getParameterAnnotation(RequestHeader.class);
+		RequestHeader annot = parameter.getParameterNestedAnnotation(RequestHeader.class);
 		return (annot == null ? null :
 				new NamedValueInfo(annot.name(), annot.required(), annot.defaultValue(), "request header", true));
 	}

--- a/spring-web/src/test/java/org/springframework/web/method/support/HandlerMethodValidationExceptionTests.java
+++ b/spring-web/src/test/java/org/springframework/web/method/support/HandlerMethodValidationExceptionTests.java
@@ -16,20 +16,11 @@
 
 package org.springframework.web.method.support;
 
-import java.lang.annotation.*;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.List;
-import java.util.StringJoiner;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
-
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.beans.BeanUtils;
 import org.springframework.context.MessageSourceResolvable;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
@@ -52,6 +43,18 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.testfixture.method.ResolvableMethod;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/spring-web/src/test/java/org/springframework/web/method/support/HandlerMethodValidationExceptionTests.java
+++ b/spring-web/src/test/java/org/springframework/web/method/support/HandlerMethodValidationExceptionTests.java
@@ -16,11 +16,24 @@
 
 package org.springframework.web.method.support;
 
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
+
 import org.springframework.beans.BeanUtils;
 import org.springframework.context.MessageSourceResolvable;
 import org.springframework.context.support.DefaultMessageSourceResolvable;
@@ -43,18 +56,6 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.testfixture.method.ResolvableMethod;
-
-import java.lang.annotation.Annotation;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-import java.lang.reflect.Method;
-import java.util.Arrays;
-import java.util.List;
-import java.util.StringJoiner;
-import java.util.function.Consumer;
-import java.util.function.Predicate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -138,7 +139,6 @@ class HandlerMethodValidationExceptionTests {
 						})
 						.toList());
 	}
-
 
 
 	@SuppressWarnings("unused")

--- a/spring-web/src/test/java/org/springframework/web/method/support/HandlerMethodValidationExceptionTests.java
+++ b/spring-web/src/test/java/org/springframework/web/method/support/HandlerMethodValidationExceptionTests.java
@@ -16,7 +16,7 @@
 
 package org.springframework.web.method.support;
 
-import java.lang.annotation.Annotation;
+import java.lang.annotation.*;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
@@ -68,7 +68,7 @@ class HandlerMethodValidationExceptionTests {
 
 
 	private final HandlerMethod handlerMethod = handlerMethod(new ValidController(),
-			controller -> controller.handle(person, person, person, List.of(), person, "", "", "", "", "", ""));
+			controller -> controller.handle(person, person, person, List.of(), person, "", "", "", "", "", "", ""));
 
 	private final TestVisitor visitor = new TestVisitor();
 
@@ -87,7 +87,7 @@ class HandlerMethodValidationExceptionTests {
 				@ModelAttribute: modelAttribute1, @ModelAttribute: modelAttribute2, \
 				@RequestBody: requestBody, @RequestBody: requestBodyList, @RequestPart: requestPart, \
 				@RequestParam: requestParam1, @RequestParam: requestParam2, \
-				@RequestHeader: header, @PathVariable: pathVariable, \
+				@RequestHeader: header, @RequestHeader: nestedAnnotationHeader, @PathVariable: pathVariable, \
 				@CookieValue: cookie, @MatrixVariable: matrixVariable""");
 	}
 
@@ -103,7 +103,7 @@ class HandlerMethodValidationExceptionTests {
 				Other: modelAttribute1, @ModelAttribute: modelAttribute2, \
 				@RequestBody: requestBody, @RequestBody: requestBodyList, @RequestPart: requestPart, \
 				Other: requestParam1, @RequestParam: requestParam2, \
-				@RequestHeader: header, @PathVariable: pathVariable, \
+				@RequestHeader: header, @RequestHeader: nestedAnnotationHeader, @PathVariable: pathVariable, \
 				@CookieValue: cookie, @MatrixVariable: matrixVariable""");
 	}
 
@@ -161,11 +161,17 @@ class HandlerMethodValidationExceptionTests {
 				@Size(min = 5) String requestParam1,
 				@Size(min = 5) @RequestParam String requestParam2,
 				@Size(min = 5) @RequestHeader String header,
+				@Size(min = 5) @HeaderRequestHeader String nestedAnnotationHeader,
 				@Size(min = 5) @PathVariable String pathVariable,
 				@Size(min = 5) @CookieValue String cookie,
 				@Size(min = 5) @MatrixVariable String matrixVariable) {
 		}
 
+		@Target(ElementType.PARAMETER)
+		@Retention(RetentionPolicy.RUNTIME)
+		@RequestHeader(name = "header")
+		private @interface HeaderRequestHeader {
+		}
 	}
 
 

--- a/spring-web/src/test/java/org/springframework/web/service/invoker/RequestHeaderArgumentResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/service/invoker/RequestHeaderArgumentResolverTests.java
@@ -16,6 +16,10 @@
 
 package org.springframework.web.service.invoker;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -57,6 +61,12 @@ class RequestHeaderArgumentResolverTests {
 		assertRequestHeaders("myHeader", "1", "2");
 	}
 
+	@Test
+	void doesNestedAnnotationNotOverrideAnnotationHeaders() {
+		this.service.executeWithAnnotationHeadersAndNestedAnnotation("2");
+		assertRequestHeaders("myHeader", "1", "2");
+	}
+
 	private void assertRequestHeaders(String key, String... values) {
 		List<String> actualValues = this.client.getRequestValues().getHeaders().get(key);
 		if (ObjectUtils.isEmpty(values)) {
@@ -76,6 +86,14 @@ class RequestHeaderArgumentResolverTests {
 		@HttpExchange(method = "GET", headers = "myHeader=1")
 		void executeWithAnnotationHeaders(@RequestHeader String myHeader);
 
+		@HttpExchange(method = "GET", headers = "myHeader=1")
+		void executeWithAnnotationHeadersAndNestedAnnotation(@MyHeader String myHeader);
+
 	}
 
+	@Target(ElementType.PARAMETER)
+	@Retention(RetentionPolicy.RUNTIME)
+	@RequestHeader(name = "myHeader")
+	private @interface MyHeader {
+	}
 }

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/HandlerMethodArgumentResolverSupport.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/HandlerMethodArgumentResolverSupport.java
@@ -118,6 +118,31 @@ public abstract class HandlerMethodArgumentResolverSupport implements HandlerMet
 			return false;
 		}
 
+		return checkAnnotatedParamNoReactiveWrapperCommon(parameter, annotation, typePredicate);
+	}
+
+
+	/**
+	 * Evaluate the {@code Predicate} on the method parameter type if it has the
+	 * given annotation, either directly declared or as a meta-annotation,
+	 * nesting within {@link java.util.Optional} if necessary,
+	 * but raise an {@code IllegalStateException} if the same matches the generic
+	 * type within a reactive type wrapper.
+	 */
+	protected <A extends Annotation> boolean checkNestedAnnotatedParamNoReactiveWrapper(
+			MethodParameter parameter, Class<A> annotationType, BiPredicate<A, Class<?>> typePredicate) {
+
+		A annotation = parameter.getParameterNestedAnnotation(annotationType);
+		if (annotation == null) {
+			return false;
+		}
+
+		return checkAnnotatedParamNoReactiveWrapperCommon(parameter, annotation, typePredicate);
+	}
+
+	private  <A extends Annotation> boolean checkAnnotatedParamNoReactiveWrapperCommon(
+			MethodParameter parameter, A annotation, BiPredicate<A, Class<?>> typePredicate) {
+
 		parameter = parameter.nestedIfOptional();
 		Class<?> type = parameter.getNestedParameterType();
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/HandlerMethodArgumentResolverSupport.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/HandlerMethodArgumentResolverSupport.java
@@ -140,7 +140,7 @@ public abstract class HandlerMethodArgumentResolverSupport implements HandlerMet
 		return checkAnnotatedParamNoReactiveWrapperCommon(parameter, annotation, typePredicate);
 	}
 
-	private  <A extends Annotation> boolean checkAnnotatedParamNoReactiveWrapperCommon(
+	private <A extends Annotation> boolean checkAnnotatedParamNoReactiveWrapperCommon(
 			MethodParameter parameter, A annotation, BiPredicate<A, Class<?>> typePredicate) {
 
 		parameter = parameter.nestedIfOptional();

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestHeaderMethodArgumentResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestHeaderMethodArgumentResolver.java
@@ -65,7 +65,7 @@ public class RequestHeaderMethodArgumentResolver extends AbstractNamedValueSyncA
 
 	@Override
 	public boolean supportsParameter(MethodParameter param) {
-		return checkAnnotatedParamNoReactiveWrapper(param, RequestHeader.class, this::singleParam);
+		return checkNestedAnnotatedParamNoReactiveWrapper(param, RequestHeader.class, this::singleParam);
 	}
 
 	private boolean singleParam(RequestHeader annotation, Class<?> type) {
@@ -74,7 +74,7 @@ public class RequestHeaderMethodArgumentResolver extends AbstractNamedValueSyncA
 
 	@Override
 	protected NamedValueInfo createNamedValueInfo(MethodParameter parameter) {
-		RequestHeader ann = parameter.getParameterAnnotation(RequestHeader.class);
+		RequestHeader ann = parameter.getParameterNestedAnnotation(RequestHeader.class);
 		Assert.state(ann != null, "No RequestHeader annotation");
 		return new RequestHeaderNamedValueInfo(ann);
 	}


### PR DESCRIPTION
As was requested in gh-21829.
Also, I'm open to adding meta-annotation support (if needed) for the following annotations. (ref: https://github.com/spring-projects/spring-framework/issues/21829#issuecomment-956252567)

`@CookieValue`
`@MatrixVariable`
`@ModelAttribute`
`@PathVariable`
`@RequestAttribute`
`@RequestBody`
`@RequestParam`
`@RequestPart`
`@SessionAttribute`

Closes gh-21829

Thanks. 