### PR TITLE
Fix sybase script execution handling

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/init/ScriptUtils.java
@@ -258,8 +258,12 @@ public abstract class ScriptUtils {
 				for (String statement : statements) {
 					stmtNumber++;
 					try {
-						stmt.execute(statement);
+						boolean results = stmt.execute(statement);
 						int rowsAffected = stmt.getUpdateCount();
+						while(results || rowsAffected != -1) {
+							rowsAffected = stmt.getUpdateCount();
+							results = stmt.getMoreResults(Statement.CLOSE_CURRENT_RESULT);
+						}
 						if (logger.isDebugEnabled()) {
 							logger.debug(rowsAffected + " returned as update count for SQL: " + statement);
 							SQLWarning warningToLog = stmt.getWarnings();


### PR DESCRIPTION
Addresses issue https://github.com/spring-projects/spring-framework/issues/35248
Updates executeSqlScript() to handle multiple result set returned by the statement execution. It uses a loop to process all the result and updates the count.

Reopened PR with sign off - had some issues with git bash so just made a new branch