### PR TITLE
Fix broken link in WebDriver docs

### DIFF
--- a/framework-docs/modules/ROOT/pages/testing/mockmvc/htmlunit/webdriver.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/mockmvc/htmlunit/webdriver.adoc
@@ -261,7 +261,7 @@ Kotlin::
 
 This improves on the design of our xref:testing/mockmvc/htmlunit/mah.adoc#spring-mvc-test-server-htmlunit-mah-usage[HtmlUnit test]
 by leveraging the Page Object Pattern. As we mentioned in
-xref:testing/mockmvc/htmlunit/webdriver.adoc#spring-mvc-test-server-htmlunit-webdriver-why[Why WebDriver and MockMvc?], we can use the Page Object Pattern
+xref:testing/mockmvc/htmlunit/webdriver.adoc#mockmvc-server-htmlunit-webdriver-why[Why WebDriver and MockMvc?], we can use the Page Object Pattern
 with HtmlUnit, but it is much easier with WebDriver. Consider the following
 `CreateMessagePage` implementation:
 


### PR DESCRIPTION
The anchor has been renamed to [mockmvc-server-htmlunit-webdriver-why](https://github.com/spring-projects/spring-framework/blob/d128dd26163cf6c0cf703d257a62a0fd84dd1a8e/framework-docs/modules/ROOT/pages/testing/mockmvc/htmlunit/webdriver.adoc?plain=1#L8) in d43dba6.