### PR TITLE
Allow getting receipt from StompSession.Subscription.unsubscribe()

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/DefaultStompSession.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/DefaultStompSession.java
@@ -345,14 +345,24 @@ public class DefaultStompSession implements ConnectionHandlingStompSession {
 		return receiptable;
 	}
 
-	private void unsubscribe(String id, @Nullable StompHeaders headers) {
-		StompHeaderAccessor accessor = createHeaderAccessor(StompCommand.UNSUBSCRIBE);
-		if (headers != null) {
-			accessor.addNativeHeaders(headers);
+	private Receiptable unsubscribe(String id, @Nullable StompHeaders headers) {
+		Assert.hasText(id, "Subscription id is required");
+
+		if (headers == null){
+			headers = new StompHeaders();
 		}
+
+		String receiptId = checkOrAddReceipt(headers);
+		Receiptable receiptable = new ReceiptHandler(receiptId);
+
+		StompHeaderAccessor accessor = createHeaderAccessor(StompCommand.UNSUBSCRIBE);
+		accessor.addNativeHeaders(headers);
 		accessor.setSubscriptionId(id);
+
 		Message<byte[]> message = createMessage(accessor, EMPTY_PAYLOAD);
 		execute(message);
+
+		return receiptable;
 	}
 
 	@Override
@@ -674,17 +684,19 @@ public class DefaultStompSession implements ConnectionHandlingStompSession {
 		}
 
 		@Override
-		public void unsubscribe() {
-			unsubscribe(null);
+		public Receiptable unsubscribe() {
+			return unsubscribe(null);
 		}
 
 		@Override
-		public void unsubscribe(@Nullable StompHeaders headers) {
+		public Receiptable unsubscribe(@Nullable StompHeaders headers) {
 			String id = this.headers.getId();
+			Receiptable receiptable = new ReceiptHandler(null);
 			if (id != null) {
 				DefaultStompSession.this.subscriptions.remove(id);
-				DefaultStompSession.this.unsubscribe(id, headers);
+				receiptable = DefaultStompSession.this.unsubscribe(id, headers);
 			}
+			return receiptable;
 		}
 
 		@Override

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompSession.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompSession.java
@@ -183,7 +183,7 @@ public interface StompSession {
 		/**
 		 * Remove the subscription by sending an UNSUBSCRIBE frame.
 		 */
-		void unsubscribe();
+		Receiptable unsubscribe();
 
 		/**
 		 * Alternative to {@link #unsubscribe()} with additional custom headers
@@ -192,7 +192,7 @@ public interface StompSession {
 		 * @param headers the custom headers, if any
 		 * @since 5.0
 		 */
-		void unsubscribe(@Nullable StompHeaders headers);
+		Receiptable unsubscribe(@Nullable StompHeaders headers);
 	}
 
 }


### PR DESCRIPTION
## Motivation

Currently `Subscription.unsubscribe()` is a `void` method, so clients have no way to know when an UNSUBSCRIBE frame has actually been processed by the server.  This PR brings `unsubscribe()` in line with `send()` and `acknowledge()` by returning a `Receiptable` that callers can use to register callbacks and track the receipt.

## Summary of Changes

- **Interface**  
  - `StompSession.Subscription` — both `unsubscribe()` overloads now return `Receiptable` instead of `void`.

- **Implementation**  
  - `DefaultStompSession.unsubscribe(String, StompHeaders)` (private helper) now returns a `Receiptable` by creating a `ReceiptHandler` after adding a receipt-id header.
  - `DefaultStompSession.DefaultSubscription.unsubscribe(...)` now invokes the helper and simply returns its `Receiptable`.

- **Tests** (in `DefaultStompSessionTests`)
  - `unsubscribeWithReceipt()`  
    Verifies that calling `unsubscribe()` returns a non‑null `Receiptable` and that the sent frame still only contains the subscription ID when auto‑receipt is off.
  - `unsubscribeWithCustomHeaderAndReceipt()`  
    Verifies that with `autoReceipt=true` and custom headers, the UNSUBSCRIBE frame contains the subscription ID, the custom header, and the generated receipt header, and that the returned `Receiptable` holds the same receipt-id.
  - `receiptReceivedOnUnsubscribe()`  
    Verifies that if a RECEIPT frame arrives for the receipt-id, a task registered on the returned `Receiptable` is executed.

All existing tests pass, and the new tests cover the added behavior.

Closes gh-22729
