### PR TITLE
Support Kotlin Context Parameters

### DIFF
--- a/spring-core/spring-core.gradle
+++ b/spring-core/spring-core.gradle
@@ -130,6 +130,12 @@ jar {
 	}
 }
 
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xcontext-parameters")
+    }
+}
+
 test {
 	// Make sure the classes dir is used on the test classpath (required by ResourceTests).
 	// When test fixtures are involved, the JAR is used by default.

--- a/spring-core/src/main/java/org/springframework/core/CoroutinesUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/CoroutinesUtils.java
@@ -130,7 +130,7 @@ public abstract class CoroutinesUtils {
 					for (KParameter parameter : function.getParameters()) {
 						switch (parameter.getKind()) {
 							case INSTANCE -> argMap.put(parameter, target);
-							case VALUE, EXTENSION_RECEIVER -> {
+							case VALUE, EXTENSION_RECEIVER, CONTEXT -> {
 								Object arg = args[index];
 								if (!(parameter.isOptional() && arg == null)) {
 									KType type = parameter.getType();

--- a/spring-core/src/test/kotlin/org/springframework/core/CoroutinesUtilsTests.kt
+++ b/spring-core/src/test/kotlin/org/springframework/core/CoroutinesUtilsTests.kt
@@ -274,6 +274,26 @@ class CoroutinesUtilsTests {
 	}
 
 	@Test
+	fun invokeSuspendingFunctionWithContextParameter() {
+		val method = CoroutinesUtilsTests::class.java.getDeclaredMethod("suspendingFunctionWithContextParameter",
+			CustomException::class.java, Continuation::class.java)
+		val mono = CoroutinesUtils.invokeSuspendingFunction(method, this, CustomException("foo")) as Mono
+		runBlocking {
+			Assertions.assertThat(mono.awaitSingleOrNull()).isEqualTo("foo")
+		}
+	}
+
+	@Test
+	fun invokeSuspendingFunctionWithContextParameterAndParameter() {
+		val method = CoroutinesUtilsTests::class.java.getDeclaredMethod("suspendingFunctionWithContextParameterAndParameter",
+			CustomException::class.java, Int::class.java, Continuation::class.java)
+		val mono = CoroutinesUtils.invokeSuspendingFunction(method, this, CustomException("foo"), 20) as Mono
+		runBlocking {
+			Assertions.assertThat(mono.awaitSingleOrNull()).isEqualTo("foo-20")
+		}
+	}
+
+	@Test
 	suspend fun invokeSuspendingFunctionWithGenericParameter() {
 		val method = GenericController::class.java.declaredMethods.first { it.name.startsWith("handle") }
 		val horse = Animal("horse")
@@ -386,6 +406,18 @@ class CoroutinesUtilsTests {
 	suspend fun CustomException.suspendingFunctionWithExtensionAndParameter(limit: Int): String {
 		delay(1)
 		return "${this.message}-$limit"
+	}
+
+	context(value: CustomException)
+	suspend fun suspendingFunctionWithContextParameter(): String {
+		delay(1)
+		return "${value.message}"
+	}
+
+	context(value: CustomException)
+	suspend fun suspendingFunctionWithContextParameterAndParameter(limit: Int): String {
+		delay(1)
+		return "${value.message}-$limit"
 	}
 
 	interface Named {

--- a/spring-web/spring-web.gradle
+++ b/spring-web/spring-web.gradle
@@ -104,3 +104,9 @@ dependencies {
 	testRuntimeOnly("org.glassfish:jakarta.el")
 	testRuntimeOnly("org.hibernate.validator:hibernate-validator")
 }
+
+kotlin {
+    compilerOptions {
+        freeCompilerArgs.addAll("-Xcontext-parameters")
+    }
+}

--- a/spring-web/src/main/java/org/springframework/web/method/support/InvocableHandlerMethod.java
+++ b/spring-web/src/main/java/org/springframework/web/method/support/InvocableHandlerMethod.java
@@ -312,7 +312,7 @@ public class InvocableHandlerMethod extends HandlerMethod {
 			for (KParameter parameter : function.getParameters()) {
 				switch (parameter.getKind()) {
 					case INSTANCE -> argMap.put(parameter, target);
-					case VALUE, EXTENSION_RECEIVER -> {
+					case VALUE, EXTENSION_RECEIVER, CONTEXT -> {
 						Object arg = args[index];
 						if (!(parameter.isOptional() && arg == null)) {
 							KType type = parameter.getType();

--- a/spring-web/src/test/kotlin/org/springframework/web/method/support/InvocableHandlerMethodKotlinTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/web/method/support/InvocableHandlerMethodKotlinTests.kt
@@ -261,6 +261,22 @@ class InvocableHandlerMethodKotlinTests {
 	}
 
 	@Test
+	fun contextParameter() {
+		composite.addResolver(StubArgumentResolver(CustomException::class.java, CustomException("foo")))
+		val value = getInvocable(ReflectionUtils.findMethod(ContextParameterHandler::class.java, "handle", CustomException::class.java)!!).invokeForRequest(request, null)
+		Assertions.assertThat(value).isEqualTo("foo")
+	}
+
+	@Test
+	fun contextParameterWithParameter() {
+		composite.addResolver(StubArgumentResolver(CustomException::class.java, CustomException("foo")))
+		composite.addResolver(StubArgumentResolver(Int::class.java, 20))
+		val value = getInvocable(ReflectionUtils.findMethod(ContextParameterHandler::class.java, "handleWithParameter", CustomException::class.java, Int::class.java)!!)
+			.invokeForRequest(request, null)
+		Assertions.assertThat(value).isEqualTo("foo-20")
+	}
+
+	@Test
 	fun genericParameter() {
 		val horse = Animal("horse")
 		composite.addResolver(StubArgumentResolver(Animal::class.java, horse))
@@ -378,6 +394,19 @@ class InvocableHandlerMethodKotlinTests {
 
 		fun CustomException.handleWithParameter(limit: Int): String {
 			return "${this.message}-$limit"
+		}
+	}
+
+	private class ContextParameterHandler {
+
+		context(exception: CustomException)
+		fun handle(): String {
+			return "${exception.message}"
+		}
+
+		context(exception: CustomException)
+		fun handleWithParameter(limit: Int): String {
+			return "${exception.message}-$limit"
 		}
 	}
 


### PR DESCRIPTION
*Note: finding a commit message for this change is quite difficult, the current one is likely to cause confusion. I'd appreciate better suggestions*

Originally introduced as Beta in 2.2.0, Context Parameters are a new Kotlin feature that I wanted to use in my project.
Those parameters have a different `KParameter.Kind` (`CONTEXT`) and are therefore not supported by [the current CoroutinesUtils implementation](https://github.com/spring-projects/spring-framework/blob/d2bdf11b3973cc7173a52c33ae7bbae2002442bd/spring-core/src/main/java/org/springframework/core/CoroutinesUtils.java). This resulted in the following error message:

```
java.lang.IllegalArgumentException: No argument provided for a required parameter: context parameter tenant of context(tenant: com.application.TenantContext)
```

## Status
~~[kotlin-reflect's Context Parameters support](https://github.com/JetBrains/kotlin/commit/38842eefbec957507162974806b3f48bcbb8d9a4) was first released in 2.2.20-Beta1. Therefore, I had to target the latest 2.2.20 RC with this PR.~~
~~Once 2.2.20 is formally released, I'll await the update on Spring's main branch, rebase onto it, and set the PR as ready to merge.~~
With 86fb62c05998f776e42b7960d9c039f00645ebb2, main is using the latest Kotlin release. I've done the rebase and marked the PR as ready to review. Thanks in advance for your considerations!