### PR TITLE
Optimize parameter matching in TableMetaDataContext

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
@@ -18,6 +18,7 @@ package org.springframework.jdbc.core.metadata;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -265,18 +266,19 @@ public class TableMetaDataContext {
 	 * @param inParameters the parameter names and values
 	 */
 	public List<Object> matchInParameterValuesWithInsertColumns(Map<String, ?> inParameters) {
-		List<Object> values = new ArrayList<>(inParameters.size());
+		List<Object> values = new ArrayList<>(this.tableColumns.size());
+		
+		Map<String, Object> caseInsensitiveLookup = new HashMap<>(inParameters.size());
+		for (Map.Entry<String, ?> entry : inParameters.entrySet()) {
+			caseInsensitiveLookup.put(entry.getKey().toLowerCase(Locale.ROOT), entry.getValue());
+		}
+		
 		for (String column : this.tableColumns) {
 			Object value = inParameters.get(column);
 			if (value == null) {
 				value = inParameters.get(column.toLowerCase(Locale.ROOT));
 				if (value == null) {
-					for (Map.Entry<String, ?> entry : inParameters.entrySet()) {
-						if (column.equalsIgnoreCase(entry.getKey())) {
-							value = entry.getValue();
-							break;
-						}
-					}
+					value = caseInsensitiveLookup.get(column.toLowerCase(Locale.ROOT));
 				}
 			}
 			values.add(value);

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
@@ -18,7 +18,6 @@ package org.springframework.jdbc.core.metadata;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -37,6 +36,7 @@ import org.springframework.jdbc.core.namedparam.SqlParameterSourceUtils;
 import org.springframework.jdbc.support.JdbcUtils;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.LinkedCaseInsensitiveMap;
 import org.springframework.util.StringUtils;
 
 /**
@@ -268,17 +268,15 @@ public class TableMetaDataContext {
 	public List<Object> matchInParameterValuesWithInsertColumns(Map<String, ?> inParameters) {
 		List<Object> values = new ArrayList<>(this.tableColumns.size());
 		
-		Map<String, Object> caseInsensitiveLookup = new HashMap<>(inParameters.size());
-		for (Map.Entry<String, ?> entry : inParameters.entrySet()) {
-			caseInsensitiveLookup.put(entry.getKey().toLowerCase(Locale.ROOT), entry.getValue());
-		}
+		LinkedCaseInsensitiveMap<Object> caseInsensitiveLookup = new LinkedCaseInsensitiveMap<>(inParameters.size());
+		caseInsensitiveLookup.putAll(inParameters);
 		
 		for (String column : this.tableColumns) {
 			Object value = inParameters.get(column);
 			if (value == null) {
 				value = inParameters.get(column.toLowerCase(Locale.ROOT));
 				if (value == null) {
-					value = caseInsensitiveLookup.get(column.toLowerCase(Locale.ROOT));
+					value = caseInsensitiveLookup.get(column);
 				}
 			}
 			values.add(value);


### PR DESCRIPTION
# Optimize parameter matching in TableMetaDataContext

## Problem

The `TableMetaDataContext.matchInParameterValuesWithInsertColumns()` method uses a nested loop for case-insensitive parameter matching, resulting in O(n×m) complexity where n = columns and m = parameters.

For each column, when exact matching fails, it iterates through **all** parameter entries to find case-insensitive matches:

```java
for (String column : this.tableColumns) {                    // O(n)
    Object value = inParameters.get(column);
    if (value == null) {
        // ... lowercase lookup
        if (value == null) {
            for (Map.Entry<String, ?> entry : inParameters.entrySet()) {  // O(m)
                if (column.equalsIgnoreCase(entry.getKey())) {
                    value = entry.getValue();
                    break;
                }
            }
        }
    }
    values.add(value);
}
```

This becomes expensive with many columns and parameters (e.g., 100 columns × 1000 parameters = 100K iterations).

## Solution

Pre-compute a case-insensitive lookup map, reducing complexity from O(n×m) to O(n+m):

```java
// Build lookup map once - O(m)
Map<String, Object> caseInsensitiveLookup = new HashMap<>(inParameters.size());
for (Map.Entry<String, ?> entry : inParameters.entrySet()) {
    caseInsensitiveLookup.put(entry.getKey().toLowerCase(Locale.ROOT), entry.getValue());
}

for (String column : this.tableColumns) {  // O(n)
    Object value = inParameters.get(column);
    if (value == null) {
        value = inParameters.get(column.toLowerCase(Locale.ROOT));
        if (value == null) {
            value = caseInsensitiveLookup.get(column.toLowerCase(Locale.ROOT)); // O(1)
        }
    }
    values.add(value);
}
```

## Performance Impact

- **Before**: O(n×m) - quadratic growth
- **After**: O(n+m) - linear growth  
- **Applications affected**: SimpleJdbcInsert users with many columns/parameters

## Testing

- ✅ All existing tests pass (no behavior change)
- ✅ Verified case-sensitive/insensitive matching logic preserved