### PR TITLE
Only add `httpServiceProxyRegistry` bean when necessary

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/service/registry/AbstractHttpServiceRegistrar.java
+++ b/spring-web/src/main/java/org/springframework/web/service/registry/AbstractHttpServiceRegistrar.java
@@ -147,20 +147,22 @@ public abstract class AbstractHttpServiceRegistrar implements
 
 		registerHttpServices(new DefaultGroupRegistry(), metadata);
 
-		RootBeanDefinition proxyRegistryBeanDef = createOrGetRegistry(beanRegistry);
+		if (this.groupsMetadata.hasRegistrations()) {
+			RootBeanDefinition proxyRegistryBeanDef = createOrGetRegistry(beanRegistry);
 
-		mergeGroups(proxyRegistryBeanDef);
+			mergeGroups(proxyRegistryBeanDef);
 
-		this.groupsMetadata.forEachRegistration((groupName, types) -> types.forEach(type -> {
-			RootBeanDefinition proxyBeanDef = new RootBeanDefinition();
-			proxyBeanDef.setBeanClassName(type);
-			proxyBeanDef.setAttribute(HTTP_SERVICE_GROUP_NAME_ATTRIBUTE, groupName);
-			proxyBeanDef.setInstanceSupplier(() -> getProxyInstance(groupName, type));
-			String beanName = (groupName + "#" + type);
-			if (!beanRegistry.containsBeanDefinition(beanName)) {
-				beanRegistry.registerBeanDefinition(beanName, proxyBeanDef);
-			}
-		}));
+			this.groupsMetadata.forEachRegistration((groupName, types) -> types.forEach(type -> {
+				RootBeanDefinition proxyBeanDef = new RootBeanDefinition();
+				proxyBeanDef.setBeanClassName(type);
+				proxyBeanDef.setAttribute(HTTP_SERVICE_GROUP_NAME_ATTRIBUTE, groupName);
+				proxyBeanDef.setInstanceSupplier(() -> getProxyInstance(groupName, type));
+				String beanName = (groupName + "#" + type);
+				if (!beanRegistry.containsBeanDefinition(beanName)) {
+					beanRegistry.registerBeanDefinition(beanName, proxyBeanDef);
+				}
+			}));
+		}
 	}
 
 	/**

--- a/spring-web/src/main/java/org/springframework/web/service/registry/GroupsMetadata.java
+++ b/spring-web/src/main/java/org/springframework/web/service/registry/GroupsMetadata.java
@@ -97,6 +97,13 @@ final class GroupsMetadata {
 		return this.groupMap.values().stream();
 	}
 
+	/**
+	 * Return if there are any {@link Registration registrations}.
+	 */
+	boolean hasRegistrations() {
+		return !this.groupMap.isEmpty();
+	}
+
 
 	/**
 	 * Registration metadata for an {@link HttpServiceGroup}.

--- a/spring-web/src/test/java/org/springframework/web/service/registry/HttpServiceRegistrarTests.java
+++ b/spring-web/src/test/java/org/springframework/web/service/registry/HttpServiceRegistrarTests.java
@@ -120,8 +120,7 @@ public class HttpServiceRegistrarTests {
 	@Test
 	void noRegistrations() {
 		doRegister(registry -> {});
-		assertRegistryBeanDef();
-		assertBeanDefinitionCount(1);
+		assertBeanDefinitionCount(0);
 	}
 
 


### PR DESCRIPTION
Update `AbstractHttpServiceRegistrar` so that the
`httpServiceProxyRegistry` bean  is only added when registrations are found.