### PR TITLE
Interface client refinements

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/service/registry/AbstractHttpServiceRegistrar.java
+++ b/spring-web/src/main/java/org/springframework/web/service/registry/AbstractHttpServiceRegistrar.java
@@ -211,7 +211,7 @@ public abstract class AbstractHttpServiceRegistrar implements
 	 * @param basePackage the names of packages to look under
 	 * @return match bean definitions
 	 */
-	private Stream<BeanDefinition> findHttpServices(String basePackage) {
+	protected final Stream<BeanDefinition> findHttpServices(String basePackage) {
 		if (this.scanner == null) {
 			Assert.state(this.environment != null, "Environment has not been set");
 			Assert.state(this.resourceLoader != null, "ResourceLoader has not been set");

--- a/spring-web/src/main/java/org/springframework/web/service/registry/ImportHttpServiceRegistrar.java
+++ b/spring-web/src/main/java/org/springframework/web/service/registry/ImportHttpServiceRegistrar.java
@@ -47,7 +47,7 @@ import org.springframework.web.service.registry.HttpServiceGroup.ClientType;
  * @author Olga Maciaszek-Sharma
  * @since 7.0
  */
-class ImportHttpServiceRegistrar extends AbstractHttpServiceRegistrar {
+public class ImportHttpServiceRegistrar extends AbstractHttpServiceRegistrar {
 
 	private @Nullable MetadataReaderFactory metadataReaderFactory;
 
@@ -97,7 +97,15 @@ class ImportHttpServiceRegistrar extends AbstractHttpServiceRegistrar {
 		return (ImportHttpServices.GroupProvider) BeanUtils.instantiateClass(groupProvider);
 	}
 
-	private void registerHttpServices(GroupRegistry groupRegistry,
+	/**
+	 * Register HTTP service to given registry.
+	 * @param groupRegistry the group registry
+	 * @param groupProvider the group provider to use
+	 * @param clientType the client type to use
+	 * @param types the types to register
+	 * @param basePackages the base packages to register
+	 */
+	protected final void registerHttpServices(GroupRegistry groupRegistry,
 			ImportHttpServices.GroupProvider groupProvider, ClientType clientType, Class<?>[] types,
 			Class<?>[] basePackageClasses, String[] basePackages) {
 

--- a/spring-web/src/main/java/org/springframework/web/service/registry/ImportHttpServices.java
+++ b/spring-web/src/main/java/org/springframework/web/service/registry/ImportHttpServices.java
@@ -23,8 +23,11 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.context.annotation.Import;
 import org.springframework.core.annotation.AliasFor;
+import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.web.service.annotation.HttpExchange;
 
 /**
@@ -47,6 +50,7 @@ import org.springframework.web.service.annotation.HttpExchange;
  *
  * @author Olga Maciaszek-Sharma
  * @author Rossen Stoyanchev
+ * @author Phillip Webb
  * @since 7.0
  * @see Container
  * @see AbstractHttpServiceRegistrar
@@ -74,8 +78,17 @@ public @interface ImportHttpServices {
 	 * The name of the HTTP Service group.
 	 * <p>If not specified, declared HTTP Services are grouped under the
 	 * {@link HttpServiceGroup#DEFAULT_GROUP_NAME}.
+	 * @see #groupProvider()
 	 */
-	String group() default HttpServiceGroup.DEFAULT_GROUP_NAME;
+	String group() default "";
+
+	/**
+	 * Strategy used to provide the name of the HTTP Service group.
+	 * <p>May be used as an alternative to {@link #group()} when the group name can
+	 * be determined from the type.
+	 * @see #group()
+	 */
+	Class<? extends GroupProvider> groupProvider() default GroupProvider.class;
 
 	/**
 	 * Detect HTTP Services in the packages of the specified classes, looking
@@ -112,4 +125,19 @@ public @interface ImportHttpServices {
 		ImportHttpServices[] value();
 	}
 
+	/**
+	 * Strategy interface to provide the group name for HTTP Service interface.
+	 */
+	@FunctionalInterface
+	interface GroupProvider {
+
+		/**
+		 * Provide the group name that should be used for the given HTTP Service interface
+		 * metadata.
+		 * @param metadata the HTTP Service interface metadata
+		 * @return the provided group name or {@code null} if the HTTP Service client
+		 * should not be registered
+		 */
+		@Nullable String group(AnnotationMetadata metadata);
+	}
 }

--- a/spring-web/src/main/java/org/springframework/web/service/registry/ImportHttpServices.java
+++ b/spring-web/src/main/java/org/springframework/web/service/registry/ImportHttpServices.java
@@ -39,6 +39,8 @@ import org.springframework.web.service.annotation.HttpExchange;
  *
  * <p>The HTTP Services for each group can be listed via {@link #types()}, or
  * detected via {@link #basePackageClasses()} or {@link #basePackages()}.
+ * If neither types or base packages are defined, detection will occur recursively
+ * beginning with the package of the class that declares this annotation.
  *
  * <p>An application can autowire HTTP Service proxy beans, or autowire the
  * {@link HttpServiceProxyRegistry} from which to obtain proxies.

--- a/spring-web/src/test/java/org/springframework/web/service/registry/ImportHttpServiceRegistrarTests.java
+++ b/spring-web/src/test/java/org/springframework/web/service/registry/ImportHttpServiceRegistrarTests.java
@@ -33,6 +33,7 @@ import org.springframework.core.type.AnnotationMetadata;
 import org.springframework.web.service.registry.HttpServiceGroup.ClientType;
 import org.springframework.web.service.registry.echo.EchoA;
 import org.springframework.web.service.registry.echo.EchoB;
+import org.springframework.web.service.registry.echo.ScanConventionConfig;
 import org.springframework.web.service.registry.greeting.GreetingA;
 import org.springframework.web.service.registry.greeting.GreetingB;
 
@@ -81,6 +82,12 @@ public class ImportHttpServiceRegistrarTests {
 		assertGroups(
 				TestGroup.ofPackageClasses(ECHO_GROUP, EchoA.class),
 				TestGroup.ofPackageClasses(GREETING_GROUP, GreetingA.class));
+	}
+
+	@Test
+	void basicScanByConvention() {
+		doRegister(ScanConventionConfig.class);
+		assertGroups(TestGroup.ofPackageNames(ECHO_GROUP, ClientType.UNSPECIFIED, EchoA.class.getPackage().getName()));
 	}
 
 	@Test

--- a/spring-web/src/test/java/org/springframework/web/service/registry/TestGroup.java
+++ b/spring-web/src/test/java/org/springframework/web/service/registry/TestGroup.java
@@ -53,4 +53,10 @@ record TestGroup(
 		return group;
 	}
 
+	public static TestGroup ofPackageNames(String name, ClientType clientType, String... packageNames) {
+		TestGroup group = new TestGroup(name, clientType);
+		group.packageNames().addAll(Arrays.asList(packageNames));
+		return group;
+	}
+
 }

--- a/spring-web/src/test/java/org/springframework/web/service/registry/echo/ScanConventionConfig.java
+++ b/spring-web/src/test/java/org/springframework/web/service/registry/echo/ScanConventionConfig.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.service.registry.echo;
+
+import org.springframework.web.service.registry.ImportHttpServices;
+
+@ImportHttpServices(group = "echo")
+public class ScanConventionConfig {
+
+}


### PR DESCRIPTION
This pull-request provides a number of possible refinements to interface client support, primarily to help with Spring Boot support.

The following commits are included:

- Make AbstractHttpServiceRegistrar.findHttpServices(...) protected
- Support convention based `@ImportHttpServices` imports
- Add `ImportHttpServices.GroupProvider` support
- Make `ImportHttpServiceRegistrar` public
