### PR TITLE
Detect Informix error codes as `DuplicateKeyException`

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/SQLStateSQLExceptionTranslator.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/SQLStateSQLExceptionTranslator.java
@@ -95,7 +95,8 @@ public class SQLStateSQLExceptionTranslator extends AbstractFallbackSQLException
 			301,   // SAP HANA
 			1062,  // MySQL/MariaDB
 			2601,  // MS SQL Server
-			2627   // MS SQL Server
+			2627,  // MS SQL Server
+			-268   // Informix
 		);
 
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/SQLStateSQLExceptionTranslator.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/SQLStateSQLExceptionTranslator.java
@@ -96,6 +96,7 @@ public class SQLStateSQLExceptionTranslator extends AbstractFallbackSQLException
 			1062,  // MySQL/MariaDB
 			2601,  // MS SQL Server
 			2627,  // MS SQL Server
+			-239,  // Informix
 			-268   // Informix
 		);
 

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/support/SQLStateSQLExceptionTranslatorTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/support/SQLStateSQLExceptionTranslatorTests.java
@@ -91,6 +91,16 @@ class SQLStateSQLExceptionTranslatorTests {
 	}
 
 	@Test
+	void translateDuplicateKeyInformix1() {
+		assertTranslation("23000", -239, DuplicateKeyException.class);
+	}
+
+	@Test
+	void translateDuplicateKeyInformix2() {
+		assertTranslation("23000", -268, DuplicateKeyException.class);
+	}
+
+	@Test
 	void translateDataAccessResourceFailure() {
 		assertTranslation("53", DataAccessResourceFailureException.class);
 	}

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/ConnectionFactoryUtils.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/ConnectionFactoryUtils.java
@@ -76,7 +76,9 @@ public abstract class ConnectionFactoryUtils {
 			301,   // SAP HANA
 			1062,  // MySQL/MariaDB
 			2601,  // MS SQL Server
-			2627   // MS SQL Server
+			2627,  // MS SQL Server
+			-239,  // Informix
+			-268   // Informix
 		);
 
 

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/ConnectionFactoryUtilsTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/ConnectionFactoryUtilsTests.java
@@ -16,21 +16,6 @@
 
 package org.springframework.r2dbc.connection;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.stream.Stream;
-
-import org.springframework.dao.CannotAcquireLockException;
-import org.springframework.dao.DataAccessResourceFailureException;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.dao.DuplicateKeyException;
-import org.springframework.dao.PermissionDeniedDataAccessException;
-import org.springframework.dao.PessimisticLockingFailureException;
-import org.springframework.dao.QueryTimeoutException;
-import org.springframework.dao.TransientDataAccessResourceException;
-import org.springframework.r2dbc.BadSqlGrammarException;
-import org.springframework.r2dbc.UncategorizedR2dbcException;
-
 import io.r2dbc.spi.R2dbcBadGrammarException;
 import io.r2dbc.spi.R2dbcDataIntegrityViolationException;
 import io.r2dbc.spi.R2dbcException;
