### PR TITLE
Refine `@Contract` Javadoc

### DIFF
--- a/spring-core/src/main/java/org/springframework/lang/Contract.java
+++ b/spring-core/src/main/java/org/springframework/lang/Contract.java
@@ -51,7 +51,8 @@ import java.lang.annotation.Target;
  * <p>The additional return values denote the following:
  * <ul>
  * <li>{@code fail} - the method throws an exception, if the arguments satisfy argument constraints
- * <li>{@code new} - the method returns a non-null new object which is distinct from any other object existing in the heap prior to method execution. If method is also pure, then we can be sure that the new object is not stored to any field/array and will be lost if method return value is not used.
+ * <li>{@code new} - the method returns a non-null new object which is distinct from any other object existing in the heap prior to method execution.
+ * If the method has no visible side effects, then we can be sure that the new object is not stored to any field/array and will be lost if the method's return value is not used.
  * <li>{@code this} - the method returns its qualifier value (not applicable for static methods)
  * <li>{@code param1, param2, ...} - the method returns its first (second, ...) parameter value
  * </ul>


### PR DESCRIPTION
This commit removes references to the `pure` attribute.

Relates to gh-33820.