### PR TITLE
Add TYPE_USE to @NonNull for type-use annotation support

### DIFF
--- a/spring-core/src/main/java/org/springframework/lang/NonNull.java
+++ b/spring-core/src/main/java/org/springframework/lang/NonNull.java
@@ -31,9 +31,9 @@ import javax.annotation.meta.TypeQualifierNickname;
  * <p>Leverages JSR-305 meta-annotations to indicate nullability in Java to common
  * tools with JSR-305 support and used by Kotlin to infer nullability of Spring API.
  *
- * <p>Should be used at the parameter, return value, and field level. Method
- * overrides should repeat parent {@code @NonNull} annotations unless they behave
- * differently.
+ * <p>Should be used at the parameter, return value, field, and type-use level, including
+ * generics and other type usages. Method overrides should repeat parent {@code @NonNull}
+ * annotations unless they behave differently.
  *
  * <p>Use {@code @NonNullApi} (scope = parameters + return values) and/or {@code @NonNullFields}
  * (scope = fields) to set the default behavior to non-nullable in order to avoid annotating
@@ -47,7 +47,7 @@ import javax.annotation.meta.TypeQualifierNickname;
  * @see NonNullFields
  * @see Nullable
  */
-@Target({ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD})
+@Target({ElementType.TYPE_USE, ElementType.METHOD, ElementType.PARAMETER, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Nonnull


### PR DESCRIPTION
### Motivation

This PR adds `ElementType.TYPE_USE` to the `@Target` annotation for `@NonNull`, enabling it to be used in type-use positions (such as generic type parameters and return types) in addition to methods, parameters, and fields. This supports modern null-safety tooling and aligns with best practices in the Java ecosystem.

Javadoc has been updated to reflect this expanded usage.

### Checklist

- [x] Signed-off-by trailer is present in the commit
- [x] PR targets the `main` branch
- [x] Follows the [Spring Framework contribution guidelines](https://github.com/spring-projects/spring-framework/blob/main/CONTRIBUTING.md)