@@ -43,6 +28,22 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.dao.CannotAcquireLockException;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.PermissionDeniedDataAccessException;
+import org.springframework.dao.PessimisticLockingFailureException;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.dao.TransientDataAccessResourceException;
+import org.springframework.r2dbc.BadSqlGrammarException;
+import org.springframework.r2dbc.UncategorizedR2dbcException;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
 
 /**
  * Tests for {@link ConnectionFactoryUtils}.

--- a/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/ConnectionFactoryUtilsTests.java
+++ b/spring-r2dbc/src/test/java/org/springframework/r2dbc/connection/ConnectionFactoryUtilsTests.java
@@ -16,15 +16,9 @@
 
 package org.springframework.r2dbc.connection;
 
-import io.r2dbc.spi.R2dbcBadGrammarException;
-import io.r2dbc.spi.R2dbcDataIntegrityViolationException;
-import io.r2dbc.spi.R2dbcException;
-import io.r2dbc.spi.R2dbcNonTransientResourceException;
-import io.r2dbc.spi.R2dbcPermissionDeniedException;
-import io.r2dbc.spi.R2dbcRollbackException;
-import io.r2dbc.spi.R2dbcTimeoutException;
-import io.r2dbc.spi.R2dbcTransientResourceException;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
 
 import org.springframework.dao.CannotAcquireLockException;
 import org.springframework.dao.DataAccessResourceFailureException;
@@ -37,7 +31,18 @@ import org.springframework.dao.TransientDataAccessResourceException;
 import org.springframework.r2dbc.BadSqlGrammarException;
 import org.springframework.r2dbc.UncategorizedR2dbcException;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import io.r2dbc.spi.R2dbcBadGrammarException;
+import io.r2dbc.spi.R2dbcDataIntegrityViolationException;
+import io.r2dbc.spi.R2dbcException;
+import io.r2dbc.spi.R2dbcNonTransientResourceException;
+import io.r2dbc.spi.R2dbcPermissionDeniedException;
+import io.r2dbc.spi.R2dbcRollbackException;
+import io.r2dbc.spi.R2dbcTimeoutException;
+import io.r2dbc.spi.R2dbcTransientResourceException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for {@link ConnectionFactoryUtils}.
@@ -86,35 +91,32 @@ class ConnectionFactoryUtilsTests {
 		assertThat(exception).isExactlyInstanceOf(DataAccessResourceFailureException.class);
 	}
 
+	private static Stream<Arguments> duplicateKeyErrorCodes() {
+		return Stream.of(
+				Arguments.of("Oracle", "23505", 0),
+				Arguments.of("Oracle", "23000", 1),
+				Arguments.of("SAP HANA", "23000", 301),
+				Arguments.of("MySQL/MariaDB", "23000", 1062),
+				Arguments.of("MS SQL Server", "23000", 2601),
+				Arguments.of("MS SQL Server", "23000", 2627),
+				Arguments.of("Informix", "23000", -239),
+				Arguments.of("Informix", "23000", -268)
+		);
+	}
+
+	@ParameterizedTest
+	@MethodSource("duplicateKeyErrorCodes")
+	void shouldTranslateIntegrityViolationException(final String db, String sqlState, final int errorCode) {
+		Exception exception = ConnectionFactoryUtils.convertR2dbcException("", "",
+				new R2dbcDataIntegrityViolationException("reason", sqlState, errorCode));
+		assertThat(exception).as(db).isExactlyInstanceOf(DuplicateKeyException.class);
+	}
+
 	@Test
-	void shouldTranslateIntegrityViolationException() {
+	void shouldTranslateGenericIntegrityViolationException() {
 		Exception exception = ConnectionFactoryUtils.convertR2dbcException("", "",
 				new R2dbcDataIntegrityViolationException());
 		assertThat(exception).isExactlyInstanceOf(DataIntegrityViolationException.class);
-
-		exception = ConnectionFactoryUtils.convertR2dbcException("", "",
-				new R2dbcDataIntegrityViolationException("reason", "23505"));
-		assertThat(exception).isExactlyInstanceOf(DuplicateKeyException.class);
-
-		exception = ConnectionFactoryUtils.convertR2dbcException("", "",
-				new R2dbcDataIntegrityViolationException("reason", "23000", 1));
-		assertThat(exception).as("Oracle").isExactlyInstanceOf(DuplicateKeyException.class);
-
-		exception = ConnectionFactoryUtils.convertR2dbcException("", "",
-				new R2dbcDataIntegrityViolationException("reason", "23000", 301));
-		assertThat(exception).as("SAP HANA").isExactlyInstanceOf(DuplicateKeyException.class);
-
-		exception = ConnectionFactoryUtils.convertR2dbcException("", "",
-				new R2dbcDataIntegrityViolationException("reason", "23000", 1062));
-		assertThat(exception).as("MySQL/MariaDB").isExactlyInstanceOf(DuplicateKeyException.class);
-
-		exception = ConnectionFactoryUtils.convertR2dbcException("", "",
-				new R2dbcDataIntegrityViolationException("reason", "23000", 2601));
-		assertThat(exception).as("MS SQL Server").isExactlyInstanceOf(DuplicateKeyException.class);
-
-		exception = ConnectionFactoryUtils.convertR2dbcException("", "",
-				new R2dbcDataIntegrityViolationException("reason", "23000", 2627));
-		assertThat(exception).as("MS SQL Server").isExactlyInstanceOf(DuplicateKeyException.class);
 	}
 
 	@Test


### PR DESCRIPTION
This fix is related to https://github.com/spring-projects/spring-framework/issues/29950 and https://github.com/spring-projects/spring-framework/issues/29699 .

After migration from Spring Boot 2 to Spring Boot 3 spring-jdbc changed behavior and now throws `DataIntegrityViolationException` instead of `DuplicateKeyException`.
