### PR TITLE
Add compression support in JdkClientHttpRequestFactory

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/JdkClientHttpRequestFactory.java
+++ b/spring-web/src/main/java/org/springframework/http/client/JdkClientHttpRequestFactory.java
@@ -43,6 +43,8 @@ public class JdkClientHttpRequestFactory implements ClientHttpRequestFactory {
 
 	private @Nullable Duration readTimeout;
 
+	private boolean compressionEnabled;
+
 
 	/**
 	 * Create a new instance of the {@code JdkClientHttpRequestFactory}
@@ -96,10 +98,18 @@ public class JdkClientHttpRequestFactory implements ClientHttpRequestFactory {
 		this.readTimeout = readTimeout;
 	}
 
+	/**
+	 * Sets custom {@link BodyHandler} that can handle gzip encoded {@link HttpClient}'s response.
+	 * @param compressionEnabled to enable compression by default for all {@link HttpClient}'s requests.
+	 */
+	public void setCompressionEnabled(boolean compressionEnabled) {
+		this.compressionEnabled = compressionEnabled;
+	}
+
 
 	@Override
 	public ClientHttpRequest createRequest(URI uri, HttpMethod httpMethod) throws IOException {
-		return new JdkClientHttpRequest(this.httpClient, uri, httpMethod, this.executor, this.readTimeout);
+		return new JdkClientHttpRequest(this.httpClient, uri, httpMethod, this.executor, this.readTimeout, this.compressionEnabled);
 	}
 
 }

--- a/spring-web/src/test/java/org/springframework/http/client/JdkClientHttpRequestFactoryTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/JdkClientHttpRequestFactoryTests.java
@@ -108,6 +108,44 @@ class JdkClientHttpRequestFactoryTests extends AbstractHttpRequestFactoryTests {
 		}
 	}
 
+	@Test
+	void compressionDisabled() throws IOException {
+		URI uri = URI.create(baseUrl + "/compress/");
+		ClientHttpRequest request = this.factory.createRequest(uri, HttpMethod.GET);
+		try (ClientHttpResponse response = request.execute()) {
+			assertThat(response.getStatusCode()).as("Invalid response status").isEqualTo(HttpStatus.OK);
+			assertThat(StreamUtils.copyToString(response.getBody(), StandardCharsets.ISO_8859_1))
+					.as("Invalid request body").isEqualTo("Test Payload");
+		}
+	}
+
+	@Test
+	void compressionGzip() throws IOException {
+		URI uri = URI.create(baseUrl + "/compress/gzip");
+		JdkClientHttpRequestFactory requestFactory = (JdkClientHttpRequestFactory) this.factory;
+		requestFactory.setCompressionEnabled(true);
+		ClientHttpRequest request = requestFactory.createRequest(uri, HttpMethod.GET);
+
+		try (ClientHttpResponse response = request.execute()) {
+			assertThat(response.getStatusCode()).as("Invalid response status").isEqualTo(HttpStatus.OK);
+			assertThat(StreamUtils.copyToString(response.getBody(), StandardCharsets.ISO_8859_1))
+					.as("Invalid request body").isEqualTo("Test Payload");
+		}
+	}
+
+	@Test
+	void compressionDeflate() throws IOException {
+		URI uri = URI.create(baseUrl + "/compress/deflate");
+		JdkClientHttpRequestFactory requestFactory = (JdkClientHttpRequestFactory) this.factory;
+		requestFactory.setCompressionEnabled(true);
+		ClientHttpRequest request = requestFactory.createRequest(uri, HttpMethod.GET);
+		try (ClientHttpResponse response = request.execute()) {
+			assertThat(response.getStatusCode()).as("Invalid response status").isEqualTo(HttpStatus.OK);
+			assertThat(StreamUtils.copyToString(response.getBody(), StandardCharsets.ISO_8859_1))
+					.as("Invalid request body").isEqualTo("Test Payload");
+		}
+	}
+
 	@Test // gh-34971
 	@EnabledForJreRange(min = JRE.JAVA_19) // behavior fixed in Java 19
 	void requestContentLengthHeaderWhenNoBody() throws Exception {


### PR DESCRIPTION
### Title
Implement custom BodyHandler for GZIP decompression in JdkClientHttpRequest

### Description

**Problem:** JDK HTTP Client doesn't automatically decompress responses.

**Solution:** creating a custom BodyHandler that checks Content-Encoding and applies GZIPInputStream when necessary.
**Key Changes:** 
- Added new boolean field `compressionEnabled` to `JdkClientHttpRequestFactory` and `JdkClientHttpRequest`.
- Modified `buildRequest()` method to add `Accept-Encoding` header with `gzip` value when compression is enabled.
- Added a custom `DecompressingBodyHandler` that implements `BodyHandler<InputStream>`. The apply() method in the custom handler checks the `Content-Encoding` header.
- If the encoding is `gzip`, it uses BodySubscribers.mapping to wrap the InputStream with GZIPInputStream.
  Otherwise, it uses the default BodySubscribers.ofInputStream().

**Testing Steps:**
- Make an HTTP request to an endpoint that returns a gzip-encoded response (e.g., https://vpic.nhtsa.dot.gov/api/vehicles/getallmanufacturers?format=json).
- Verify that the response body is correctly decompressed and the data is accessible.
