### PR TITLE
HTTP method support in MappedInterceptor

### DIFF
--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/handler/MappedInterceptorTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/handler/MappedInterceptorTests.java
@@ -26,10 +26,12 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.http.HttpMethod;
 import org.springframework.util.PathMatcher;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
 import org.springframework.web.testfixture.servlet.MockHttpServletRequest;
+import org.springframework.web.util.ServletRequestPathUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -50,16 +52,23 @@ class MappedInterceptorTests {
 		return PathPatternsTestUtils.requestArguments();
 	}
 
+	private MockHttpServletRequest requestWithMethod(String method) {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setRequestURI("/some/path");
+		request.setMethod(method);
+		ServletRequestPathUtils.parseAndCache(request);
+		return request;
+	}
 
 	@PathPatternsParameterizedTest
 	void noPatterns(Function<String, MockHttpServletRequest> requestFactory) {
-		MappedInterceptor interceptor = new MappedInterceptor(null, null, delegate);
+		MappedInterceptor interceptor = new MappedInterceptor(null, null,null,null, delegate);
 		assertThat(interceptor.matches(requestFactory.apply("/foo"))).isTrue();
 	}
 
 	@PathPatternsParameterizedTest
 	void includePattern(Function<String, MockHttpServletRequest> requestFactory) {
-		MappedInterceptor interceptor = new MappedInterceptor(new String[] { "/foo/*" }, null, delegate);
+		MappedInterceptor interceptor = new MappedInterceptor(new String[] { "/foo/*" }, null,null,null, delegate);
 
 		assertThat(interceptor.matches(requestFactory.apply("/foo/bar"))).isTrue();
 		assertThat(interceptor.matches(requestFactory.apply("/bar/foo"))).isFalse();
@@ -67,13 +76,13 @@ class MappedInterceptorTests {
 
 	@PathPatternsParameterizedTest
 	void includePatternWithMatrixVariables(Function<String, MockHttpServletRequest> requestFactory) {
-		MappedInterceptor interceptor = new MappedInterceptor(new String[] { "/foo*/*" }, null, delegate);
+		MappedInterceptor interceptor = new MappedInterceptor(new String[] { "/foo*/*" },null,null, null, delegate);
 		assertThat(interceptor.matches(requestFactory.apply("/foo;q=1/bar;s=2"))).isTrue();
 	}
 
 	@PathPatternsParameterizedTest
 	void excludePattern(Function<String, MockHttpServletRequest> requestFactory) {
-		MappedInterceptor interceptor = new MappedInterceptor(null, new String[] { "/admin/**" }, delegate);
+		MappedInterceptor interceptor = new MappedInterceptor(null, new String[] { "/admin/**" },null,null, delegate);
 
 		assertThat(interceptor.matches(requestFactory.apply("/foo"))).isTrue();
 		assertThat(interceptor.matches(requestFactory.apply("/admin/foo"))).isFalse();
@@ -82,7 +91,7 @@ class MappedInterceptorTests {
 	@PathPatternsParameterizedTest
 	void includeAndExcludePatterns(Function<String, MockHttpServletRequest> requestFactory) {
 		MappedInterceptor interceptor =
-				new MappedInterceptor(new String[] { "/**" }, new String[] { "/admin/**" }, delegate);
+				new MappedInterceptor(new String[] { "/**" }, new String[] { "/admin/**" },null,null, delegate);
 
 		assertThat(interceptor.matches(requestFactory.apply("/foo"))).isTrue();
 		assertThat(interceptor.matches(requestFactory.apply("/admin/foo"))).isFalse();
@@ -90,7 +99,7 @@ class MappedInterceptorTests {
 
 	@PathPatternsParameterizedTest // gh-26690
 	void includePatternWithFallbackOnPathMatcher(Function<String, MockHttpServletRequest> requestFactory) {
-		MappedInterceptor interceptor = new MappedInterceptor(new String[] { "/path1/**/path2" }, null, delegate);
+		MappedInterceptor interceptor = new MappedInterceptor(new String[] { "/path1/**/path2" },null,null, null, delegate);
 
 		assertThat(interceptor.matches(requestFactory.apply("/path1/foo/bar/path2"))).isTrue();
 		assertThat(interceptor.matches(requestFactory.apply("/path1/foo/bar/path3"))).isFalse();
@@ -100,7 +109,7 @@ class MappedInterceptorTests {
 	@SuppressWarnings("removal")
 	@PathPatternsParameterizedTest
 	void customPathMatcher(Function<String, MockHttpServletRequest> requestFactory) {
-		MappedInterceptor interceptor = new MappedInterceptor(new String[] { "/foo/[0-9]*" }, null, delegate);
+		MappedInterceptor interceptor = new MappedInterceptor(new String[] { "/foo/[0-9]*" },null,null, null, delegate);
 		interceptor.setPathMatcher(new TestPathMatcher());
 
 		assertThat(interceptor.matches(requestFactory.apply("/foo/123"))).isTrue();
@@ -108,10 +117,89 @@ class MappedInterceptorTests {
 	}
 
 	@Test
+	void includeMethods(){
+		MappedInterceptor interceptor = new MappedInterceptor(null, null,new HttpMethod[]{HttpMethod.GET},null, delegate);
+		assertThat(interceptor.matches(requestWithMethod("GET"))).isTrue();
+		assertThat(interceptor.matches(requestWithMethod("HEAD"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("POST"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("PUT"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("DELETE"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("CONNECT"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("OPTIONS"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("TRACE"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("PATCH"))).isFalse();
+	}
+
+	@Test
+	void includeMultipleMethods(){
+		MappedInterceptor interceptor = new MappedInterceptor(null, null,new HttpMethod[]{HttpMethod.GET,HttpMethod.POST},null, delegate);
+		assertThat(interceptor.matches(requestWithMethod("GET"))).isTrue();
+		assertThat(interceptor.matches(requestWithMethod("HEAD"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("POST"))).isTrue();
+		assertThat(interceptor.matches(requestWithMethod("PUT"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("DELETE"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("CONNECT"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("OPTIONS"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("TRACE"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("PATCH"))).isFalse();
+	}
+
+	@Test
+	void excludeMethods(){
+		MappedInterceptor interceptor = new MappedInterceptor(null, null,null,new HttpMethod[]{HttpMethod.GET}, delegate);
+		assertThat(interceptor.matches(requestWithMethod("GET"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("HEAD"))).isTrue();
+		assertThat(interceptor.matches(requestWithMethod("POST"))).isTrue();
+		assertThat(interceptor.matches(requestWithMethod("PUT"))).isTrue();
+		assertThat(interceptor.matches(requestWithMethod("DELETE"))).isTrue();
+		assertThat(interceptor.matches(requestWithMethod("CONNECT"))).isTrue();
+		assertThat(interceptor.matches(requestWithMethod("OPTIONS"))).isTrue();
+		assertThat(interceptor.matches(requestWithMethod("TRACE"))).isTrue();
+		assertThat(interceptor.matches(requestWithMethod("PATCH"))).isTrue();
+	}
+
+	@Test
+	void excludeMultipleMethods(){
+		MappedInterceptor interceptor = new MappedInterceptor(null, null,null,new HttpMethod[]{HttpMethod.GET,HttpMethod.POST,HttpMethod.OPTIONS}, delegate);
+		assertThat(interceptor.matches(requestWithMethod("GET"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("HEAD"))).isTrue();
+		assertThat(interceptor.matches(requestWithMethod("POST"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("PUT"))).isTrue();
+		assertThat(interceptor.matches(requestWithMethod("DELETE"))).isTrue();
+		assertThat(interceptor.matches(requestWithMethod("CONNECT"))).isTrue();
+		assertThat(interceptor.matches(requestWithMethod("OPTIONS"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("TRACE"))).isTrue();
+		assertThat(interceptor.matches(requestWithMethod("PATCH"))).isTrue();
+	}
+
+	@Test
+	void includeMethodsAndExcludeMethods(){
+		MappedInterceptor interceptor = new MappedInterceptor(null, null,new HttpMethod[]{HttpMethod.GET,HttpMethod.POST},new HttpMethod[]{HttpMethod.OPTIONS}, delegate);
+		assertThat(interceptor.matches(requestWithMethod("GET"))).isTrue();
+		assertThat(interceptor.matches(requestWithMethod("HEAD"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("POST"))).isTrue();
+		assertThat(interceptor.matches(requestWithMethod("PUT"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("DELETE"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("CONNECT"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("OPTIONS"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("TRACE"))).isFalse();
+		assertThat(interceptor.matches(requestWithMethod("PATCH"))).isFalse();
+	}
+
+	@PathPatternsParameterizedTest
+	void includePatternAndIncludeMethods(Function<String, MockHttpServletRequest> requestFactory) {
+		MappedInterceptor interceptor = new MappedInterceptor(new String[] { "/foo/*" }, null,new HttpMethod[]{HttpMethod.GET},null, delegate);
+
+		assertThat(interceptor.matches(requestFactory.apply("/foo/bar"))).isTrue();
+		assertThat(interceptor.matches(requestFactory.apply("/bar/foo"))).isFalse();
+	}
+
+
+	@Test
 	void preHandle() throws Exception {
 		HandlerInterceptor delegate = mock();
 
-		new MappedInterceptor(null, delegate).preHandle(mock(), mock(), null);
+		new MappedInterceptor(null,null,null,null, delegate).preHandle(mock(), mock(), null);
 
 		then(delegate).should().preHandle(any(HttpServletRequest.class), any(HttpServletResponse.class), any());
 	}
@@ -120,7 +208,7 @@ class MappedInterceptorTests {
 	void postHandle() throws Exception {
 		HandlerInterceptor delegate = mock();
 
-		new MappedInterceptor(null, delegate).postHandle(mock(), mock(), null, mock());
+		new MappedInterceptor(null,null,null,null, delegate).postHandle(mock(), mock(), null, mock());
 
 		then(delegate).should().postHandle(any(), any(), any(), any());
 	}
@@ -129,7 +217,7 @@ class MappedInterceptorTests {
 	void afterCompletion() throws Exception {
 		HandlerInterceptor delegate = mock();
 
-		new MappedInterceptor(null, delegate).afterCompletion(mock(), mock(), null, mock());
+		new MappedInterceptor(null,null,null,null, delegate).afterCompletion(mock(), mock(), null, mock());
 
 		then(delegate).should().afterCompletion(any(), any(), any(), any());
 	}


### PR DESCRIPTION
# Support HTTP method-restricted interceptors in `InterceptorRegistration`

This PR implements [#35272](https://github.com/spring-projects/spring-framework/issues/35272), adding support for restricting `HandlerInterceptor` registration to specific HTTP methods.

## Motivation

Spring MVC currently allows interceptors to be applied based on path patterns, but not HTTP methods. When method-based filtering is needed, it must be manually implemented within the interceptor itself:

```java
@Override
public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
    if (!"POST".equals(request.getMethod())) {
        return true;
    }
    // Logic here
    return true;
}
```

This approach clutters interceptor logic with method checks and duplicates similar logic across interceptors when needed. Centralizing HTTP method filtering in the registration API provides a cleaner and more declarative configuration style.

## Solution

This PR introduces a new method to `InterceptorRegistration`:

```java
public InterceptorRegistration allowedMethods(HttpMethod... methods)
```

This allows restricting the interceptor to specific HTTP methods like `GET`, `POST`, etc. Under the hood, the framework wraps the given `HandlerInterceptor` in a new `MethodInterceptor` that delegates calls only when the request's HTTP method matches one of the allowed methods.

```java
registry.addInterceptor(new MyInterceptor())
        .addPathPatterns("/api/**")
        .allowedMethods(HttpMethod.POST, HttpMethod.PUT);
```

The interceptor will now be invoked **only** for POST and PUT requests matching `/api/**`.

## Implementation Details

- `InterceptorRegistration` stores allowed HTTP methods as a `Set<String>`.
- If any methods are configured, it wraps the given interceptor using the new `MethodInterceptor`.
- `MethodInterceptor` checks the request's method before delegating to the original interceptor.
- The implementation is fully backward compatible; if no methods are provided, all HTTP methods are allowed (default behavior).

## Tests

A dedicated test class `MethodInterceptorTests` is included to validate:

- Delegation occurs only for allowed HTTP methods.
- Interceptor is skipped for disallowed methods.
- All interceptor lifecycle methods (`preHandle`, `postHandle`, `afterCompletion`) are covered.

## Example

```java
@Configuration
public class WebConfig implements WebMvcConfigurer {

    @Override
    public void addInterceptors(InterceptorRegistry registry) {
        registry.addInterceptor(new AuditInterceptor())
                .addPathPatterns("/admin/**")
                .allowedMethods(HttpMethod.GET);
    }
}
```

In this example, `AuditInterceptor` will apply only for `GET` requests under `/admin/**`.

## Compatibility

- No breaking changes introduced.
- The feature is opt-in.
- Reuses existing Spring MVC components (`MappedInterceptor`, `HandlerInterceptor`) without exposing new public types.
