### PR TITLE
Restore mixed usage support with uri() and queryParam() for query parameters in AbstractMockHttpServletRequestBuilder.buildRequest()

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/request/AbstractMockHttpServletRequestBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/request/AbstractMockHttpServletRequestBuilder.java
@@ -826,7 +826,7 @@ public abstract class AbstractMockHttpServletRequestBuilder<B extends AbstractMo
 		addRequestParams(request, UriComponentsBuilder.fromUri(uri).build().getQueryParams());
 
 		this.parameters.forEach((name, values) ->
-				request.setParameter(name, values.toArray(new String[0])));
+				request.addParameter(name, values.toArray(new String[0])));
 
 		if (!this.formFields.isEmpty()) {
 			if (this.content != null && this.content.length > 0) {

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilderTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilderTests.java
@@ -274,6 +274,15 @@ class MockHttpServletRequestBuilderTests {
 	}
 
 	@Test
+	void queryParametersWithUriAndQueryParam() {
+		this.builder = new MockHttpServletRequestBuilder(GET).uri("/path?param1=value1");
+		this.builder.queryParam("param1", "value2");
+		MockHttpServletRequest request = this.builder.buildRequest(this.servletContext);
+
+		assertThat(request.getParameterMap().get("param1")).containsExactly("value1", "value2");
+	}
+
+	@Test
 	void queryParameterMap() {
 		this.builder = new MockHttpServletRequestBuilder(GET).uri("/");
 		MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();


### PR DESCRIPTION
I'm not sure if it was intentional, but 8ec0c21b0a0ef6c725c27d787c4e27ae5fe328f4 has changed the behavior when both `uri()` and `queryParam()` are used for the same query parameters by overwriting the former with the latter rather than merging both.

See gh-35210