### PR TITLE
Improve documentation for `ApplicationEvents` to clarify recommended usage

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/event/ApplicationEvents.java
+++ b/spring-test/src/main/java/org/springframework/test/context/event/ApplicationEvents.java
@@ -33,12 +33,14 @@ import org.springframework.context.ApplicationEvent;
  * to be manually registered if you have custom configuration via
  * {@link org.springframework.test.context.TestExecutionListeners @TestExecutionListeners}
  * that does not include the default listeners.</li>
- * <li>Annotate a field of type {@code ApplicationEvents} with
+ * <li>With JUnit Jupiter, declare a parameter of type {@code ApplicationEvents}
+ * in a test or lifecycle method. Since {@code ApplicationEvents} is scoped to the
+ * lifecycle of the current test method, this is the recommended approach.</li>
+ * <li>Alternatively, you can annotate a field of type {@code ApplicationEvents} with
  * {@link org.springframework.beans.factory.annotation.Autowired @Autowired} and
- * use that instance of {@code ApplicationEvents} in your test and lifecycle methods.</li>
- * <li>With JUnit Jupiter, you may optionally declare a parameter of type
- * {@code ApplicationEvents} in a test or lifecycle method as an alternative to
- * an {@code @Autowired} field in the test class.</li>
+ * use that instance of {@code ApplicationEvents} in your test and lifecycle methods.
+ * Note that {@code ApplicationEvents} is not a general Spring bean and is specifically
+ * designed for use within test methods.</li>
  * </ul>
  *
  * @author Sam Brannen


### PR DESCRIPTION
## Description
This PR improves the Javadoc of `ApplicationEvents` to better guide developers on its proper usage.

## Problem
The current Javadoc mentions field injection with `@Autowired` before method parameter injection, which creates the impression that `ApplicationEvents` is a regular Spring bean eligible for dependency injection. This confuses developers who then attempt to use constructor injection and find it doesn't work.

## Solution
Reordered and clarified the usage instructions to:
1. **Recommend method parameter injection as the primary approach** - since `ApplicationEvents` has a per-method lifecycle, this is the most appropriate usage pattern
2. **Clarify that `ApplicationEvents` is not a general Spring bean** - explicitly state that it's specifically designed for use within test methods
3. **Position field injection as an alternative** - rather than the primary approach

## Changes
- Reordered the bullet points to show method parameter injection first
- Added clarification about the per-method lifecycle
- Added a note that `ApplicationEvents` is not a general Spring bean

This helps prevent the confusion described in the linked German documentation where developers were puzzled by the inability to use constructor injection.

Closes gh-35297