### PR TITLE
Use Collections#isEmpty or String#isEmpty

### DIFF
--- a/integration-tests/src/test/java/org/springframework/beans/factory/xml/ComponentFactoryBean.java
+++ b/integration-tests/src/test/java/org/springframework/beans/factory/xml/ComponentFactoryBean.java
@@ -35,7 +35,7 @@ public class ComponentFactoryBean implements FactoryBean<Component> {
 
 	@Override
 	public Component getObject() {
-		if (this.children != null && this.children.size() > 0) {
+		if (this.children != null && !this.children.isEmpty()) {
 			for (Component child : children) {
 				this.parent.addComponent(child);
 			}

--- a/spring-context/src/main/java/org/springframework/context/support/ReloadableResourceBundleMessageSource.java
+++ b/spring-context/src/main/java/org/springframework/context/support/ReloadableResourceBundleMessageSource.java
@@ -379,18 +379,18 @@ public class ReloadableResourceBundleMessageSource extends AbstractResourceBased
 		StringBuilder temp = new StringBuilder(basename);
 
 		temp.append('_');
-		if (language.length() > 0) {
+		if (!language.isEmpty()) {
 			temp.append(language);
 			result.add(0, temp.toString());
 		}
 
 		temp.append('_');
-		if (country.length() > 0) {
+		if (!country.isEmpty()) {
 			temp.append(country);
 			result.add(0, temp.toString());
 		}
 
-		if (variant.length() > 0 && (language.length() > 0 || country.length() > 0)) {
+		if (!variant.isEmpty() && (!language.isEmpty() || !country.isEmpty())) {
 			temp.append('_').append(variant);
 			result.add(0, temp.toString());
 		}

--- a/spring-context/src/testFixtures/java/org/springframework/context/testfixture/jndi/SimpleNamingContext.java
+++ b/spring-context/src/testFixtures/java/org/springframework/context/testfixture/jndi/SimpleNamingContext.java
@@ -326,7 +326,7 @@ public class SimpleNamingContext implements Context {
 					}
 				}
 			}
-			if (contents.size() == 0) {
+			if (contents.isEmpty()) {
 				throw new NamingException("Invalid root: [" + context.root + proot + "]");
 			}
 			this.iterator = contents.values().iterator();

--- a/spring-core/src/main/java/org/springframework/asm/TypePath.java
+++ b/spring-core/src/main/java/org/springframework/asm/TypePath.java
@@ -117,7 +117,7 @@ public final class TypePath {
    * @return the corresponding TypePath object, or {@literal null} if the path is empty.
    */
   public static TypePath fromString(final String typePath) {
-    if (typePath == null || typePath.length() == 0) {
+    if (typePath == null || typePath.isEmpty()) {
       return null;
     }
     int typePathLength = typePath.length();

--- a/spring-core/src/main/java/org/springframework/cglib/proxy/CallbackHelper.java
+++ b/spring-core/src/main/java/org/springframework/cglib/proxy/CallbackHelper.java
@@ -63,7 +63,7 @@ implements CallbackFilter
     abstract protected Object getCallback(Method method);
 
     public Callback[] getCallbacks() {
-        if (callbacks.size() == 0) {
+        if (callbacks.isEmpty()) {
             return new Callback[0];
         }
         if (callbacks.get(0) instanceof Callback) {
@@ -75,7 +75,7 @@ implements CallbackFilter
     }
 
     public Class[] getCallbackTypes() {
-        if (callbacks.size() == 0) {
+        if (callbacks.isEmpty()) {
             return new Class[0];
         }
         if (callbacks.get(0) instanceof Callback) {

--- a/spring-core/src/main/java/org/springframework/cglib/proxy/Enhancer.java
+++ b/spring-core/src/main/java/org/springframework/cglib/proxy/Enhancer.java
@@ -755,7 +755,7 @@ public class Enhancer extends AbstractClassGenerator {
 	 */
 	protected void filterConstructors(Class sc, List constructors) {
 		CollectionUtils.filter(constructors, new VisibilityPredicate(sc, true));
-		if (constructors.size() == 0) {
+		if (constructors.isEmpty()) {
 			throw new IllegalArgumentException("No visible constructors in " + sc);
 		}
 	}

--- a/spring-core/src/main/java/org/springframework/core/io/support/LocalizedResourceHelper.java
+++ b/spring-core/src/main/java/org/springframework/core/io/support/LocalizedResourceHelper.java
@@ -100,20 +100,20 @@ public class LocalizedResourceHelper {
 			String variant = locale.getVariant();
 
 			// Check for file with language, country and variant localization.
-			if (variant.length() > 0) {
+			if (!variant.isEmpty()) {
 				String location =
 						name + this.separator + lang + this.separator + country + this.separator + variant + extension;
 				resource = this.resourceLoader.getResource(location);
 			}
 
 			// Check for file with language and country localization.
-			if ((resource == null || !resource.exists()) && country.length() > 0) {
+			if ((resource == null || !resource.exists()) && !country.isEmpty()) {
 				String location = name + this.separator + lang + this.separator + country + extension;
 				resource = this.resourceLoader.getResource(location);
 			}
 
 			// Check for document with language localization.
-			if ((resource == null || !resource.exists()) && lang.length() > 0) {
+			if ((resource == null || !resource.exists()) && !lang.isEmpty()) {
 				String location = name + this.separator + lang + extension;
 				resource = this.resourceLoader.getResource(location);
 			}

--- a/spring-core/src/main/java/org/springframework/core/io/support/PropertySourceProcessor.java
+++ b/spring-core/src/main/java/org/springframework/core/io/support/PropertySourceProcessor.java
@@ -80,7 +80,7 @@ public class PropertySourceProcessor {
 		String name = descriptor.name();
 		String encoding = descriptor.encoding();
 		List<String> locations = descriptor.locations();
-		Assert.isTrue(locations.size() > 0, "At least one @PropertySource(value) location is required");
+		Assert.isTrue(!locations.isEmpty(), "At least one @PropertySource(value) location is required");
 		boolean ignoreResourceNotFound = descriptor.ignoreResourceNotFound();
 		PropertySourceFactory factory = (descriptor.propertySourceFactory() != null ?
 				instantiateClass(descriptor.propertySourceFactory()) : defaultPropertySourceFactory);

--- a/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
+++ b/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
@@ -348,7 +348,7 @@ public class AntPathMatcher implements PathMatcher {
 				pos += skipped;
 				skipped = skipSegment(path, pos, pattDir);
 				if (skipped < pattDir.length()) {
-					return (skipped > 0 || (pattDir.length() > 0 && isWildcardChar(pattDir.charAt(0))));
+					return (skipped > 0 || (!pattDir.isEmpty() && isWildcardChar(pattDir.charAt(0))));
 				}
 				pos += skipped;
 			}

--- a/spring-core/src/main/java/org/springframework/util/CommonsLogWriter.java
+++ b/spring-core/src/main/java/org/springframework/util/CommonsLogWriter.java
@@ -44,7 +44,7 @@ public class CommonsLogWriter extends Writer {
 
 
 	public void write(char ch) {
-		if (ch == '\n' && this.buffer.length() > 0) {
+		if (ch == '\n' && !this.buffer.isEmpty()) {
 			logger.debug(this.buffer.toString());
 			this.buffer.setLength(0);
 		}

--- a/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
@@ -244,7 +244,7 @@ public abstract class MimeTypeUtils {
 				nextIndex++;
 			}
 			String parameter = mimeType.substring(index + 1, nextIndex).trim();
-			if (parameter.length() > 0) {
+			if (!parameter.isEmpty()) {
 				if (parameters == null) {
 					parameters = new LinkedHashMap<>(4);
 				}

--- a/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectivePropertyAccessor.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectivePropertyAccessor.java
@@ -443,7 +443,7 @@ public class ReflectivePropertyAccessor implements PropertyAccessor {
 	 */
 	protected String[] getPropertyMethodSuffixes(String propertyName) {
 		String suffix = getPropertyMethodSuffix(propertyName);
-		if (suffix.length() > 0 && Character.isUpperCase(suffix.charAt(0))) {
+		if (!suffix.isEmpty() && Character.isUpperCase(suffix.charAt(0))) {
 			return new String[] {suffix};
 		}
 		return new String[] {suffix, StringUtils.capitalize(suffix)};

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
@@ -338,7 +338,7 @@ public abstract class ScriptUtils {
 		while (currentStatement != null) {
 			if ((blockCommentEndDelimiter != null && currentStatement.contains(blockCommentEndDelimiter)) ||
 				(commentPrefixes != null && !startsWithAny(currentStatement, commentPrefixes, 0))) {
-				if (scriptBuilder.length() > 0) {
+				if (!scriptBuilder.isEmpty()) {
 					scriptBuilder.append('\n');
 				}
 				scriptBuilder.append(currentStatement);
@@ -508,7 +508,7 @@ public abstract class ScriptUtils {
 			if (!inSingleQuote && !inDoubleQuote) {
 				if (script.startsWith(separator, i)) {
 					// We've reached the end of the current statement
-					if (sb.length() > 0) {
+					if (!sb.isEmpty()) {
 						statements.add(sb.toString());
 						sb = new StringBuilder();
 					}
@@ -541,7 +541,7 @@ public abstract class ScriptUtils {
 				}
 				else if (c == ' ' || c == '\r' || c == '\n' || c == '\t') {
 					// Avoid multiple adjacent whitespace characters
-					if (sb.length() > 0 && sb.charAt(sb.length() - 1) != ' ') {
+					if (!sb.isEmpty() && sb.charAt(sb.length() - 1) != ' ') {
 						c = ' ';
 					}
 					else {

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompDecoder.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompDecoder.java
@@ -134,7 +134,7 @@ public class StompDecoder {
 		byteBuffer.mark();
 
 		String command = readCommand(byteBuffer);
-		if (command.length() > 0) {
+		if (!command.isEmpty()) {
 			StompHeaderAccessor headerAccessor = null;
 			byte[] payload = null;
 			if (byteBuffer.remaining() > 0) {

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/AbstractStompBrokerRelayIntegrationTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/AbstractStompBrokerRelayIntegrationTests.java
@@ -293,7 +293,7 @@ public abstract class AbstractStompBrokerRelayIntegrationTests {
 
 		public void expectMessages(MessageExchange... messageExchanges) throws InterruptedException {
 			List<MessageExchange> expectedMessages = new ArrayList<>(Arrays.asList(messageExchanges));
-			while (expectedMessages.size() > 0) {
+			while (!expectedMessages.isEmpty()) {
 				Message<?> message = this.queue.poll(10000, TimeUnit.MILLISECONDS);
 				assertThat(message).as("Timed out waiting for messages, expected [" + expectedMessages + "]").isNotNull();
 				MessageExchange match = findMatch(expectedMessages, message);

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/init/ScriptUtils.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/init/ScriptUtils.java
@@ -318,7 +318,7 @@ public abstract class ScriptUtils {
 		StringBuilder scriptBuilder = new StringBuilder();
 		String currentLine = lineNumberReader.readLine();
 		while (currentLine != null) {
-			if (scriptBuilder.length() > 0) {
+			if (!scriptBuilder.isEmpty()) {
 				scriptBuilder.append('\n');
 			}
 			scriptBuilder.append(currentLine);
@@ -487,7 +487,7 @@ public abstract class ScriptUtils {
 			if (!inSingleQuote && !inDoubleQuote) {
 				if (script.startsWith(separator, i)) {
 					// We've reached the end of the current statement
-					if (sb.length() > 0) {
+					if (!sb.isEmpty()) {
 						statements.add(sb.toString());
 						sb = new StringBuilder();
 					}
@@ -520,7 +520,7 @@ public abstract class ScriptUtils {
 				}
 				else if (c == ' ' || c == '\r' || c == '\n' || c == '\t') {
 					// Avoid multiple adjacent whitespace characters
-					if (sb.length() > 0 && sb.charAt(sb.length() - 1) != ' ') {
+					if (!sb.isEmpty() && sb.charAt(sb.length() - 1) != ' ') {
 						c = ' ';
 					}
 					else {

--- a/spring-test/src/main/java/org/springframework/test/web/ModelAndViewAssert.java
+++ b/spring-test/src/main/java/org/springframework/test/web/ModelAndViewAssert.java
@@ -128,7 +128,7 @@ public abstract class ModelAndViewAssert {
 			}
 		});
 
-		if (sb.length() != 0) {
+		if (!sb.isEmpty()) {
 			sb.insert(0, "Values of expected model do not match.\n");
 			fail(sb.toString());
 		}

--- a/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageWriter.java
@@ -162,7 +162,7 @@ public class FormHttpMessageWriter extends LoggingCodecSupport
 		StringBuilder builder = new StringBuilder();
 		formData.forEach((name, values) ->
 				values.forEach(value -> {
-					if (builder.length() != 0) {
+					if (!builder.isEmpty()) {
 						builder.append('&');
 					}
 					builder.append(URLEncoder.encode(name, charset));

--- a/spring-web/src/main/java/org/springframework/http/converter/FormHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/FormHttpMessageConverter.java
@@ -444,7 +444,7 @@ public class FormHttpMessageConverter implements HttpMessageConverter<MultiValue
 					return;
 				}
 				values.forEach(value -> {
-					if (builder.length() != 0) {
+					if (!builder.isEmpty()) {
 						builder.append('&');
 					}
 					builder.append(URLEncoder.encode(name, charset));

--- a/spring-web/src/main/java/org/springframework/web/util/UriTemplate.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriTemplate.java
@@ -238,14 +238,14 @@ public class UriTemplate implements Serializable {
 				}
 				builder.append(c);
 			}
-			if (builder.length() > 0) {
+			if (!builder.isEmpty()) {
 				pattern.append(quote(builder));
 			}
 			return new TemplateInfo(variableNames, Pattern.compile(pattern.toString()));
 		}
 
 		private static String quote(StringBuilder builder) {
-			return (builder.length() > 0 ? Pattern.quote(builder.toString()) : "");
+			return (!builder.isEmpty() ? Pattern.quote(builder.toString()) : "");
 		}
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/util/pattern/PathPattern.java
+++ b/spring-web/src/main/java/org/springframework/web/util/pattern/PathPattern.java
@@ -567,7 +567,7 @@ public class PathPattern implements Comparable<PathPattern> {
 	 * @return {@code true} has more than zero elements
 	 */
 	private boolean hasLength(@Nullable PathContainer container) {
-		return container != null && container.elements().size() > 0;
+		return container != null && !container.elements().isEmpty();
 	}
 
 	private static int scoreByNormalizedLength(PathPattern pattern) {

--- a/spring-web/src/test/java/org/springframework/web/multipart/support/DefaultMultipartHttpServletRequestTests.java
+++ b/spring-web/src/test/java/org/springframework/web/multipart/support/DefaultMultipartHttpServletRequestTests.java
@@ -81,7 +81,7 @@ class DefaultMultipartHttpServletRequestTests {
 		for (String key : this.queryParams.keySet()) {
 			for (String value : this.queryParams.get(key)) {
 				this.servletRequest.addParameter(key, value);
-				query.append(query.length() > 0 ? "&" : "").append(key).append('=').append(value);
+				query.append(!query.isEmpty() ? "&" : "").append(key).append('=').append(value);
 			}
 		}
 		this.servletRequest.setQueryString(query.toString());

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractUrlHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractUrlHandlerMapping.java
@@ -383,7 +383,7 @@ public abstract class AbstractUrlHandlerMapping extends AbstractHandlerMapping i
 					uriTemplateVariables.putAll(decodedVars);
 				}
 			}
-			if (logger.isTraceEnabled() && uriTemplateVariables.size() > 0) {
+			if (logger.isTraceEnabled() && !uriTemplateVariables.isEmpty()) {
 				logger.trace("URI variables " + uriTemplateVariables);
 			}
 			return buildPathExposingHandler(handler, bestMatch, pathWithinMapping, uriTemplateVariables);

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/ParameterizableViewController.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/ParameterizableViewController.java
@@ -187,7 +187,7 @@ public class ParameterizableViewController extends AbstractController {
 			sb.append("status=").append(this.statusCode);
 		}
 		if (this.view != null) {
-			sb.append(sb.length() != 0 ? ", " : "");
+			sb.append(!sb.isEmpty() ? ", " : "");
 			String viewName = getViewName();
 			sb.append("view=").append(viewName != null ? "\"" + viewName + "\"" : this.view);
 		}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/NestedPathTag.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/NestedPathTag.java
@@ -84,7 +84,7 @@ public class NestedPathTag extends TagSupport implements TryCatchFinally {
 		if (path == null) {
 			path = "";
 		}
-		if (path.length() > 0 && !path.endsWith(PropertyAccessor.NESTED_PROPERTY_SEPARATOR)) {
+		if (!path.isEmpty() && !path.endsWith(PropertyAccessor.NESTED_PROPERTY_SEPARATOR)) {
 			path += PropertyAccessor.NESTED_PROPERTY_SEPARATOR;
 		}
 		this.path = path;

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/support/SockJsHttpRequestHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/support/SockJsHttpRequestHandler.java
@@ -141,7 +141,7 @@ public class SockJsHttpRequestHandler
 	private String getSockJsPath(HttpServletRequest servletRequest) {
 		String attribute = HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE;
 		String path = (String) servletRequest.getAttribute(attribute);
-		return (path.length() > 0 && path.charAt(0) != '/' ? "/" + path : path);
+		return (!path.isEmpty() && path.charAt(0) != '/' ? "/" + path : path);
 	}
 
 	@Override


### PR DESCRIPTION
**Summary**  
This PR improves readability and consistency across the codebase by replacing manual size/length checks with more idiomatic methods:

Replaces collection.size() == 0 or collection.size() != 0 with collection.isEmpty() / !collection.isEmpty()

Replaces string.length() == 0 with string.isEmpty()

**Motivation**
These changes align with modern Java best practices:

isEmpty() is more expressive and self-documenting than comparing .size() or .length() to 0.

This is similar to the [MNG-8060](https://github.com/apache/maven/pull/1420) change made in Apache Maven and [#10945](https://github.com/apache/maven/pull/10945), which improved code clarity.


Please check : 
[[Experimental] Add rewrite support for errorprone.refasterrules.StringRulesRecipes](https://github.com/diffplug/spotless/pull/2576)
[Convert value.trim().length() < 1 to value.isBlank() < 1](https://github.com/openrewrite/rewrite-apache/issues/90)
https://error-prone.picnic.tech/refasterrules/StringRules

These patterns are common and can be enforced or auto-corrected via CI using static analysis and refactoring tools.