### PR TITLE
Fall back to JDK proxy if CGLIB proxy creation fails

### DIFF
--- a/spring-context/src/test/java/org/springframework/aop/framework/CglibProxyTests.java
+++ b/spring-context/src/test/java/org/springframework/aop/framework/CglibProxyTests.java
@@ -50,6 +50,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  * @author Rob Harrop
  * @author Ramnivas Laddad
  * @author Chris Beams
+ * @author Yongjun Hong
  */
 class CglibProxyTests extends AbstractAopProxyTests {
 
@@ -429,6 +430,48 @@ class CglibProxyTests extends AbstractAopProxyTests {
 		assertThat(proxy.doWithVarargs(MyEnum.A, MyOtherEnum.C)).isTrue();
 	}
 
+	@Test
+	void testProxyCreationAndPrivateAccess() {
+		ProxyFactory proxyFactory = new ProxyFactory(new TestServiceImpl());
+		proxyFactory.setProxyTargetClass(true);
+
+		TestService proxy = (TestService) proxyFactory.getProxy();
+
+		String result = proxy.publicMethod();
+		assertThat(result).isEqualTo("Private Access Success");
+	}
+
+	@Test
+	void testProxyCreationWithoutInterfaceShouldThrowException() {
+		ProxyFactory proxyFactory = new ProxyFactory(new TestServiceImplWithOutInterface());
+		proxyFactory.setProxyTargetClass(true);
+
+		assertThatExceptionOfType(AopConfigException.class)
+				.isThrownBy(proxyFactory::getProxy)
+				.withMessageContaining("Could not generate CGLIB subclass of");
+	}
+
+	interface TestService {
+		String publicMethod();
+	}
+
+	static class TestServiceImpl implements TestService {
+		private TestServiceImpl() { }
+
+		@Override
+		public String publicMethod() {
+			return "Private Access Success";
+		}
+	}
+
+	static class TestServiceImplWithOutInterface {
+
+		private TestServiceImplWithOutInterface() { }
+
+		public String publicMethod() {
+			return "Private Access Success";
+		}
+	}
 
 	public static class MyBean {
 


### PR DESCRIPTION
Prior to this change, if the default CGLIB proxy creation failed for a non-subclassable target class (e.g., due to a private constructor), the ApplicationContext would fail to start.

fixes #31634 