### PR TITLE
Add exception for required versioning without resolvers

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/config/ApiVersionConfigurer.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/config/ApiVersionConfigurer.java
@@ -133,6 +133,11 @@ public class ApiVersionConfigurer {
 	 */
 	public ApiVersionConfigurer setVersionRequired(boolean required) {
 		this.versionRequired = required;
+
+		if(required && this.versionResolvers.isEmpty()) {
+			throw new IllegalStateException("API Versioning is required but no version resolvers are configured");
+		}
+		
 		return this;
 	}
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/config/ApiVersionConfigurer.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/config/ApiVersionConfigurer.java
@@ -137,7 +137,6 @@ public class ApiVersionConfigurer {
 		if(required && this.versionResolvers.isEmpty()) {
 			throw new IllegalStateException("API Versioning is required but no version resolvers are configured");
 		}
-		
 		return this;
 	}
 


### PR DESCRIPTION
Addresses Issue #35256
- Throws an exception if API versioning is required but no resolvers are configured
- Alternative approach would be to log a warning and add a default resolver `.useRequestHeader("X-API-Version");`