### PR TITLE
Add isNotEmpty Utility Methods to Improve Readability and Safety

### DIFF
--- a/integration-tests/src/test/java/org/springframework/beans/factory/xml/ComponentBeanDefinitionParser.java
+++ b/integration-tests/src/test/java/org/springframework/beans/factory/xml/ComponentBeanDefinitionParser.java
@@ -39,7 +39,7 @@ public class ComponentBeanDefinitionParser extends AbstractBeanDefinitionParser 
 		factory.addPropertyValue("parent", parseComponent(element));
 
 		List<Element> childElements = DomUtils.getChildElementsByTagName(element, "component");
-		if (!CollectionUtils.isEmpty(childElements)) {
+		if (CollectionUtils.isNotEmpty(childElements)) {
 			parseChildComponents(childElements, factory);
 		}
 

--- a/integration-tests/src/test/java/org/springframework/beans/factory/xml/ComponentFactoryBean.java
+++ b/integration-tests/src/test/java/org/springframework/beans/factory/xml/ComponentFactoryBean.java
@@ -19,6 +19,7 @@ package org.springframework.beans.factory.xml;
 import java.util.List;
 
 import org.springframework.beans.factory.FactoryBean;
+import org.springframework.util.CollectionUtils;
 
 public class ComponentFactoryBean implements FactoryBean<Component> {
 
@@ -35,7 +36,7 @@ public class ComponentFactoryBean implements FactoryBean<Component> {
 
 	@Override
 	public Component getObject() {
-		if (this.children != null && this.children.size() > 0) {
+		if (this.children != null && CollectionUtils.isNotEmpty(this.children)) {
 			for (Component child : children) {
 				this.parent.addComponent(child);
 			}

--- a/spring-aop/src/main/java/org/springframework/aop/aspectj/AbstractAspectJAdvice.java
+++ b/spring-aop/src/main/java/org/springframework/aop/aspectj/AbstractAspectJAdvice.java
@@ -571,7 +571,7 @@ public abstract class AbstractAspectJAdvice implements Advice, AspectJPrecedence
 			numBound++;
 		}
 
-		if (!CollectionUtils.isEmpty(this.argumentBindings)) {
+		if (CollectionUtils.isNotEmpty(this.argumentBindings)) {
 			// binding from pointcut match
 			if (jpMatch != null) {
 				PointcutParameter[] parameterBindings = jpMatch.getParameterBindings();

--- a/spring-aop/src/main/java/org/springframework/aop/framework/AdvisedSupport.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/AdvisedSupport.java
@@ -378,7 +378,7 @@ public class AdvisedSupport extends ProxyConfig implements Advised {
 		if (isFrozen()) {
 			throw new AopConfigException("Cannot add advisor: Configuration is frozen.");
 		}
-		if (!CollectionUtils.isEmpty(advisors)) {
+		if (CollectionUtils.isNotEmpty(advisors)) {
 			for (Advisor advisor : advisors) {
 				if (advisor instanceof IntroductionAdvisor introductionAdvisor) {
 					validateIntroductionAdvisor(introductionAdvisor);

--- a/spring-beans/src/main/java/org/springframework/beans/factory/annotation/InitDestroyAnnotationBeanPostProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/annotation/InitDestroyAnnotationBeanPostProcessor.java
@@ -186,11 +186,11 @@ public class InitDestroyAnnotationBeanPostProcessor implements DestructionAwareB
 		RootBeanDefinition beanDefinition = registeredBean.getMergedBeanDefinition();
 		beanDefinition.resolveDestroyMethodIfNecessary();
 		LifecycleMetadata metadata = findLifecycleMetadata(beanDefinition, registeredBean.getBeanClass());
-		if (!CollectionUtils.isEmpty(metadata.initMethods)) {
+		if (CollectionUtils.isNotEmpty(metadata.initMethods)) {
 			String[] initMethodNames = safeMerge(beanDefinition.getInitMethodNames(), metadata.initMethods);
 			beanDefinition.setInitMethodNames(initMethodNames);
 		}
-		if (!CollectionUtils.isEmpty(metadata.destroyMethods)) {
+		if (CollectionUtils.isNotEmpty(metadata.destroyMethods)) {
 			String[] destroyMethodNames = safeMerge(beanDefinition.getDestroyMethodNames(), metadata.destroyMethods);
 			beanDefinition.setDestroyMethodNames(destroyMethodNames);
 		}

--- a/spring-beans/src/main/java/org/springframework/beans/factory/groovy/GroovyBeanDefinitionWrapper.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/groovy/GroovyBeanDefinitionWrapper.java
@@ -103,7 +103,7 @@ class GroovyBeanDefinitionWrapper extends GroovyObjectSupport {
 	protected AbstractBeanDefinition createBeanDefinition() {
 		AbstractBeanDefinition bd = new GenericBeanDefinition();
 		bd.setBeanClass(this.clazz);
-		if (!CollectionUtils.isEmpty(this.constructorArgs)) {
+		if (CollectionUtils.isNotEmpty(this.constructorArgs)) {
 			ConstructorArgumentValues cav = new ConstructorArgumentValues();
 			for (Object constructorArg : this.constructorArgs) {
 				cav.addGenericArgumentValue(constructorArg);

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DisposableBeanAdapter.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DisposableBeanAdapter.java
@@ -194,7 +194,7 @@ class DisposableBeanAdapter implements DisposableBean, Runnable, Serializable {
 
 	@Override
 	public void destroy() {
-		if (!CollectionUtils.isEmpty(this.beanPostProcessors)) {
+		if (CollectionUtils.isNotEmpty(this.beanPostProcessors)) {
 			for (DestructionAwareBeanPostProcessor processor : this.beanPostProcessors) {
 				processor.postProcessBeforeDestruction(this.bean, this.beanName);
 			}
@@ -448,7 +448,7 @@ class DisposableBeanAdapter implements DisposableBean, Runnable, Serializable {
 	 * @param postProcessors the post-processor candidates
 	 */
 	public static boolean hasApplicableProcessors(Object bean, List<DestructionAwareBeanPostProcessor> postProcessors) {
-		if (!CollectionUtils.isEmpty(postProcessors)) {
+		if (CollectionUtils.isNotEmpty(postProcessors)) {
 			for (DestructionAwareBeanPostProcessor processor : postProcessors) {
 				if (processor.requiresDestruction(bean)) {
 					return true;
@@ -467,7 +467,7 @@ class DisposableBeanAdapter implements DisposableBean, Runnable, Serializable {
 			List<DestructionAwareBeanPostProcessor> processors, Object bean) {
 
 		List<DestructionAwareBeanPostProcessor> filteredPostProcessors = null;
-		if (!CollectionUtils.isEmpty(processors)) {
+		if (CollectionUtils.isNotEmpty(processors)) {
 			filteredPostProcessors = new ArrayList<>(processors.size());
 			for (DestructionAwareBeanPostProcessor processor : processors) {
 				if (processor.requiresDestruction(bean)) {

--- a/spring-context-support/src/main/java/org/springframework/ui/freemarker/FreeMarkerConfigurationFactory.java
+++ b/spring-context-support/src/main/java/org/springframework/ui/freemarker/FreeMarkerConfigurationFactory.java
@@ -299,7 +299,7 @@ public class FreeMarkerConfigurationFactory {
 			config.setSettings(props);
 		}
 
-		if (!CollectionUtils.isEmpty(this.freemarkerVariables)) {
+		if (CollectionUtils.isNotEmpty(this.freemarkerVariables)) {
 			config.setAllSharedVariables(new SimpleHash(this.freemarkerVariables, config.getObjectWrapper()));
 		}
 

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/AbstractFallbackCacheOperationSource.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/AbstractFallbackCacheOperationSource.java
@@ -74,7 +74,7 @@ public abstract class AbstractFallbackCacheOperationSource implements CacheOpera
 
 	@Override
 	public boolean hasCacheOperations(Method method, @Nullable Class<?> targetClass) {
-		return !CollectionUtils.isEmpty(getCacheOperations(method, targetClass, false));
+		return CollectionUtils.isNotEmpty(getCacheOperations(method, targetClass, false));
 	}
 
 	@Override

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/CacheAspectSupport.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/CacheAspectSupport.java
@@ -399,7 +399,7 @@ public abstract class CacheAspectSupport extends AbstractCacheInvoker
 			CacheOperationSource cacheOperationSource = getCacheOperationSource();
 			if (cacheOperationSource != null) {
 				Collection<CacheOperation> operations = cacheOperationSource.getCacheOperations(method, targetClass);
-				if (!CollectionUtils.isEmpty(operations)) {
+				if (CollectionUtils.isNotEmpty(operations)) {
 					return execute(invoker, method,
 							new CacheOperationContexts(operations, method, args, target, targetClass));
 				}

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/CacheOperationSource.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/CacheOperationSource.java
@@ -62,7 +62,7 @@ public interface CacheOperationSource {
 	 * @see #getCacheOperations
 	 */
 	default boolean hasCacheOperations(Method method, @Nullable Class<?> targetClass) {
-		return !CollectionUtils.isEmpty(getCacheOperations(method, targetClass));
+		return CollectionUtils.isNotEmpty(getCacheOperations(method, targetClass));
 	}
 
 	/**

--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassPostProcessor.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassPostProcessor.java
@@ -341,7 +341,7 @@ public class ConfigurationClassPostProcessor implements BeanDefinitionRegistryPo
 
 	@Override
 	public @Nullable BeanFactoryInitializationAotContribution processAheadOfTime(ConfigurableListableBeanFactory beanFactory) {
-		boolean hasPropertySourceDescriptors = !CollectionUtils.isEmpty(this.propertySourceDescriptors);
+		boolean hasPropertySourceDescriptors = CollectionUtils.isNotEmpty(this.propertySourceDescriptors);
 		boolean hasImportRegistry = beanFactory.containsBean(IMPORT_REGISTRY_BEAN_NAME);
 		boolean hasBeanRegistrars = !this.beanRegistrars.isEmpty();
 		if (hasPropertySourceDescriptors || hasImportRegistry || hasBeanRegistrars) {

--- a/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
+++ b/spring-context/src/main/java/org/springframework/context/support/AbstractApplicationContext.java
@@ -914,7 +914,7 @@ public abstract class AbstractApplicationContext extends DefaultResourceLoader
 		// Publish early application events now that we finally have a multicaster...
 		Set<ApplicationEvent> earlyEventsToProcess = this.earlyApplicationEvents;
 		this.earlyApplicationEvents = null;
-		if (!CollectionUtils.isEmpty(earlyEventsToProcess)) {
+		if (CollectionUtils.isNotEmpty(earlyEventsToProcess)) {
 			for (ApplicationEvent earlyEvent : earlyEventsToProcess) {
 				getApplicationEventMulticaster().multicastEvent(earlyEvent);
 			}

--- a/spring-context/src/main/java/org/springframework/context/support/DefaultLifecycleProcessor.java
+++ b/spring-context/src/main/java/org/springframework/context/support/DefaultLifecycleProcessor.java
@@ -591,7 +591,7 @@ public class DefaultLifecycleProcessor implements LifecycleProcessor, BeanFactor
 			for (LifecycleGroupMember member : this.members) {
 				doStart(this.lifecycleBeans, member.name, this.autoStartupOnly, futures);
 			}
-			if (concurrentStartup != null && !CollectionUtils.isEmpty(futures)) {
+			if (concurrentStartup != null && CollectionUtils.isNotEmpty(futures)) {
 				try {
 					CompletableFuture.allOf(futures.toArray(new CompletableFuture<?>[0]))
 							.get(concurrentStartup, TimeUnit.MILLISECONDS);

--- a/spring-context/src/main/java/org/springframework/context/support/ReloadableResourceBundleMessageSource.java
+++ b/spring-context/src/main/java/org/springframework/context/support/ReloadableResourceBundleMessageSource.java
@@ -123,7 +123,7 @@ public class ReloadableResourceBundleMessageSource extends AbstractResourceBased
 	 * @since 6.1
 	 */
 	public void setFileExtensions(List<String> fileExtensions) {
-		Assert.isTrue(!CollectionUtils.isEmpty(fileExtensions), "At least one file extension is required");
+		Assert.isTrue(CollectionUtils.isNotEmpty(fileExtensions), "At least one file extension is required");
 		for (String extension : fileExtensions) {
 			if (!extension.startsWith(".")) {
 				throw new IllegalArgumentException("File extension '" + extension + "' should start with '.'");
@@ -379,18 +379,18 @@ public class ReloadableResourceBundleMessageSource extends AbstractResourceBased
 		StringBuilder temp = new StringBuilder(basename);
 
 		temp.append('_');
-		if (language.length() > 0) {
+		if (StringUtils.hasLength(language)) {
 			temp.append(language);
 			result.add(0, temp.toString());
 		}
 
 		temp.append('_');
-		if (country.length() > 0) {
+		if (StringUtils.hasLength(country)) {
 			temp.append(country);
 			result.add(0, temp.toString());
 		}
 
-		if (variant.length() > 0 && (language.length() > 0 || country.length() > 0)) {
+		if (StringUtils.hasLength(variant) && (StringUtils.hasLength(language) || StringUtils.hasLength(country))) {
 			temp.append('_').append(variant);
 			result.add(0, temp.toString());
 		}

--- a/spring-context/src/main/java/org/springframework/jmx/support/JmxUtils.java
+++ b/spring-context/src/main/java/org/springframework/jmx/support/JmxUtils.java
@@ -95,7 +95,7 @@ public abstract class JmxUtils {
 		// null means any registered server, but "" specifically means the platform server
 		if (!"".equals(agentId)) {
 			List<MBeanServer> servers = MBeanServerFactory.findMBeanServer(agentId);
-			if (!CollectionUtils.isEmpty(servers)) {
+			if (CollectionUtils.isNotEmpty(servers)) {
 				// Check to see if an MBeanServer is registered.
 				if (servers.size() > 1 && logger.isInfoEnabled()) {
 					logger.info("Found more than one MBeanServer instance" +

--- a/spring-context/src/main/java/org/springframework/scheduling/config/ScheduledTaskRegistrar.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/config/ScheduledTaskRegistrar.java
@@ -395,11 +395,11 @@ public class ScheduledTaskRegistrar implements ScheduledTaskHolder, Initializing
 	 * @since 3.2
 	 */
 	public boolean hasTasks() {
-		return (!CollectionUtils.isEmpty(this.triggerTasks) ||
-				!CollectionUtils.isEmpty(this.cronTasks) ||
-				!CollectionUtils.isEmpty(this.fixedRateTasks) ||
-				!CollectionUtils.isEmpty(this.fixedDelayTasks) ||
-				!CollectionUtils.isEmpty(this.oneTimeTasks));
+		return (CollectionUtils.isNotEmpty(this.triggerTasks) ||
+				CollectionUtils.isNotEmpty(this.cronTasks) ||
+				CollectionUtils.isNotEmpty(this.fixedRateTasks) ||
+				CollectionUtils.isNotEmpty(this.fixedDelayTasks) ||
+				CollectionUtils.isNotEmpty(this.oneTimeTasks));
 	}
 
 

--- a/spring-context/src/main/java/org/springframework/validation/beanvalidation/LocalValidatorFactoryBean.java
+++ b/spring-context/src/main/java/org/springframework/validation/beanvalidation/LocalValidatorFactoryBean.java
@@ -346,7 +346,7 @@ public class LocalValidatorFactoryBean extends SpringValidatorAdapter
 	}
 
 	private void closeMappingStreams(@Nullable List<InputStream> mappingStreams){
-		if (!CollectionUtils.isEmpty(mappingStreams)) {
+		if (CollectionUtils.isNotEmpty(mappingStreams)) {
 			for (InputStream stream : mappingStreams) {
 				try {
 					stream.close();

--- a/spring-context/src/testFixtures/java/org/springframework/context/testfixture/jndi/SimpleNamingContext.java
+++ b/spring-context/src/testFixtures/java/org/springframework/context/testfixture/jndi/SimpleNamingContext.java
@@ -326,7 +326,7 @@ public class SimpleNamingContext implements Context {
 					}
 				}
 			}
-			if (contents.size() == 0) {
+			if (contents.isEmpty()) {
 				throw new NamingException("Invalid root: [" + context.root + proot + "]");
 			}
 			this.iterator = contents.values().iterator();

--- a/spring-core/src/main/java/org/springframework/asm/TypePath.java
+++ b/spring-core/src/main/java/org/springframework/asm/TypePath.java
@@ -117,7 +117,7 @@ public final class TypePath {
    * @return the corresponding TypePath object, or {@literal null} if the path is empty.
    */
   public static TypePath fromString(final String typePath) {
-    if (typePath == null || typePath.length() == 0) {
+    if (typePath == null || typePath.isEmpty()) {
       return null;
     }
     int typePathLength = typePath.length();

--- a/spring-core/src/main/java/org/springframework/cglib/proxy/CallbackHelper.java
+++ b/spring-core/src/main/java/org/springframework/cglib/proxy/CallbackHelper.java
@@ -63,7 +63,7 @@ implements CallbackFilter
     abstract protected Object getCallback(Method method);
 
     public Callback[] getCallbacks() {
-        if (callbacks.size() == 0) {
+        if (callbacks.isEmpty()) {
             return new Callback[0];
         }
         if (callbacks.get(0) instanceof Callback) {
@@ -75,7 +75,7 @@ implements CallbackFilter
     }
 
     public Class[] getCallbackTypes() {
-        if (callbacks.size() == 0) {
+        if (callbacks.isEmpty()) {
             return new Class[0];
         }
         if (callbacks.get(0) instanceof Callback) {

--- a/spring-core/src/main/java/org/springframework/cglib/proxy/Enhancer.java
+++ b/spring-core/src/main/java/org/springframework/cglib/proxy/Enhancer.java
@@ -755,7 +755,7 @@ public class Enhancer extends AbstractClassGenerator {
 	 */
 	protected void filterConstructors(Class sc, List constructors) {
 		CollectionUtils.filter(constructors, new VisibilityPredicate(sc, true));
-		if (constructors.size() == 0) {
+		if (constructors.isEmpty()) {
 			throw new IllegalArgumentException("No visible constructors in " + sc);
 		}
 	}

--- a/spring-core/src/main/java/org/springframework/core/io/support/LocalizedResourceHelper.java
+++ b/spring-core/src/main/java/org/springframework/core/io/support/LocalizedResourceHelper.java
@@ -24,6 +24,7 @@ import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Helper class for loading a localized resource,
@@ -100,20 +101,20 @@ public class LocalizedResourceHelper {
 			String variant = locale.getVariant();
 
 			// Check for file with language, country and variant localization.
-			if (variant.length() > 0) {
+			if (StringUtils.hasLength(variant)) {
 				String location =
 						name + this.separator + lang + this.separator + country + this.separator + variant + extension;
 				resource = this.resourceLoader.getResource(location);
 			}
 
 			// Check for file with language and country localization.
-			if ((resource == null || !resource.exists()) && country.length() > 0) {
+			if ((resource == null || !resource.exists()) && StringUtils.hasLength(country)) {
 				String location = name + this.separator + lang + this.separator + country + extension;
 				resource = this.resourceLoader.getResource(location);
 			}
 
 			// Check for document with language localization.
-			if ((resource == null || !resource.exists()) && lang.length() > 0) {
+			if ((resource == null || !resource.exists()) && StringUtils.hasLength(lang)) {
 				String location = name + this.separator + lang + extension;
 				resource = this.resourceLoader.getResource(location);
 			}

--- a/spring-core/src/main/java/org/springframework/core/io/support/PropertySourceProcessor.java
+++ b/spring-core/src/main/java/org/springframework/core/io/support/PropertySourceProcessor.java
@@ -35,6 +35,7 @@ import org.springframework.core.env.PropertySource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.PlaceholderResolutionException;
 import org.springframework.util.ReflectionUtils;
 
@@ -80,7 +81,7 @@ public class PropertySourceProcessor {
 		String name = descriptor.name();
 		String encoding = descriptor.encoding();
 		List<String> locations = descriptor.locations();
-		Assert.isTrue(locations.size() > 0, "At least one @PropertySource(value) location is required");
+		Assert.isTrue(CollectionUtils.isNotEmpty(locations), "At least one @PropertySource(value) location is required");
 		boolean ignoreResourceNotFound = descriptor.ignoreResourceNotFound();
 		PropertySourceFactory factory = (descriptor.propertySourceFactory() != null ?
 				instantiateClass(descriptor.propertySourceFactory()) : defaultPropertySourceFactory);

--- a/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
+++ b/spring-core/src/main/java/org/springframework/util/AntPathMatcher.java
@@ -348,7 +348,7 @@ public class AntPathMatcher implements PathMatcher {
 				pos += skipped;
 				skipped = skipSegment(path, pos, pattDir);
 				if (skipped < pattDir.length()) {
-					return (skipped > 0 || (pattDir.length() > 0 && isWildcardChar(pattDir.charAt(0))));
+					return (skipped > 0 || (StringUtils.hasLength(pattDir) && isWildcardChar(pattDir.charAt(0))));
 				}
 				pos += skipped;
 			}

--- a/spring-core/src/main/java/org/springframework/util/ClassUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ClassUtils.java
@@ -753,7 +753,7 @@ public abstract class ClassUtils {
 	 * @see StringUtils#toStringArray
 	 */
 	public static Class<?>[] toClassArray(@Nullable Collection<Class<?>> collection) {
-		return (!CollectionUtils.isEmpty(collection) ? collection.toArray(EMPTY_CLASS_ARRAY) : EMPTY_CLASS_ARRAY);
+		return (CollectionUtils.isNotEmpty(collection) ? collection.toArray(EMPTY_CLASS_ARRAY) : EMPTY_CLASS_ARRAY);
 	}
 
 	/**

--- a/spring-core/src/main/java/org/springframework/util/CollectionUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/CollectionUtils.java
@@ -81,6 +81,27 @@ public abstract class CollectionUtils {
 	}
 
 	/**
+	 * Return {@code true} if the supplied Collection is not {@code null} and not empty.
+	 * Otherwise, return {@code false}.
+	 * @param collection the Collection to check
+	 * @return whether the given Collection is not empty
+	 */
+	public static boolean isNotEmpty(@Nullable Collection<? extends @Nullable Object> collection) {
+		return (collection != null && !collection.isEmpty());
+	}
+
+	/**
+	 * Return {@code true} if the supplied Map is not {@code null} and not empty.
+	 * Otherwise, return {@code false}.
+	 * @param map the Map to check
+	 * @return whether the given Map is not empty
+	 */
+	public static boolean isNotEmpty(@Nullable Map<?, ? extends @Nullable Object> map) {
+		return (map != null && !map.isEmpty());
+	}
+
+
+	/**
 	 * Instantiate a new {@link HashMap} with an initial capacity
 	 * that can accommodate the specified number of elements without
 	 * any immediate resize/rehash operations to be expected.

--- a/spring-core/src/main/java/org/springframework/util/CommonsLogWriter.java
+++ b/spring-core/src/main/java/org/springframework/util/CommonsLogWriter.java
@@ -44,7 +44,7 @@ public class CommonsLogWriter extends Writer {
 
 
 	public void write(char ch) {
-		if (ch == '\n' && this.buffer.length() > 0) {
+		if (ch == '\n' && StringUtils.hasLength(this.buffer)) {
 			logger.debug(this.buffer.toString());
 			this.buffer.setLength(0);
 		}

--- a/spring-core/src/main/java/org/springframework/util/MimeType.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeType.java
@@ -181,7 +181,7 @@ public class MimeType implements Comparable<MimeType>, Serializable {
 		checkToken(subtype);
 		this.type = type.toLowerCase(Locale.ROOT);
 		this.subtype = subtype.toLowerCase(Locale.ROOT);
-		if (!CollectionUtils.isEmpty(parameters)) {
+		if (CollectionUtils.isNotEmpty(parameters)) {
 			Map<String, String> map = new LinkedCaseInsensitiveMap<>(parameters.size(), Locale.ROOT);
 			parameters.forEach((parameter, value) -> {
 				checkParameters(parameter, value);

--- a/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
@@ -244,7 +244,7 @@ public abstract class MimeTypeUtils {
 				nextIndex++;
 			}
 			String parameter = mimeType.substring(index + 1, nextIndex).trim();
-			if (parameter.length() > 0) {
+			if (StringUtils.hasLength(parameter)) {
 				if (parameters == null) {
 					parameters = new LinkedHashMap<>(4);
 				}

--- a/spring-core/src/main/java/org/springframework/util/MultiToSingleValueMapAdapter.java
+++ b/spring-core/src/main/java/org/springframework/util/MultiToSingleValueMapAdapter.java
@@ -201,7 +201,7 @@ final class MultiToSingleValueMapAdapter<K, V> implements Map<K, V>, Serializabl
 	}
 
 	private @Nullable V adaptValue(@Nullable List<V> values) {
-		if (!CollectionUtils.isEmpty(values)) {
+		if (CollectionUtils.isNotEmpty(values)) {
 			return values.get(0);
 		}
 		else {

--- a/spring-core/src/main/java/org/springframework/util/MultiValueMapAdapter.java
+++ b/spring-core/src/main/java/org/springframework/util/MultiValueMapAdapter.java
@@ -58,7 +58,7 @@ public class MultiValueMapAdapter<K, V> implements MultiValueMap<K, V>, Serializ
 	@Override
 	public @Nullable V getFirst(K key) {
 		List<V> values = this.targetMap.get(key);
-		return (!CollectionUtils.isEmpty(values) ? values.get(0) : null);
+		return (CollectionUtils.isNotEmpty(values) ? values.get(0) : null);
 	}
 
 	@Override
@@ -94,7 +94,7 @@ public class MultiValueMapAdapter<K, V> implements MultiValueMap<K, V>, Serializ
 	public Map<K, V> toSingleValueMap() {
 		Map<K, V> singleValueMap = CollectionUtils.newLinkedHashMap(this.targetMap.size());
 		this.targetMap.forEach((key, values) -> {
-			if (!CollectionUtils.isEmpty(values)) {
+			if (CollectionUtils.isNotEmpty(values)) {
 				singleValueMap.put(key, values.get(0));
 			}
 		});

--- a/spring-core/src/main/java/org/springframework/util/PlaceholderResolutionException.java
+++ b/spring-core/src/main/java/org/springframework/util/PlaceholderResolutionException.java
@@ -60,7 +60,7 @@ public class PlaceholderResolutionException extends IllegalArgumentException {
 	private static String buildMessage(String reason, List<String> values) {
 		StringBuilder sb = new StringBuilder();
 		sb.append(reason);
-		if (!CollectionUtils.isEmpty(values)) {
+		if (CollectionUtils.isNotEmpty(values)) {
 			String valuesChain = values.stream().map(value -> "\"" + value + "\"")
 					.collect(Collectors.joining(" <-- "));
 			sb.append(" in value %s".formatted(valuesChain));

--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -1001,7 +1001,7 @@ public abstract class StringUtils {
 	 * @return the resulting {@code String} array
 	 */
 	public static String[] toStringArray(@Nullable Collection<String> collection) {
-		return (!CollectionUtils.isEmpty(collection) ? collection.toArray(EMPTY_STRING_ARRAY) : EMPTY_STRING_ARRAY);
+		return (CollectionUtils.isNotEmpty(collection) ? collection.toArray(EMPTY_STRING_ARRAY) : EMPTY_STRING_ARRAY);
 	}
 
 	/**

--- a/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectionHelper.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectionHelper.java
@@ -149,7 +149,7 @@ public abstract class ReflectionHelper {
 	static @Nullable ArgumentsMatchKind compareArgumentsVarargs(
 			List<TypeDescriptor> expectedArgTypes, List<TypeDescriptor> suppliedArgTypes, TypeConverter typeConverter) {
 
-		Assert.isTrue(!CollectionUtils.isEmpty(expectedArgTypes),
+		Assert.isTrue(CollectionUtils.isNotEmpty(expectedArgTypes),
 				"Expected arguments must at least include one array (the varargs parameter)");
 		Assert.isTrue(expectedArgTypes.get(expectedArgTypes.size() - 1).isArray(),
 				"Final expected argument should be array type (the varargs parameter)");

--- a/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectivePropertyAccessor.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectivePropertyAccessor.java
@@ -443,7 +443,7 @@ public class ReflectivePropertyAccessor implements PropertyAccessor {
 	 */
 	protected String[] getPropertyMethodSuffixes(String propertyName) {
 		String suffix = getPropertyMethodSuffix(propertyName);
-		if (suffix.length() > 0 && Character.isUpperCase(suffix.charAt(0))) {
+		if (StringUtils.hasLength(suffix) && Character.isUpperCase(suffix.charAt(0))) {
 			return new String[] {suffix};
 		}
 		return new String[] {suffix, StringUtils.capitalize(suffix)};

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
@@ -338,7 +338,7 @@ public abstract class ScriptUtils {
 		while (currentStatement != null) {
 			if ((blockCommentEndDelimiter != null && currentStatement.contains(blockCommentEndDelimiter)) ||
 				(commentPrefixes != null && !startsWithAny(currentStatement, commentPrefixes, 0))) {
-				if (scriptBuilder.length() > 0) {
+				if (StringUtils.hasLength(scriptBuilder)) {
 					scriptBuilder.append('\n');
 				}
 				scriptBuilder.append(currentStatement);
@@ -508,7 +508,7 @@ public abstract class ScriptUtils {
 			if (!inSingleQuote && !inDoubleQuote) {
 				if (script.startsWith(separator, i)) {
 					// We've reached the end of the current statement
-					if (sb.length() > 0) {
+					if (StringUtils.hasLength(sb)) {
 						statements.add(sb.toString());
 						sb = new StringBuilder();
 					}
@@ -541,7 +541,7 @@ public abstract class ScriptUtils {
 				}
 				else if (c == ' ' || c == '\r' || c == '\n' || c == '\t') {
 					// Avoid multiple adjacent whitespace characters
-					if (sb.length() > 0 && sb.charAt(sb.length() - 1) != ' ') {
+					if (StringUtils.hasLength(sb) && sb.charAt(sb.length() - 1) != ' ') {
 						c = ' ';
 					}
 					else {

--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/reactive/MessageMappingMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/reactive/MessageMappingMessageHandler.java
@@ -344,12 +344,12 @@ public class MessageMappingMessageHandler extends AbstractMethodMessageHandler<C
 			CompositeMessageCondition mapping, HandlerMethod handlerMethod, Message<?> message) {
 
 		Set<String> patterns = mapping.getCondition(DestinationPatternsMessageCondition.class).getPatterns();
-		if (!CollectionUtils.isEmpty(patterns)) {
+		if (CollectionUtils.isNotEmpty(patterns)) {
 			String pattern = patterns.iterator().next();
 			RouteMatcher.Route destination = getDestination(message);
 			Assert.state(destination != null, "Missing destination header");
 			Map<String, String> vars = obtainRouteMatcher().matchAndExtract(pattern, destination);
-			if (!CollectionUtils.isEmpty(vars)) {
+			if (CollectionUtils.isNotEmpty(vars)) {
 				MessageHeaderAccessor mha = MessageHeaderAccessor.getAccessor(message, MessageHeaderAccessor.class);
 				Assert.state(mha != null && mha.isMutable(), "Mutable MessageHeaderAccessor required");
 				mha.setHeader(DestinationVariableMethodArgumentResolver.DESTINATION_TEMPLATE_VARIABLES_HEADER, vars);

--- a/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/reactive/PayloadMethodArgumentResolver.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/handler/annotation/reactive/PayloadMethodArgumentResolver.java
@@ -89,7 +89,7 @@ public class PayloadMethodArgumentResolver implements HandlerMethodArgumentResol
 	public PayloadMethodArgumentResolver(List<? extends Decoder<?>> decoders, @Nullable Validator validator,
 			@Nullable ReactiveAdapterRegistry registry, boolean useDefaultResolution) {
 
-		Assert.isTrue(!CollectionUtils.isEmpty(decoders), "At least one Decoder is required");
+		Assert.isTrue(CollectionUtils.isNotEmpty(decoders), "At least one Decoder is required");
 		this.decoders = List.copyOf(decoders);
 		this.validator = validator;
 		this.adapterRegistry = registry != null ? registry : ReactiveAdapterRegistry.getSharedInstance();

--- a/spring-messaging/src/main/java/org/springframework/messaging/rsocket/DefaultRSocketRequesterBuilder.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/rsocket/DefaultRSocketRequesterBuilder.java
@@ -266,7 +266,7 @@ final class DefaultRSocketRequesterBuilder implements RSocketRequester.Builder {
 			MimeType dataMimeType, MimeType metaMimeType, RSocketStrategies strategies) {
 
 		Object data = this.setupData;
-		boolean hasMetadata = (this.setupRoute != null || !CollectionUtils.isEmpty(this.setupMetadata));
+		boolean hasMetadata = (this.setupRoute != null || CollectionUtils.isNotEmpty(this.setupMetadata));
 		if (!hasMetadata && data == null) {
 			return Mono.just(EMPTY_SETUP_PAYLOAD);
 		}

--- a/spring-messaging/src/main/java/org/springframework/messaging/rsocket/MetadataEncoder.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/rsocket/MetadataEncoder.java
@@ -158,7 +158,7 @@ final class MetadataEncoder {
 		if (route != null) {
 			this.route = expand(route, vars != null ? vars : new Object[0]);
 		}
-		if (!CollectionUtils.isEmpty(metadata)) {
+		if (CollectionUtils.isNotEmpty(metadata)) {
 			for (Map.Entry<Object, MimeType> entry : metadata.entrySet()) {
 				metadata(entry.getKey(), entry.getValue());
 			}

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpMessageHeaderAccessor.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/SimpMessageHeaderAccessor.java
@@ -203,7 +203,7 @@ public class SimpMessageHeaderAccessor extends NativeMessageHeaderAccessor {
 			return super.getDetailedLogMessage(payload);
 		}
 		StringBuilder sb = getBaseLogMessage();
-		if (!CollectionUtils.isEmpty(getSessionAttributes())) {
+		if (CollectionUtils.isNotEmpty(getSessionAttributes())) {
 			sb.append(" attributes[").append(getSessionAttributes().size()).append(']');
 		}
 		sb.append(getShortPayloadLogMessage(payload));
@@ -217,10 +217,10 @@ public class SimpMessageHeaderAccessor extends NativeMessageHeaderAccessor {
 			return super.getDetailedLogMessage(payload);
 		}
 		StringBuilder sb = getBaseLogMessage();
-		if (!CollectionUtils.isEmpty(getSessionAttributes())) {
+		if (CollectionUtils.isNotEmpty(getSessionAttributes())) {
 			sb.append(" attributes=").append(getSessionAttributes());
 		}
-		if (!CollectionUtils.isEmpty((Map<String, List<String>>) getHeader(NATIVE_HEADERS))) {
+		if (CollectionUtils.isNotEmpty((Map<String, List<String>>) getHeader(NATIVE_HEADERS))) {
 			sb.append(" nativeHeaders=").append(getHeader(NATIVE_HEADERS));
 		}
 		sb.append(getDetailedPayloadLogMessage(payload));

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SimpAnnotationMethodMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SimpAnnotationMethodMessageHandler.java
@@ -503,10 +503,10 @@ public class SimpAnnotationMethodMessageHandler extends AbstractMethodMessageHan
 			String lookupDestination, Message<?> message) {
 
 		Set<String> patterns = mapping.getDestinationConditions().getPatterns();
-		if (!CollectionUtils.isEmpty(patterns)) {
+		if (CollectionUtils.isNotEmpty(patterns)) {
 			String pattern = patterns.iterator().next();
 			Map<String, String> vars = getPathMatcher().extractUriTemplateVariables(pattern, lookupDestination);
-			if (!CollectionUtils.isEmpty(vars)) {
+			if (CollectionUtils.isNotEmpty(vars)) {
 				MessageHeaderAccessor mha = MessageHeaderAccessor.getAccessor(message, MessageHeaderAccessor.class);
 				Assert.state(mha != null && mha.isMutable(), "Mutable MessageHeaderAccessor required");
 				mha.setHeader(DestinationVariableMethodArgumentResolver.DESTINATION_TEMPLATE_VARIABLES_HEADER, vars);

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompDecoder.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompDecoder.java
@@ -33,6 +33,7 @@ import org.springframework.messaging.support.NativeMessageHeaderAccessor;
 import org.springframework.util.InvalidMimeTypeException;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StreamUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Decodes one or more STOMP frames contained in a {@link ByteBuffer}.
@@ -134,7 +135,7 @@ public class StompDecoder {
 		byteBuffer.mark();
 
 		String command = readCommand(byteBuffer);
-		if (command.length() > 0) {
+		if (StringUtils.hasLength(command)) {
 			StompHeaderAccessor headerAccessor = null;
 			byte[] payload = null;
 			if (byteBuffer.remaining() > 0) {

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompHeaderAccessor.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompHeaderAccessor.java
@@ -528,7 +528,7 @@ public class StompHeaderAccessor extends SimpMessageHeaderAccessor {
 
 	public static @Nullable Integer getContentLength(Map<String, List<String>> nativeHeaders) {
 		List<String> values = nativeHeaders.get(STOMP_CONTENT_LENGTH_HEADER);
-		return (!CollectionUtils.isEmpty(values) ? Integer.valueOf(values.get(0)) : null);
+		return (CollectionUtils.isNotEmpty(values) ? Integer.valueOf(values.get(0)) : null);
 	}
 
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/support/NativeMessageHeaderAccessor.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/support/NativeMessageHeaderAccessor.java
@@ -62,7 +62,7 @@ public class NativeMessageHeaderAccessor extends MessageHeaderAccessor {
 	 * @param nativeHeaders native headers to create the message with (may be {@code null})
 	 */
 	protected NativeMessageHeaderAccessor(@Nullable Map<String, List<String>> nativeHeaders) {
-		if (!CollectionUtils.isEmpty(nativeHeaders)) {
+		if (CollectionUtils.isNotEmpty(nativeHeaders)) {
 			setHeader(NATIVE_HEADERS, new LinkedMultiValueMap<>(nativeHeaders));
 		}
 	}
@@ -172,7 +172,7 @@ public class NativeMessageHeaderAccessor extends MessageHeaderAccessor {
 		Map<String, List<String>> map = getNativeHeaders();
 		if (map != null) {
 			List<String> values = map.get(headerName);
-			if (!CollectionUtils.isEmpty(values)) {
+			if (CollectionUtils.isNotEmpty(values)) {
 				return values.get(0);
 			}
 		}
@@ -292,7 +292,7 @@ public class NativeMessageHeaderAccessor extends MessageHeaderAccessor {
 		Map<String, List<String>> map = (Map<String, List<String>>) headers.get(NATIVE_HEADERS);
 		if (map != null) {
 			List<String> values = map.get(headerName);
-			if (!CollectionUtils.isEmpty(values)) {
+			if (CollectionUtils.isNotEmpty(values)) {
 				return values.get(0);
 			}
 		}

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/AbstractStompBrokerRelayIntegrationTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/stomp/AbstractStompBrokerRelayIntegrationTests.java
@@ -49,6 +49,7 @@ import org.springframework.messaging.support.ExecutorSubscribableChannel;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.messaging.tcp.TcpOperations;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -293,7 +294,7 @@ public abstract class AbstractStompBrokerRelayIntegrationTests {
 
 		public void expectMessages(MessageExchange... messageExchanges) throws InterruptedException {
 			List<MessageExchange> expectedMessages = new ArrayList<>(Arrays.asList(messageExchanges));
-			while (expectedMessages.size() > 0) {
+			while (CollectionUtils.isNotEmpty(expectedMessages)) {
 				Message<?> message = this.queue.poll(10000, TimeUnit.MILLISECONDS);
 				assertThat(message).as("Timed out waiting for messages, expected [" + expectedMessages + "]").isNotNull();
 				MessageExchange match = findMatch(expectedMessages, message);

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/AbstractEntityManagerFactoryBean.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/AbstractEntityManagerFactoryBean.java
@@ -362,7 +362,7 @@ public abstract class AbstractEntityManagerFactoryBean implements
 			PersistenceUnitInfo pui = getPersistenceUnitInfo();
 			Map<String, ?> vendorPropertyMap = (pui != null ? jpaVendorAdapter.getJpaPropertyMap(pui) :
 					jpaVendorAdapter.getJpaPropertyMap());
-			if (!CollectionUtils.isEmpty(vendorPropertyMap)) {
+			if (CollectionUtils.isNotEmpty(vendorPropertyMap)) {
 				vendorPropertyMap.forEach((key, value) -> {
 					if (!this.jpaPropertyMap.containsKey(key)) {
 						this.jpaPropertyMap.put(key, value);
@@ -583,7 +583,7 @@ public abstract class AbstractEntityManagerFactoryBean implements
 
 	@Override
 	public EntityManager createNativeEntityManager(@Nullable Map<?, ?> properties) {
-		EntityManager rawEntityManager = (!CollectionUtils.isEmpty(properties) ?
+		EntityManager rawEntityManager = (CollectionUtils.isNotEmpty(properties) ?
 				getNativeEntityManagerFactory().createEntityManager(properties) :
 				getNativeEntityManagerFactory().createEntityManager());
 		postProcessEntityManager(rawEntityManager);

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/EntityManagerFactoryAccessor.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/EntityManagerFactoryAccessor.java
@@ -162,7 +162,7 @@ public abstract class EntityManagerFactoryAccessor implements BeanFactoryAware {
 	protected EntityManager createEntityManager() throws IllegalStateException {
 		EntityManagerFactory emf = obtainEntityManagerFactory();
 		Map<String, Object> properties = getJpaPropertyMap();
-		return (!CollectionUtils.isEmpty(properties) ? emf.createEntityManager(properties) : emf.createEntityManager());
+		return (CollectionUtils.isNotEmpty(properties) ? emf.createEntityManager(properties) : emf.createEntityManager());
 	}
 
 	/**

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/EntityManagerFactoryUtils.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/EntityManagerFactoryUtils.java
@@ -259,7 +259,7 @@ public abstract class EntityManagerFactoryUtils {
 			}
 		}
 		if (em == null) {
-			em = (!CollectionUtils.isEmpty(properties) ? emf.createEntityManager(properties) : emf.createEntityManager());
+			em = (CollectionUtils.isNotEmpty(properties) ? emf.createEntityManager(properties) : emf.createEntityManager());
 		}
 
 		try {

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/ExtendedEntityManagerCreator.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/ExtendedEntityManagerCreator.java
@@ -174,7 +174,7 @@ public abstract class ExtendedEntityManagerCreator {
 			return createProxy(rawEntityManager, emfInfo, true, synchronizedWithTransaction);
 		}
 		else {
-			EntityManager rawEntityManager = (!CollectionUtils.isEmpty(properties) ?
+			EntityManager rawEntityManager = (CollectionUtils.isNotEmpty(properties) ?
 					emf.createEntityManager(properties) : emf.createEntityManager());
 			return createProxy(rawEntityManager, null, null, null, null, true, synchronizedWithTransaction);
 		}

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/JpaTransactionManager.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/JpaTransactionManager.java
@@ -477,7 +477,7 @@ public class JpaTransactionManager extends AbstractPlatformTransactionManager
 			em = emfInfo.createNativeEntityManager(properties);
 		}
 		else {
-			em = (!CollectionUtils.isEmpty(properties) ?
+			em = (CollectionUtils.isNotEmpty(properties) ?
 					emf.createEntityManager(properties) : emf.createEntityManager());
 		}
 		if (this.entityManagerInitializer != null) {

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/LocalContainerEntityManagerFactoryBean.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/LocalContainerEntityManagerFactoryBean.java
@@ -376,7 +376,7 @@ public class LocalContainerEntityManagerFactoryBean extends AbstractEntityManage
 		}
 
 		List<String> qualifiers = this.persistenceUnitInfo.getQualifierAnnotationNames();
-		if (!CollectionUtils.isEmpty(qualifiers)) {
+		if (CollectionUtils.isNotEmpty(qualifiers)) {
 			BeanFactory beanFactory = getBeanFactory();
 			String beanName = getBeanName();
 			if (beanFactory instanceof ConfigurableBeanFactory cbf && beanName != null) {

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/SharedEntityManagerCreator.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/SharedEntityManagerCreator.java
@@ -306,7 +306,7 @@ public abstract class SharedEntityManagerCreator {
 			boolean isNewEm = false;
 			if (target == null) {
 				logger.debug("Creating new EntityManager for shared EntityManager invocation");
-				target = (!CollectionUtils.isEmpty(this.properties) ?
+				target = (CollectionUtils.isNotEmpty(this.properties) ?
 						this.targetFactory.createEntityManager(this.properties) :
 						this.targetFactory.createEntityManager());
 				isNewEm = true;

--- a/spring-orm/src/main/java/org/springframework/orm/jpa/support/PersistenceAnnotationBeanPostProcessor.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/support/PersistenceAnnotationBeanPostProcessor.java
@@ -361,7 +361,7 @@ public class PersistenceAnnotationBeanPostProcessor implements InstantiationAwar
 		InjectionMetadata metadata = findInjectionMetadata(beanDefinition, beanClass, beanName);
 		Collection<InjectedElement> injectedElements = metadata.getInjectedElements(
 				beanDefinition.getPropertyValues());
-		if (!CollectionUtils.isEmpty(injectedElements)) {
+		if (CollectionUtils.isNotEmpty(injectedElements)) {
 			return new AotContribution(beanClass, injectedElements);
 		}
 		return null;
@@ -863,7 +863,7 @@ public class PersistenceAnnotationBeanPostProcessor implements InstantiationAwar
 					"$T entityManagerFactory = $T.findEntityManagerFactory(($T) $L.getBeanFactory(), $S)",
 					EntityManagerFactory.class, EntityManagerFactoryUtils.class,
 					ListableBeanFactory.class, REGISTERED_BEAN_PARAMETER, unitName);
-			boolean hasProperties = !CollectionUtils.isEmpty(properties);
+			boolean hasProperties = CollectionUtils.isNotEmpty(properties);
 			if (hasProperties) {
 				method.addStatement("$T properties = new Properties()",
 						Properties.class);

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/init/ScriptUtils.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/init/ScriptUtils.java
@@ -487,7 +487,7 @@ public abstract class ScriptUtils {
 			if (!inSingleQuote && !inDoubleQuote) {
 				if (script.startsWith(separator, i)) {
 					// We've reached the end of the current statement
-					if (sb.length() > 0) {
+					if (StringUtils.hasLength(sb)) {
 						statements.add(sb.toString());
 						sb = new StringBuilder();
 					}
@@ -520,7 +520,7 @@ public abstract class ScriptUtils {
 				}
 				else if (c == ' ' || c == '\r' || c == '\n' || c == '\t') {
 					// Avoid multiple adjacent whitespace characters
-					if (sb.length() > 0 && sb.charAt(sb.length() - 1) != ' ') {
+					if (StringUtils.hasLength(sb) && sb.charAt(sb.length() - 1) != ' ') {
 						c = ' ';
 					}
 					else {

--- a/spring-test/src/main/java/org/springframework/test/util/XpathExpectationsHelper.java
+++ b/spring-test/src/main/java/org/springframework/test/util/XpathExpectationsHelper.java
@@ -69,7 +69,7 @@ public class XpathExpectationsHelper {
 
 		this.expression = String.format(expression, args);
 		this.xpathExpression = compileXpathExpression(this.expression, namespaces);
-		this.hasNamespaces = !CollectionUtils.isEmpty(namespaces);
+		this.hasNamespaces = CollectionUtils.isNotEmpty(namespaces);
 	}
 
 	private static XPathExpression compileXpathExpression(String expression,

--- a/spring-test/src/main/java/org/springframework/test/web/ModelAndViewAssert.java
+++ b/spring-test/src/main/java/org/springframework/test/web/ModelAndViewAssert.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.ModelAndView;
 
 import static org.springframework.test.util.AssertionErrors.assertTrue;
@@ -128,7 +129,7 @@ public abstract class ModelAndViewAssert {
 			}
 		});
 
-		if (sb.length() != 0) {
+		if (StringUtils.hasLength(sb)) {
 			sb.insert(0, "Values of expected model do not match.\n");
 			fail(sb.toString());
 		}

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/AbstractMockServerSpec.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/AbstractMockServerSpec.java
@@ -92,13 +92,13 @@ abstract class AbstractMockServerSpec<B extends WebTestClient.MockServerSpec<B>>
 	@Override
 	public WebTestClient.Builder configureClient() {
 		WebHttpHandlerBuilder builder = initHttpHandlerBuilder();
-		if (!CollectionUtils.isEmpty(this.filters)) {
+		if (CollectionUtils.isNotEmpty(this.filters)) {
 			builder.filters(theFilters -> theFilters.addAll(0, this.filters));
 		}
 		if (!builder.hasSessionManager() && this.sessionManager != null) {
 			builder.sessionManager(this.sessionManager);
 		}
-		if (!CollectionUtils.isEmpty(this.configurers)) {
+		if (CollectionUtils.isNotEmpty(this.configurers)) {
 			this.configurers.forEach(configurer -> configurer.beforeServerCreated(builder));
 		}
 		return new DefaultWebTestClientBuilder(builder, this.sslInfo);

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
@@ -397,10 +397,10 @@ class DefaultWebTestClient implements WebTestClient {
 						}
 					})
 					.cookies(cookiesToUse -> {
-						if (!CollectionUtils.isEmpty(DefaultWebTestClient.this.defaultCookies)) {
+						if (CollectionUtils.isNotEmpty(DefaultWebTestClient.this.defaultCookies)) {
 							cookiesToUse.putAll(DefaultWebTestClient.this.defaultCookies);
 						}
-						if (!CollectionUtils.isEmpty(this.cookies)) {
+						if (CollectionUtils.isNotEmpty(this.cookies)) {
 							cookiesToUse.putAll(this.cookies);
 						}
 					})

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/HeaderAssertions.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/HeaderAssertions.java
@@ -199,7 +199,7 @@ public class HeaderAssertions {
 
 	private List<String> getRequiredValues(String name) {
 		List<String> values = getHeaders().get(name);
-		if (!CollectionUtils.isEmpty(values)) {
+		if (CollectionUtils.isNotEmpty(values)) {
 			return values;
 		}
 		else {

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/samples/client/standalone/MultipartControllerTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/samples/client/standalone/MultipartControllerTests.java
@@ -272,7 +272,7 @@ public class MultipartControllerTests {
 		public String processMultipartFileList(@RequestParam(required = false) List<MultipartFile> file,
 				@RequestPart(required = false) Map<String, String> json) throws IOException {
 
-			if (!CollectionUtils.isEmpty(file)) {
+			if (CollectionUtils.isNotEmpty(file)) {
 				byte[] content = file.get(0).getBytes();
 				assertThat(file.get(1).getBytes()).isEqualTo(content);
 			}

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/samples/standalone/MultipartControllerTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/samples/standalone/MultipartControllerTests.java
@@ -272,7 +272,7 @@ class MultipartControllerTests {
 		public String processMultipartFileList(@RequestParam(required = false) List<MultipartFile> file,
 				@RequestPart(required = false) Map<String, String> json) throws IOException {
 
-			if (!CollectionUtils.isEmpty(file)) {
+			if (CollectionUtils.isNotEmpty(file)) {
 				byte[] content = file.get(0).getBytes();
 				assertThat(file.get(1).getBytes()).isEqualTo(content);
 			}

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/HttpComponentsClientHttpRequest.java
@@ -142,7 +142,7 @@ class HttpComponentsClientHttpRequest extends AbstractClientHttpRequest {
 		if (getCookies().isEmpty()) {
 			return;
 		}
-		if (!CollectionUtils.isEmpty(getCookies())) {
+		if (CollectionUtils.isNotEmpty(getCookies())) {
 			this.httpRequest.setHeader(HttpHeaders.COOKIE, serializeCookies());
 		}
 	}

--- a/spring-web/src/main/java/org/springframework/http/client/support/InterceptingHttpAccessor.java
+++ b/spring-web/src/main/java/org/springframework/http/client/support/InterceptingHttpAccessor.java
@@ -96,7 +96,7 @@ public abstract class InterceptingHttpAccessor extends HttpAccessor {
 	@Override
 	public ClientHttpRequestFactory getRequestFactory() {
 		List<ClientHttpRequestInterceptor> interceptors = getInterceptors();
-		if (!CollectionUtils.isEmpty(interceptors)) {
+		if (CollectionUtils.isNotEmpty(interceptors)) {
 			ClientHttpRequestFactory factory = this.interceptingRequestFactory;
 			if (factory == null) {
 				factory = new InterceptingClientHttpRequestFactory(

--- a/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageWriter.java
@@ -26,6 +26,7 @@ import java.util.Map;
 
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
+import org.springframework.util.StringUtils;
 import reactor.core.publisher.Mono;
 
 import org.springframework.core.ResolvableType;
@@ -162,7 +163,7 @@ public class FormHttpMessageWriter extends LoggingCodecSupport
 		StringBuilder builder = new StringBuilder();
 		formData.forEach((name, values) ->
 				values.forEach(value -> {
-					if (builder.length() != 0) {
+					if (StringUtils.hasLength(builder)) {
 						builder.append('&');
 					}
 					builder.append(URLEncoder.encode(name, charset));

--- a/spring-web/src/main/java/org/springframework/http/codec/JacksonCodecSupport.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/JacksonCodecSupport.java
@@ -189,7 +189,7 @@ public abstract class JacksonCodecSupport {
 				result.addAll(entry.getValue().keySet());
 			}
 		}
-		if (!CollectionUtils.isEmpty(result)) {
+		if (CollectionUtils.isNotEmpty(result)) {
 			return result;
 		}
 		return (ProblemDetail.class.isAssignableFrom(elementClass) ? getMediaTypesForProblemDetail() : getMimeTypes());

--- a/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2CodecSupport.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2CodecSupport.java
@@ -181,7 +181,7 @@ public abstract class Jackson2CodecSupport {
 				result.addAll(entry.getValue().keySet());
 			}
 		}
-		if (!CollectionUtils.isEmpty(result)) {
+		if (CollectionUtils.isNotEmpty(result)) {
 			return result;
 		}
 		return (ProblemDetail.class.isAssignableFrom(elementClass) ? getMediaTypesForProblemDetail() : getMimeTypes());

--- a/spring-web/src/main/java/org/springframework/http/converter/AbstractJacksonHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/AbstractJacksonHttpMessageConverter.java
@@ -238,7 +238,7 @@ public abstract class AbstractJacksonHttpMessageConverter extends AbstractSmartH
 				result.addAll(entry.getValue().keySet());
 			}
 		}
-		if (!CollectionUtils.isEmpty(result)) {
+		if (CollectionUtils.isNotEmpty(result)) {
 			return result;
 		}
 		return (ProblemDetail.class.isAssignableFrom(clazz) ?

--- a/spring-web/src/main/java/org/springframework/http/converter/FormHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/FormHttpMessageConverter.java
@@ -444,7 +444,7 @@ public class FormHttpMessageConverter implements HttpMessageConverter<MultiValue
 					return;
 				}
 				values.forEach(value -> {
-					if (builder.length() != 0) {
+					if (StringUtils.hasLength(builder)) {
 						builder.append('&');
 					}
 					builder.append(URLEncoder.encode(name, charset));

--- a/spring-web/src/main/java/org/springframework/http/converter/json/AbstractJackson2HttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/AbstractJackson2HttpMessageConverter.java
@@ -203,7 +203,7 @@ public abstract class AbstractJackson2HttpMessageConverter extends AbstractGener
 				result.addAll(entry.getValue().keySet());
 			}
 		}
-		if (!CollectionUtils.isEmpty(result)) {
+		if (CollectionUtils.isNotEmpty(result)) {
 			return result;
 		}
 		return (ProblemDetail.class.isAssignableFrom(clazz) ?

--- a/spring-web/src/main/java/org/springframework/web/accept/ContentNegotiationManagerFactoryBean.java
+++ b/spring-web/src/main/java/org/springframework/web/accept/ContentNegotiationManagerFactoryBean.java
@@ -158,7 +158,7 @@ public class ContentNegotiationManagerFactoryBean implements FactoryBean<Content
 	 * @see #addMediaTypes(Map)
 	 */
 	public void setMediaTypes(Properties mediaTypes) {
-		if (!CollectionUtils.isEmpty(mediaTypes)) {
+		if (CollectionUtils.isNotEmpty(mediaTypes)) {
 			mediaTypes.forEach((key, value) ->
 					addMediaType((String) key, MediaType.valueOf((String) value)));
 		}
@@ -269,7 +269,7 @@ public class ContentNegotiationManagerFactoryBean implements FactoryBean<Content
 		// Ensure media type mappings are available via ContentNegotiationManager#getMediaTypeMappings()
 		// independent of path extension or parameter strategies.
 
-		if (!CollectionUtils.isEmpty(this.mediaTypes) && !this.favorParameter) {
+		if (CollectionUtils.isNotEmpty(this.mediaTypes) && !this.favorParameter) {
 			this.contentNegotiationManager.addFileExtensionResolvers(
 					new MappingMediaTypeFileExtensionResolver(this.mediaTypes));
 		}

--- a/spring-web/src/main/java/org/springframework/web/accept/HeaderContentNegotiationStrategy.java
+++ b/spring-web/src/main/java/org/springframework/web/accept/HeaderContentNegotiationStrategy.java
@@ -54,7 +54,7 @@ public class HeaderContentNegotiationStrategy implements ContentNegotiationStrat
 		try {
 			List<MediaType> mediaTypes = MediaType.parseMediaTypes(headerValues);
 			MimeTypeUtils.sortBySpecificity(mediaTypes);
-			return !CollectionUtils.isEmpty(mediaTypes) ? mediaTypes : MEDIA_TYPE_ALL_LIST;
+			return CollectionUtils.isNotEmpty(mediaTypes) ? mediaTypes : MEDIA_TYPE_ALL_LIST;
 		}
 		catch (InvalidMediaTypeException | InvalidMimeTypeException ex) {
 			throw new HttpMediaTypeNotAcceptableException(

--- a/spring-web/src/main/java/org/springframework/web/bind/support/WebExchangeDataBinder.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/support/WebExchangeDataBinder.java
@@ -147,7 +147,7 @@ public class WebExchangeDataBinder extends WebDataBinder {
 	}
 
 	protected static void addBindValue(Map<String, Object> params, String key, List<?> values) {
-		if (!CollectionUtils.isEmpty(values)) {
+		if (CollectionUtils.isNotEmpty(values)) {
 			if (values.size() == 1) {
 				params.put(key, adaptBindValue(values.get(0)));
 			}

--- a/spring-web/src/main/java/org/springframework/web/client/DefaultResponseErrorHandler.java
+++ b/spring-web/src/main/java/org/springframework/web/client/DefaultResponseErrorHandler.java
@@ -151,7 +151,7 @@ public class DefaultResponseErrorHandler implements ResponseErrorHandler {
 			ex = new UnknownHttpStatusCodeException(message, statusCode.value(), statusText, headers, body, charset);
 		}
 
-		if (!CollectionUtils.isEmpty(this.messageConverters)) {
+		if (CollectionUtils.isNotEmpty(this.messageConverters)) {
 			ex.setBodyConvertFunction(initBodyConvertFunction(response, body));
 		}
 
@@ -226,7 +226,7 @@ public class DefaultResponseErrorHandler implements ResponseErrorHandler {
 	 */
 	@SuppressWarnings("NullAway") // Lambda
 	protected Function<ResolvableType, ?> initBodyConvertFunction(ClientHttpResponse response, byte[] body) {
-		Assert.state(!CollectionUtils.isEmpty(this.messageConverters), "Expected message converters");
+		Assert.state(CollectionUtils.isNotEmpty(this.messageConverters), "Expected message converters");
 		return resolvableType -> {
 			try {
 				HttpMessageConverterExtractor<?> extractor =

--- a/spring-web/src/main/java/org/springframework/web/client/DefaultRestClient.java
+++ b/spring-web/src/main/java/org/springframework/web/client/DefaultRestClient.java
@@ -663,7 +663,7 @@ final class DefaultRestClient implements RestClient {
 				map.putAll(defaultCookies);
 				map.putAll(this.cookies);
 			}
-			return (!CollectionUtils.isEmpty(map) ? serializeCookies(map) : null);
+			return (CollectionUtils.isNotEmpty(map) ? serializeCookies(map) : null);
 		}
 
 		private static String serializeCookies(MultiValueMap<String, String> map) {

--- a/spring-web/src/main/java/org/springframework/web/client/DefaultRestClientBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/client/DefaultRestClientBuilder.java
@@ -152,11 +152,11 @@ final class DefaultRestClientBuilder implements RestClient.Builder {
 		this.uriBuilderFactory = getUriBuilderFactory(restTemplate);
 		this.statusHandlers = new ArrayList<>();
 		this.statusHandlers.add(StatusHandler.fromErrorHandler(restTemplate.getErrorHandler()));
-		if (!CollectionUtils.isEmpty(restTemplate.getInterceptors())) {
+		if (CollectionUtils.isNotEmpty(restTemplate.getInterceptors())) {
 			this.interceptors = new ArrayList<>(restTemplate.getInterceptors());
 		}
 		this.bufferingPredicate = restTemplate.getBufferingPredicate();
-		if (!CollectionUtils.isEmpty(restTemplate.getClientHttpRequestInitializers())) {
+		if (CollectionUtils.isNotEmpty(restTemplate.getClientHttpRequestInitializers())) {
 			this.initializers = new ArrayList<>(restTemplate.getClientHttpRequestInitializers());
 		}
 		this.requestFactory = getRequestFactory(restTemplate);

--- a/spring-web/src/main/java/org/springframework/web/client/ExtractingResponseErrorHandler.java
+++ b/spring-web/src/main/java/org/springframework/web/client/ExtractingResponseErrorHandler.java
@@ -106,7 +106,7 @@ public class ExtractingResponseErrorHandler extends DefaultResponseErrorHandler 
 	 * {@link RestClientException}.
 	 */
 	public void setStatusMapping(Map<HttpStatusCode, Class<? extends RestClientException>> statusMapping) {
-		if (!CollectionUtils.isEmpty(statusMapping)) {
+		if (CollectionUtils.isNotEmpty(statusMapping)) {
 			this.statusMapping.putAll(statusMapping);
 		}
 	}
@@ -122,7 +122,7 @@ public class ExtractingResponseErrorHandler extends DefaultResponseErrorHandler 
 	 * {@link RestClientException}.
 	 */
 	public void setSeriesMapping(Map<HttpStatus.Series, Class<? extends RestClientException>> seriesMapping) {
-		if (!CollectionUtils.isEmpty(seriesMapping)) {
+		if (CollectionUtils.isNotEmpty(seriesMapping)) {
 			this.seriesMapping.putAll(seriesMapping);
 		}
 	}

--- a/spring-web/src/main/java/org/springframework/web/client/StatusHandler.java
+++ b/spring-web/src/main/java/org/springframework/web/client/StatusHandler.java
@@ -92,7 +92,7 @@ final class StatusHandler {
 					else {
 						ex = new UnknownHttpStatusCodeException(message, statusCode.value(), statusText, headers, body, charset);
 					}
-					if (!CollectionUtils.isEmpty(messageConverters)) {
+					if (CollectionUtils.isNotEmpty(messageConverters)) {
 						ex.setBodyConvertFunction(initBodyConvertFunction(response, body, messageConverters));
 					}
 					throw ex;
@@ -101,7 +101,7 @@ final class StatusHandler {
 
 	@SuppressWarnings("NullAway")
 	private static Function<ResolvableType, ? extends @Nullable Object> initBodyConvertFunction(ClientHttpResponse response, byte[] body, List<HttpMessageConverter<?>> messageConverters) {
-		Assert.state(!CollectionUtils.isEmpty(messageConverters), "Expected message converters");
+		Assert.state(CollectionUtils.isNotEmpty(messageConverters), "Expected message converters");
 		return resolvableType -> {
 			try {
 				HttpMessageConverterExtractor<?> extractor =

--- a/spring-web/src/main/java/org/springframework/web/cors/CorsConfiguration.java
+++ b/spring-web/src/main/java/org/springframework/web/cors/CorsConfiguration.java
@@ -291,7 +291,7 @@ public class CorsConfiguration {
 	 */
 	public void setAllowedMethods(@Nullable List<String> allowedMethods) {
 		this.allowedMethods = (allowedMethods != null ? new ArrayList<>(allowedMethods) : null);
-		if (!CollectionUtils.isEmpty(allowedMethods)) {
+		if (CollectionUtils.isNotEmpty(allowedMethods)) {
 			this.resolvedMethods = new ArrayList<>(allowedMethods.size());
 			for (String method : allowedMethods) {
 				if (ALL.equals(method)) {
@@ -601,7 +601,7 @@ public class CorsConfiguration {
 		CorsConfiguration config = new CorsConfiguration(this);
 		List<String> origins = combine(getAllowedOrigins(), other.getAllowedOrigins());
 		List<OriginPattern> patterns = combinePatterns(this.allowedOriginPatterns, other.allowedOriginPatterns);
-		config.allowedOrigins = (origins == DEFAULT_PERMIT_ALL && !CollectionUtils.isEmpty(patterns) ? null : origins);
+		config.allowedOrigins = (origins == DEFAULT_PERMIT_ALL && CollectionUtils.isNotEmpty(patterns) ? null : origins);
 		config.allowedOriginPatterns = patterns;
 		config.setAllowedMethods(combine(getAllowedMethods(), other.getAllowedMethods()));
 		config.setAllowedHeaders(combine(getAllowedHeaders(), other.getAllowedHeaders()));

--- a/spring-web/src/main/java/org/springframework/web/cors/DefaultCorsProcessor.java
+++ b/spring-web/src/main/java/org/springframework/web/cors/DefaultCorsProcessor.java
@@ -156,11 +156,11 @@ public class DefaultCorsProcessor implements CorsProcessor {
 			responseHeaders.setAccessControlAllowMethods(allowMethods);
 		}
 
-		if (preFlightRequest && !CollectionUtils.isEmpty(allowHeaders)) {
+		if (preFlightRequest && CollectionUtils.isNotEmpty(allowHeaders)) {
 			responseHeaders.setAccessControlAllowHeaders(allowHeaders);
 		}
 
-		if (!CollectionUtils.isEmpty(config.getExposedHeaders())) {
+		if (CollectionUtils.isNotEmpty(config.getExposedHeaders())) {
 			responseHeaders.setAccessControlExposeHeaders(config.getExposedHeaders());
 		}
 

--- a/spring-web/src/main/java/org/springframework/web/cors/reactive/DefaultCorsProcessor.java
+++ b/spring-web/src/main/java/org/springframework/web/cors/reactive/DefaultCorsProcessor.java
@@ -153,11 +153,11 @@ public class DefaultCorsProcessor implements CorsProcessor {
 			responseHeaders.setAccessControlAllowMethods(allowMethods);
 		}
 
-		if (preFlightRequest && !CollectionUtils.isEmpty(allowHeaders)) {
+		if (preFlightRequest && CollectionUtils.isNotEmpty(allowHeaders)) {
 			responseHeaders.setAccessControlAllowHeaders(allowHeaders);
 		}
 
-		if (!CollectionUtils.isEmpty(config.getExposedHeaders())) {
+		if (CollectionUtils.isNotEmpty(config.getExposedHeaders())) {
 			responseHeaders.setAccessControlExposeHeaders(config.getExposedHeaders());
 		}
 

--- a/spring-web/src/main/java/org/springframework/web/filter/FormContentFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/FormContentFilter.java
@@ -86,7 +86,7 @@ public class FormContentFilter extends OncePerRequestFilter {
 			throws ServletException, IOException {
 
 		MultiValueMap<String, String> params = parseIfNecessary(request);
-		if (!CollectionUtils.isEmpty(params)) {
+		if (CollectionUtils.isNotEmpty(params)) {
 			filterChain.doFilter(new FormContentRequestWrapper(request, params), response);
 		}
 		else {

--- a/spring-web/src/main/java/org/springframework/web/filter/GenericFilterBean.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/GenericFilterBean.java
@@ -331,7 +331,7 @@ public abstract class GenericFilterBean implements Filter, BeanNameAware, Enviro
 		public FilterConfigPropertyValues(FilterConfig config, Set<String> requiredProperties)
 				throws ServletException {
 
-			Set<String> missingProps = (!CollectionUtils.isEmpty(requiredProperties) ?
+			Set<String> missingProps = (CollectionUtils.isNotEmpty(requiredProperties) ?
 					new HashSet<>(requiredProperties) : null);
 
 			Enumeration<String> paramNames = config.getInitParameterNames();
@@ -345,7 +345,7 @@ public abstract class GenericFilterBean implements Filter, BeanNameAware, Enviro
 			}
 
 			// Fail if we are still missing properties.
-			if (!CollectionUtils.isEmpty(missingProps)) {
+			if (CollectionUtils.isNotEmpty(missingProps)) {
 				throw new ServletException(
 						"Initialization from FilterConfig for filter '" + config.getFilterName() +
 						"' failed; the following required properties were missing: " +

--- a/spring-web/src/main/java/org/springframework/web/service/invoker/HttpRequestValues.java
+++ b/spring-web/src/main/java/org/springframework/web/service/invoker/HttpRequestValues.java
@@ -539,7 +539,7 @@ public class HttpRequestValues {
 				bodyValue = buildMultipartBody();
 			}
 
-			if (!CollectionUtils.isEmpty(this.requestParams)) {
+			if (CollectionUtils.isNotEmpty(this.requestParams)) {
 				if (hasFormDataContentType()) {
 					Assert.isTrue(!hasParts(), "Request parts not expected for a form data request");
 					Assert.isTrue(!hasBody(), "Body not expected for a form data request");

--- a/spring-web/src/main/java/org/springframework/web/util/DefaultUriBuilderFactory.java
+++ b/spring-web/src/main/java/org/springframework/web/util/DefaultUriBuilderFactory.java
@@ -432,7 +432,7 @@ public class DefaultUriBuilderFactory implements UriBuilderFactory {
 
 		@Override
 		public URI build(Map<String, ?> uriVars) {
-			if (!CollectionUtils.isEmpty(defaultUriVariables)) {
+			if (CollectionUtils.isNotEmpty(defaultUriVariables)) {
 				Map<String, Object> map = new HashMap<>(defaultUriVariables.size() + uriVars.size());
 				map.putAll(defaultUriVariables);
 				map.putAll(uriVars);
@@ -447,7 +447,7 @@ public class DefaultUriBuilderFactory implements UriBuilderFactory {
 
 		@Override
 		public URI build(@Nullable Object... uriVars) {
-			if (ObjectUtils.isEmpty(uriVars) && !CollectionUtils.isEmpty(defaultUriVariables)) {
+			if (ObjectUtils.isEmpty(uriVars) && CollectionUtils.isNotEmpty(defaultUriVariables)) {
 				return build(Collections.emptyMap());
 			}
 			if (encodingMode.equals(EncodingMode.VALUES_ONLY)) {

--- a/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
+++ b/spring-web/src/main/java/org/springframework/web/util/HierarchicalUriComponents.java
@@ -211,14 +211,14 @@ final class HierarchicalUriComponents extends UriComponents {
 			StringBuilder queryBuilder = new StringBuilder();
 			this.queryParams.forEach((name, values) -> {
 				if (CollectionUtils.isEmpty(values)) {
-					if (queryBuilder.length() != 0) {
+					if (StringUtils.hasLength(queryBuilder)) {
 						queryBuilder.append('&');
 					}
 					queryBuilder.append(name);
 				}
 				else {
 					for (Object value : values) {
-						if (queryBuilder.length() != 0) {
+						if (StringUtils.hasLength(queryBuilder)) {
 							queryBuilder.append('&');
 						}
 						queryBuilder.append(name);
@@ -482,7 +482,7 @@ final class HierarchicalUriComponents extends UriComponents {
 		}
 		String path = getPath();
 		if (StringUtils.hasLength(path)) {
-			if (uriBuilder.length() != 0 && path.charAt(0) != PATH_DELIMITER) {
+			if (StringUtils.hasLength(uriBuilder) && path.charAt(0) != PATH_DELIMITER) {
 				uriBuilder.append(PATH_DELIMITER);
 			}
 			uriBuilder.append(path);

--- a/spring-web/src/main/java/org/springframework/web/util/UriTemplate.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriTemplate.java
@@ -29,6 +29,7 @@ import org.jspecify.annotations.Nullable;
 
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 /**
  * Representation of a URI template that can be expanded with URI variables via
@@ -238,14 +239,14 @@ public class UriTemplate implements Serializable {
 				}
 				builder.append(c);
 			}
-			if (builder.length() > 0) {
+			if (StringUtils.hasLength(builder)) {
 				pattern.append(quote(builder));
 			}
 			return new TemplateInfo(variableNames, Pattern.compile(pattern.toString()));
 		}
 
 		private static String quote(StringBuilder builder) {
-			return (builder.length() > 0 ? Pattern.quote(builder.toString()) : "");
+			return (StringUtils.hasLength(builder) ? Pattern.quote(builder.toString()) : "");
 		}
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/util/pattern/PathPattern.java
+++ b/spring-web/src/main/java/org/springframework/web/util/pattern/PathPattern.java
@@ -567,7 +567,7 @@ public class PathPattern implements Comparable<PathPattern> {
 	 * @return {@code true} has more than zero elements
 	 */
 	private boolean hasLength(@Nullable PathContainer container) {
-		return container != null && container.elements().size() > 0;
+		return container != null && CollectionUtils.isNotEmpty(container.elements());
 	}
 
 	private static int scoreByNormalizedLength(PathPattern pattern) {

--- a/spring-web/src/test/java/org/springframework/web/multipart/support/DefaultMultipartHttpServletRequestTests.java
+++ b/spring-web/src/test/java/org/springframework/web/multipart/support/DefaultMultipartHttpServletRequestTests.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
 import org.springframework.web.testfixture.servlet.MockHttpServletRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -81,7 +82,7 @@ class DefaultMultipartHttpServletRequestTests {
 		for (String key : this.queryParams.keySet()) {
 			for (String value : this.queryParams.get(key)) {
 				this.servletRequest.addParameter(key, value);
-				query.append(query.length() > 0 ? "&" : "").append(key).append('=').append(value);
+				query.append(StringUtils.hasLength(query) ? "&" : "").append(key).append('=').append(value);
 			}
 		}
 		this.servletRequest.setQueryString(query.toString());

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/accept/HeaderContentTypeResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/accept/HeaderContentTypeResolver.java
@@ -38,7 +38,7 @@ public class HeaderContentTypeResolver implements RequestedContentTypeResolver {
 		try {
 			List<MediaType> mediaTypes = exchange.getRequest().getHeaders().getAccept();
 			MimeTypeUtils.sortBySpecificity(mediaTypes);
-			return (!CollectionUtils.isEmpty(mediaTypes) ? mediaTypes : MEDIA_TYPE_ALL_LIST);
+			return (CollectionUtils.isNotEmpty(mediaTypes) ? mediaTypes : MEDIA_TYPE_ALL_LIST);
 		}
 		catch (InvalidMediaTypeException ex) {
 			String value = exchange.getRequest().getHeaders().getFirst("Accept");

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/config/DelegatingWebFluxConfiguration.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/config/DelegatingWebFluxConfiguration.java
@@ -49,7 +49,7 @@ public class DelegatingWebFluxConfiguration extends WebFluxConfigurationSupport 
 
 	@Autowired(required = false)
 	public void setConfigurers(List<WebFluxConfigurer> configurers) {
-		if (!CollectionUtils.isEmpty(configurers)) {
+		if (CollectionUtils.isNotEmpty(configurers)) {
 			this.configurers.addWebFluxConfigurers(configurers);
 		}
 	}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/config/WebFluxConfigurerComposite.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/config/WebFluxConfigurerComposite.java
@@ -46,7 +46,7 @@ public class WebFluxConfigurerComposite implements WebFluxConfigurer {
 
 
 	public void addWebFluxConfigurers(List<WebFluxConfigurer> configurers) {
-		if (!CollectionUtils.isEmpty(configurers)) {
+		if (CollectionUtils.isNotEmpty(configurers)) {
 			this.delegates.addAll(configurers);
 		}
 	}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
@@ -521,10 +521,10 @@ final class DefaultWebClient implements WebClient {
 		}
 
 		private void initCookies(MultiValueMap<String, String> out) {
-			if (!CollectionUtils.isEmpty(defaultCookies)) {
+			if (CollectionUtils.isNotEmpty(defaultCookies)) {
 				out.putAll(defaultCookies);
 			}
-			if (!CollectionUtils.isEmpty(this.cookies)) {
+			if (CollectionUtils.isNotEmpty(this.cookies)) {
 				out.putAll(this.cookies);
 			}
 		}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
@@ -521,7 +521,7 @@ public class ResourceWebHandler implements WebHandler, InitializingBean {
 	private @Nullable MediaType getMediaType(Resource resource) {
 		MediaType mediaType = null;
 		String filename = resource.getFilename();
-		if (!CollectionUtils.isEmpty(this.mediaTypes)) {
+		if (CollectionUtils.isNotEmpty(this.mediaTypes)) {
 			String ext = StringUtils.getFilenameExtension(filename);
 			if (ext != null) {
 				mediaType = this.mediaTypes.get(ext.toLowerCase(Locale.ROOT));
@@ -529,7 +529,7 @@ public class ResourceWebHandler implements WebHandler, InitializingBean {
 		}
 		if (mediaType == null) {
 			List<MediaType> mediaTypes = MediaTypeFactory.getMediaTypes(filename);
-			if (!CollectionUtils.isEmpty(mediaTypes)) {
+			if (CollectionUtils.isNotEmpty(mediaTypes)) {
 				mediaType = mediaTypes.get(0);
 			}
 		}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/condition/ConsumesRequestCondition.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/condition/ConsumesRequestCondition.java
@@ -207,7 +207,7 @@ public final class ConsumesRequestCondition extends AbstractRequestCondition<Con
 			return EMPTY_CONDITION;
 		}
 		List<ConsumeMediaTypeExpression> result = getMatchingExpressions(exchange);
-		return !CollectionUtils.isEmpty(result) ? new ConsumesRequestCondition(result) : null;
+		return CollectionUtils.isNotEmpty(result) ? new ConsumesRequestCondition(result) : null;
 	}
 
 	private boolean hasBody(ServerHttpRequest request) {

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/condition/ProducesRequestCondition.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/condition/ProducesRequestCondition.java
@@ -202,7 +202,7 @@ public final class ProducesRequestCondition extends AbstractRequestCondition<Pro
 			return this;
 		}
 		List<ProduceMediaTypeExpression> result = getMatchingExpressions(exchange);
-		if (!CollectionUtils.isEmpty(result)) {
+		if (CollectionUtils.isNotEmpty(result)) {
 			return new ProducesRequestCondition(result, this);
 		}
 		else {

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractMessageWriterResultHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractMessageWriterResultHandler.java
@@ -240,7 +240,7 @@ public abstract class AbstractMessageWriterResultHandler extends HandlerResultHa
 		MediaType contentType = exchange.getResponse().getHeaders().getContentType();
 		boolean isPresentMediaType = (contentType != null && contentType.equals(bestMediaType));
 		Set<MediaType> producibleTypes = exchange.getAttribute(HandlerMapping.PRODUCIBLE_MEDIA_TYPES_ATTRIBUTE);
-		if (isPresentMediaType || !CollectionUtils.isEmpty(producibleTypes)) {
+		if (isPresentMediaType || CollectionUtils.isNotEmpty(producibleTypes)) {
 			return Mono.error(new HttpMessageNotWritableException(
 					"No Encoder for [" + elementType + "] with preset Content-Type '" + contentType + "'"));
 		}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/ExtendedWebExchangeDataBinder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/ExtendedWebExchangeDataBinder.java
@@ -83,7 +83,7 @@ public class ExtendedWebExchangeDataBinder extends WebExchangeDataBinder {
 	public Mono<Map<String, Object>> getValuesToBind(ServerWebExchange exchange) {
 		return super.getValuesToBind(exchange).doOnNext(map -> {
 			Map<String, String> vars = exchange.getAttribute(HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE);
-			if (!CollectionUtils.isEmpty(vars)) {
+			if (CollectionUtils.isNotEmpty(vars)) {
 				vars.forEach((key, value) -> addValueIfNotPresent(map, "URI variable", key, value));
 			}
 			HttpHeaders headers = exchange.getRequest().getHeaders();
@@ -93,7 +93,7 @@ public class ExtendedWebExchangeDataBinder extends WebExchangeDataBinder {
 					continue;
 				}
 				List<String> values = entry.getValue();
-				if (!CollectionUtils.isEmpty(values)) {
+				if (CollectionUtils.isNotEmpty(values)) {
 					// For constructor args with @BindParam mapped to the actual header name
 					addValueIfNotPresent(map, "Header", name, (values.size() == 1 ? values.get(0) : values));
 					// Also adapt to Java conventions for setters

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/HttpServletBean.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/HttpServletBean.java
@@ -215,7 +215,7 @@ public abstract class HttpServletBean extends HttpServlet implements Environment
 		public ServletConfigPropertyValues(ServletConfig config, Set<String> requiredProperties)
 				throws ServletException {
 
-			Set<String> missingProps = (!CollectionUtils.isEmpty(requiredProperties) ?
+			Set<String> missingProps = (CollectionUtils.isNotEmpty(requiredProperties) ?
 					new HashSet<>(requiredProperties) : null);
 
 			Enumeration<String> paramNames = config.getInitParameterNames();
@@ -229,7 +229,7 @@ public abstract class HttpServletBean extends HttpServlet implements Environment
 			}
 
 			// Fail if we are still missing properties.
-			if (!CollectionUtils.isEmpty(missingProps)) {
+			if (CollectionUtils.isNotEmpty(missingProps)) {
 				throw new ServletException(
 						"Initialization from ServletConfig for servlet '" + config.getServletName() +
 						"' failed; the following required properties were missing: " +

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/DelegatingWebMvcConfiguration.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/DelegatingWebMvcConfiguration.java
@@ -50,7 +50,7 @@ public class DelegatingWebMvcConfiguration extends WebMvcConfigurationSupport {
 
 	@Autowired(required = false)
 	public void setConfigurers(List<WebMvcConfigurer> configurers) {
-		if (!CollectionUtils.isEmpty(configurers)) {
+		if (CollectionUtils.isNotEmpty(configurers)) {
 			this.configurers.addWebMvcConfigurers(configurers);
 		}
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/ViewResolverRegistry.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/ViewResolverRegistry.java
@@ -114,7 +114,7 @@ public class ViewResolverRegistry {
 
 		if (this.contentNegotiatingResolver != null) {
 			if (!ObjectUtils.isEmpty(defaultViews) &&
-					!CollectionUtils.isEmpty(this.contentNegotiatingResolver.getDefaultViews())) {
+					CollectionUtils.isNotEmpty(this.contentNegotiatingResolver.getDefaultViews())) {
 				List<View> views = new ArrayList<>(this.contentNegotiatingResolver.getDefaultViews());
 				views.addAll(Arrays.asList(defaultViews));
 				this.contentNegotiatingResolver.setDefaultViews(views);

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurerComposite.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurerComposite.java
@@ -44,7 +44,7 @@ class WebMvcConfigurerComposite implements WebMvcConfigurer {
 
 
 	public void addWebMvcConfigurers(List<WebMvcConfigurer> configurers) {
-		if (!CollectionUtils.isEmpty(configurers)) {
+		if (CollectionUtils.isNotEmpty(configurers)) {
 			this.delegates.addAll(configurers);
 		}
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractUrlHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractUrlHandlerMapping.java
@@ -383,7 +383,7 @@ public abstract class AbstractUrlHandlerMapping extends AbstractHandlerMapping i
 					uriTemplateVariables.putAll(decodedVars);
 				}
 			}
-			if (logger.isTraceEnabled() && uriTemplateVariables.size() > 0) {
+			if (logger.isTraceEnabled() && CollectionUtils.isNotEmpty(uriTemplateVariables)) {
 				logger.trace("URI variables " + uriTemplateVariables);
 			}
 			return buildPathExposingHandler(handler, bestMatch, pathWithinMapping, uriTemplateVariables);
@@ -434,7 +434,7 @@ public abstract class AbstractUrlHandlerMapping extends AbstractHandlerMapping i
 
 		HandlerExecutionChain chain = new HandlerExecutionChain(rawHandler);
 		chain.addInterceptor(new PathExposingHandlerInterceptor(bestMatchingPattern, pathWithinMapping));
-		if (!CollectionUtils.isEmpty(uriTemplateVariables)) {
+		if (CollectionUtils.isNotEmpty(uriTemplateVariables)) {
 			chain.addInterceptor(new UriTemplateVariablesHandlerInterceptor(uriTemplateVariables));
 		}
 		return chain;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/ParameterizableViewController.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/ParameterizableViewController.java
@@ -23,6 +23,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.View;
 import org.springframework.web.servlet.support.RequestContextUtils;
@@ -187,7 +188,7 @@ public class ParameterizableViewController extends AbstractController {
 			sb.append("status=").append(this.statusCode);
 		}
 		if (this.view != null) {
-			sb.append(sb.length() != 0 ? ", " : "");
+			sb.append(StringUtils.hasLength(sb) ? ", " : "");
 			String viewName = getViewName();
 			sb.append("view=").append(viewName != null ? "\"" + viewName + "\"" : this.view);
 		}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/ConsumesRequestCondition.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/ConsumesRequestCondition.java
@@ -220,7 +220,7 @@ public final class ConsumesRequestCondition extends AbstractRequestCondition<Con
 		}
 
 		List<ConsumeMediaTypeExpression> result = getMatchingExpressions(contentType);
-		return !CollectionUtils.isEmpty(result) ? new ConsumesRequestCondition(result) : null;
+		return CollectionUtils.isNotEmpty(result) ? new ConsumesRequestCondition(result) : null;
 	}
 
 	private boolean hasBody(HttpServletRequest request) {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/ProducesRequestCondition.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/ProducesRequestCondition.java
@@ -210,7 +210,7 @@ public final class ProducesRequestCondition extends AbstractRequestCondition<Pro
 			return null;
 		}
 		List<ProduceMediaTypeExpression> result = getMatchingExpressions(acceptedMediaTypes);
-		if (!CollectionUtils.isEmpty(result)) {
+		if (CollectionUtils.isNotEmpty(result)) {
 			return new ProducesRequestCondition(result, this);
 		}
 		else if (MediaType.ALL.isPresentIn(acceptedMediaTypes)) {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/RequestMappingInfoHandlerMapping.java
@@ -409,7 +409,7 @@ public abstract class RequestMappingInfoHandlerMapping extends AbstractHandlerMe
 			for (PartialMatch match : this.partialMatches) {
 				if (match.hasProducesMatch()) {
 					Set<NameValueExpression<String>> set = match.getInfo().getParamsCondition().getExpressions();
-					if (!CollectionUtils.isEmpty(set)) {
+					if (CollectionUtils.isNotEmpty(set)) {
 						int i = 0;
 						String[] array = new String[set.size()];
 						for (NameValueExpression<String> expression : set) {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodProcessor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodProcessor.java
@@ -360,7 +360,7 @@ public abstract class AbstractMessageConverterMethodProcessor extends AbstractMe
 					(Set<MediaType>) inputMessage.getServletRequest()
 							.getAttribute(HandlerMapping.PRODUCIBLE_MEDIA_TYPES_ATTRIBUTE);
 
-			if (isContentTypePreset || !CollectionUtils.isEmpty(producibleMediaTypes)) {
+			if (isContentTypePreset || CollectionUtils.isNotEmpty(producibleMediaTypes)) {
 				throw new HttpMessageNotWritableException(
 						"No converter for [" + valueType + "] with preset Content-Type '" + contentType + "'");
 			}
@@ -423,7 +423,7 @@ public abstract class AbstractMessageConverterMethodProcessor extends AbstractMe
 
 		Set<MediaType> mediaTypes =
 				(Set<MediaType>) request.getAttribute(HandlerMapping.PRODUCIBLE_MEDIA_TYPES_ATTRIBUTE);
-		if (!CollectionUtils.isEmpty(mediaTypes)) {
+		if (CollectionUtils.isNotEmpty(mediaTypes)) {
 			return new ArrayList<>(mediaTypes);
 		}
 		Set<MediaType> result = new LinkedHashSet<>();
@@ -542,7 +542,7 @@ public abstract class AbstractMessageConverterMethodProcessor extends AbstractMe
 		if (extension.equals("html")) {
 			String name = HandlerMapping.PRODUCIBLE_MEDIA_TYPES_ATTRIBUTE;
 			Set<MediaType> mediaTypes = (Set<MediaType>) request.getAttribute(name);
-			if (!CollectionUtils.isEmpty(mediaTypes) && mediaTypes.contains(MediaType.TEXT_HTML)) {
+			if (CollectionUtils.isNotEmpty(mediaTypes) && mediaTypes.contains(MediaType.TEXT_HTML)) {
 				return true;
 			}
 		}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessor.java
@@ -305,7 +305,7 @@ public class HttpEntityMethodProcessor extends AbstractMessageConverterMethodPro
 		ModelMap model = mav.getModel();
 		if (model instanceof RedirectAttributes redirectAttributes) {
 			Map<String, ?> flashAttributes = redirectAttributes.getFlashAttributes();
-			if (!CollectionUtils.isEmpty(flashAttributes)) {
+			if (CollectionUtils.isNotEmpty(flashAttributes)) {
 				HttpServletRequest req = request.getNativeRequest(HttpServletRequest.class);
 				HttpServletResponse res = request.getNativeResponse(HttpServletResponse.class);
 				if (req != null) {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMapMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/PathVariableMapMethodArgumentResolver.java
@@ -63,7 +63,7 @@ public class PathVariableMapMethodArgumentResolver implements HandlerMethodArgum
 				(Map<String, String>) webRequest.getAttribute(
 						HandlerMapping.URI_TEMPLATE_VARIABLES_ATTRIBUTE, RequestAttributes.SCOPE_REQUEST);
 
-		if (!CollectionUtils.isEmpty(uriTemplateVars)) {
+		if (CollectionUtils.isNotEmpty(uriTemplateVars)) {
 			return Collections.unmodifiableMap(uriTemplateVars);
 		}
 		else {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerAdapter.java
@@ -764,7 +764,7 @@ public class RequestMappingHandlerAdapter extends AbstractHandlerMethodAdapter
 		}
 
 		// Catch-all
-		if (!CollectionUtils.isEmpty(getModelAndViewResolvers())) {
+		if (CollectionUtils.isNotEmpty(getModelAndViewResolvers())) {
 			handlers.add(new ModelAndViewResolverMethodReturnValueHandler(getModelAndViewResolvers()));
 		}
 		else {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
@@ -653,7 +653,7 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 			}
 			if (mediaType == null) {
 				List<MediaType> mediaTypes = MediaTypeFactory.getMediaTypes(filename);
-				if (!CollectionUtils.isEmpty(mediaTypes)) {
+				if (CollectionUtils.isNotEmpty(mediaTypes)) {
 					mediaType = mediaTypes.get(0);
 				}
 			}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/NestedPathTag.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/NestedPathTag.java
@@ -23,6 +23,7 @@ import jakarta.servlet.jsp.tagext.TryCatchFinally;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.beans.PropertyAccessor;
+import org.springframework.util.StringUtils;
 
 /**
  * <p>The {@code <nestedPath>} tag supports and assists with nested beans or
@@ -84,7 +85,7 @@ public class NestedPathTag extends TagSupport implements TryCatchFinally {
 		if (path == null) {
 			path = "";
 		}
-		if (path.length() > 0 && !path.endsWith(PropertyAccessor.NESTED_PROPERTY_SEPARATOR)) {
+		if (StringUtils.hasLength(path) && !path.endsWith(PropertyAccessor.NESTED_PROPERTY_SEPARATOR)) {
 			path += PropertyAccessor.NESTED_PROPERTY_SEPARATOR;
 		}
 		this.path = path;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/AbstractHtmlElementTag.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/AbstractHtmlElementTag.java
@@ -446,7 +446,7 @@ public abstract class AbstractHtmlElementTag extends AbstractDataBoundFormElemen
 		writeOptionalAttribute(tagWriter, ONKEYUP_ATTRIBUTE, getOnkeyup());
 		writeOptionalAttribute(tagWriter, ONKEYDOWN_ATTRIBUTE, getOnkeydown());
 
-		if (!CollectionUtils.isEmpty(this.dynamicAttributes)) {
+		if (CollectionUtils.isNotEmpty(this.dynamicAttributes)) {
 			for (Map.Entry<String, Object> entry : this.dynamicAttributes.entrySet()) {
 				tagWriter.writeOptionalAttributeValue(entry.getKey(), getDisplayString(entry.getValue()));
 			}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/FormTag.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/FormTag.java
@@ -681,7 +681,7 @@ public class FormTag extends AbstractHtmlElementTag {
 	 * Writes the given values as hidden fields.
 	 */
 	private void writeHiddenFields(@Nullable Map<String, String> hiddenFields) throws JspException {
-		if (!CollectionUtils.isEmpty(hiddenFields)) {
+		if (CollectionUtils.isNotEmpty(hiddenFields)) {
 			Assert.state(this.tagWriter != null, "No TagWriter set");
 			this.tagWriter.appendValue("<div>\n");
 			for (Map.Entry<String, String> entry : hiddenFields.entrySet()) {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/ContentNegotiatingViewResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/ContentNegotiatingViewResolver.java
@@ -277,7 +277,7 @@ public class ContentNegotiatingViewResolver extends WebApplicationObjectSupport
 	private List<MediaType> getProducibleMediaTypes(HttpServletRequest request) {
 		Set<MediaType> mediaTypes = (Set<MediaType>)
 				request.getAttribute(HandlerMapping.PRODUCIBLE_MEDIA_TYPES_ATTRIBUTE);
-		if (!CollectionUtils.isEmpty(mediaTypes)) {
+		if (CollectionUtils.isNotEmpty(mediaTypes)) {
 			return new ArrayList<>(mediaTypes);
 		}
 		else {
@@ -322,7 +322,7 @@ public class ContentNegotiatingViewResolver extends WebApplicationObjectSupport
 				}
 			}
 		}
-		if (!CollectionUtils.isEmpty(this.defaultViews)) {
+		if (CollectionUtils.isNotEmpty(this.defaultViews)) {
 			candidateViews.addAll(this.defaultViews);
 		}
 		return candidateViews;

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/ViewResolverComposite.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/ViewResolverComposite.java
@@ -54,7 +54,7 @@ public class ViewResolverComposite implements ViewResolver, Ordered, Initializin
 	 */
 	public void setViewResolvers(List<ViewResolver> viewResolvers) {
 		this.viewResolvers.clear();
-		if (!CollectionUtils.isEmpty(viewResolvers)) {
+		if (CollectionUtils.isNotEmpty(viewResolvers)) {
 			this.viewResolvers.addAll(viewResolvers);
 		}
 	}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/json/JacksonJsonView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/json/JacksonJsonView.java
@@ -151,7 +151,7 @@ public class JacksonJsonView extends AbstractJacksonView {
 	@Override
 	protected Object filterModel(Map<String, Object> model, HttpServletRequest request) {
 		Map<String, Object> result = CollectionUtils.newHashMap(model.size());
-		Set<String> modelKeys = (!CollectionUtils.isEmpty(this.modelKeys) ? this.modelKeys : model.keySet());
+		Set<String> modelKeys = (CollectionUtils.isNotEmpty(this.modelKeys) ? this.modelKeys : model.keySet());
 		model.forEach((clazz, value) -> {
 			if (!(value instanceof BindingResult) && modelKeys.contains(clazz) &&
 					!clazz.equals(JSON_VIEW_HINT) &&

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/view/json/MappingJackson2JsonView.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/view/json/MappingJackson2JsonView.java
@@ -150,7 +150,7 @@ public class MappingJackson2JsonView extends AbstractJackson2View {
 	@Override
 	protected Object filterModel(Map<String, Object> model) {
 		Map<String, Object> result = CollectionUtils.newHashMap(model.size());
-		Set<String> modelKeys = (!CollectionUtils.isEmpty(this.modelKeys) ? this.modelKeys : model.keySet());
+		Set<String> modelKeys = (CollectionUtils.isNotEmpty(this.modelKeys) ? this.modelKeys : model.keySet());
 		model.forEach((clazz, value) -> {
 			if (!(value instanceof BindingResult) && modelKeys.contains(clazz) &&
 					!clazz.equals(JsonView.class.getName()) &&

--- a/spring-websocket/src/main/java/org/springframework/web/socket/WebSocketExtension.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/WebSocketExtension.java
@@ -72,7 +72,7 @@ public class WebSocketExtension {
 	public WebSocketExtension(String name, @Nullable Map<String, String> parameters) {
 		Assert.hasLength(name, "Extension name must not be empty");
 		this.name = name;
-		if (!CollectionUtils.isEmpty(parameters)) {
+		if (CollectionUtils.isNotEmpty(parameters)) {
 			Map<String, String> map = new LinkedCaseInsensitiveMap<>(parameters.size(), Locale.ROOT);
 			map.putAll(parameters);
 			this.parameters = Collections.unmodifiableMap(map);

--- a/spring-websocket/src/main/java/org/springframework/web/socket/adapter/jetty/JettyWebSocketSession.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/adapter/jetty/JettyWebSocketSession.java
@@ -174,7 +174,7 @@ public class JettyWebSocketSession extends AbstractWebSocketSession<Session> {
 
 		HttpHeaders headers = new HttpHeaders();
 		Map<String, List<String>> nativeHeaders = session.getUpgradeRequest().getHeaders();
-		if (!CollectionUtils.isEmpty(nativeHeaders)) {
+		if (CollectionUtils.isNotEmpty(nativeHeaders)) {
 			headers.putAll(nativeHeaders);
 		}
 		this.headers = HttpHeaders.readOnlyHttpHeaders(headers);
@@ -189,7 +189,7 @@ public class JettyWebSocketSession extends AbstractWebSocketSession<Session> {
 
 	private List<WebSocketExtension> getExtensions(Session session) {
 		List<ExtensionConfig> configs = session.getUpgradeResponse().getExtensions();
-		if (!CollectionUtils.isEmpty(configs)) {
+		if (CollectionUtils.isNotEmpty(configs)) {
 			List<WebSocketExtension> result = new ArrayList<>(configs.size());
 			for (ExtensionConfig config : configs) {
 				result.add(new WebSocketExtension(config.getName(), config.getParameters()));

--- a/spring-websocket/src/main/java/org/springframework/web/socket/adapter/standard/StandardWebSocketSession.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/adapter/standard/StandardWebSocketSession.java
@@ -185,7 +185,7 @@ public class StandardWebSocketSession extends AbstractWebSocketSession<Session> 
 		this.acceptedProtocol = session.getNegotiatedSubprotocol();
 
 		List<Extension> standardExtensions = getNativeSession().getNegotiatedExtensions();
-		if (!CollectionUtils.isEmpty(standardExtensions)) {
+		if (CollectionUtils.isNotEmpty(standardExtensions)) {
 			this.extensions = new ArrayList<>(standardExtensions.size());
 			for (Extension standardExtension : standardExtensions) {
 				this.extensions.add(new StandardToWebSocketExtensionAdapter(standardExtension));

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/DelegatingWebSocketConfiguration.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/DelegatingWebSocketConfiguration.java
@@ -40,7 +40,7 @@ public class DelegatingWebSocketConfiguration extends WebSocketConfigurationSupp
 
 	@Autowired(required = false)
 	public void setConfigurers(List<WebSocketConfigurer> configurers) {
-		if (!CollectionUtils.isEmpty(configurers)) {
+		if (CollectionUtils.isNotEmpty(configurers)) {
 			this.configurers.addAll(configurers);
 		}
 	}

--- a/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/DelegatingWebSocketMessageBrokerConfiguration.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/config/annotation/DelegatingWebSocketMessageBrokerConfiguration.java
@@ -48,7 +48,7 @@ public class DelegatingWebSocketMessageBrokerConfiguration extends WebSocketMess
 
 	@Autowired(required = false)
 	public void setConfigurers(List<WebSocketMessageBrokerConfigurer> configurers) {
-		if (!CollectionUtils.isEmpty(configurers)) {
+		if (CollectionUtils.isNotEmpty(configurers)) {
 			this.configurers.addAll(configurers);
 		}
 	}

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/support/AbstractSockJsService.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/support/AbstractSockJsService.java
@@ -416,8 +416,8 @@ public abstract class AbstractSockJsService implements SockJsService, CorsConfig
 			}
 
 			else if (sockJsPath.matches("/iframe[0-9-.a-z_]*.html")) {
-				if (!CollectionUtils.isEmpty(getAllowedOrigins()) && !getAllowedOrigins().contains("*") ||
-						!CollectionUtils.isEmpty(getAllowedOriginPatterns())) {
+				if (CollectionUtils.isNotEmpty(getAllowedOrigins()) && !getAllowedOrigins().contains("*") ||
+						CollectionUtils.isNotEmpty(getAllowedOriginPatterns())) {
 					if (requestInfo != null) {
 						logger.debug("Iframe support is disabled when an origin check is required. " +
 								"Ignoring transport request: " + requestInfo);
@@ -648,7 +648,7 @@ public abstract class AbstractSockJsService implements SockJsService, CorsConfig
 			String etagValue = builder.toString();
 
 			List<String> ifNoneMatch = request.getHeaders().getIfNoneMatch();
-			if (!CollectionUtils.isEmpty(ifNoneMatch) && ifNoneMatch.get(0).equals(etagValue)) {
+			if (CollectionUtils.isNotEmpty(ifNoneMatch) && ifNoneMatch.get(0).equals(etagValue)) {
 				response.setStatusCode(HttpStatus.NOT_MODIFIED);
 				return;
 			}

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/support/SockJsHttpRequestHandler.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/support/SockJsHttpRequestHandler.java
@@ -30,6 +30,8 @@ import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpRequest;
 import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 import org.springframework.web.HttpRequestHandler;
 import org.springframework.web.context.ServletContextAware;
 import org.springframework.web.cors.CorsConfiguration;
@@ -141,7 +143,7 @@ public class SockJsHttpRequestHandler
 	private String getSockJsPath(HttpServletRequest servletRequest) {
 		String attribute = HandlerMapping.PATH_WITHIN_HANDLER_MAPPING_ATTRIBUTE;
 		String path = (String) servletRequest.getAttribute(attribute);
-		return (path.length() > 0 && path.charAt(0) != '/' ? "/" + path : path);
+		return (StringUtils.hasLength(path) && path.charAt(0) != '/' ? "/" + path : path);
 	}
 
 	@Override

--- a/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/TransportHandlingSockJsService.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/sockjs/transport/TransportHandlingSockJsService.java
@@ -353,8 +353,8 @@ public class TransportHandlingSockJsService extends AbstractSockJsService implem
 			return false;
 		}
 
-		if (!CollectionUtils.isEmpty(getAllowedOrigins()) && !getAllowedOrigins().contains("*") ||
-				!CollectionUtils.isEmpty(getAllowedOriginPatterns())) {
+		if (CollectionUtils.isNotEmpty(getAllowedOrigins()) && !getAllowedOrigins().contains("*") ||
+				CollectionUtils.isNotEmpty(getAllowedOriginPatterns())) {
 			TransportType transportType = TransportType.fromValue(transport);
 			if (transportType == null || !transportType.supportsOrigin()) {
 				if (logger.isWarnEnabled()) {


### PR DESCRIPTION
Summary
This PR introduces new utility methods to improve readability and reduce the risk of subtle bugs related to negated emptiness checks:

Adds CollectionUtils.isNotEmpty(Collection<?>)
Adds CollectionUtils.isNotEmpty(Map<?, ?>)

Motivation
As noted by @mdeinum in #35243 , negated expressions like !collection.isEmpty() can be error-prone: