### PR TITLE
Add @Nullable annotation to AbstractJsonPathAssertions.isEqualTo

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/support/AbstractJsonPathAssertions.java
+++ b/spring-test/src/main/java/org/springframework/test/web/support/AbstractJsonPathAssertions.java
@@ -58,7 +58,7 @@ public abstract class AbstractJsonPathAssertions<B> {
 	/**
 	 * Applies {@link JsonPathExpectationsHelper#assertValue(String, Object)}.
 	 */
-	public B isEqualTo(Object expectedValue) {
+	public B isEqualTo(@Nullable Object expectedValue) {
 		this.pathHelper.assertValue(this.content, expectedValue);
 		return this.bodySpec;
 	}

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/client/JsonPathAssertionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/client/JsonPathAssertionTests.java
@@ -19,6 +19,7 @@ package org.springframework.test.web.servlet.client;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.LinkedHashMap
 
 import org.junit.jupiter.api.Test;
 
@@ -192,6 +193,14 @@ class JsonPathAssertionTests {
 				.jsonPath("$.composers").isArray();
 	}
 
+	@Test
+	void isEqualToWithNull() {
+		client.get().uri("/music/null")
+				.exchange()
+				.expectBody()
+				.jsonPath("$.value").isEqualTo(null);
+	}
+
 	@RestController
 	private static class MusicController {
 		@GetMapping("/music/instruments")
@@ -211,6 +220,12 @@ class JsonPathAssertionTests {
 			map.add("performers", new Person("Vladimir Ashkenazy"));
 			map.add("performers", new Person("Yehudi Menuhin"));
 
+			return map;
+		}
+		@GetMapping("/music/null")
+		public Map<String, Object> getNull() {
+			Map<String, Object> map = new LinkedHashMap<>();
+			map.put("value", null);
 			return map;
 		}
 	}

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/client/JsonPathAssertionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/client/JsonPathAssertionTests.java
@@ -19,7 +19,7 @@ package org.springframework.test.web.servlet.client;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.LinkedHashMap
+import java.util.LinkedHashMap;
 
 import org.junit.jupiter.api.Test;
 

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/client/JsonPathAssertionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/client/JsonPathAssertionTests.java
@@ -222,10 +222,13 @@ class JsonPathAssertionTests {
 
 			return map;
 		}
+
 		@GetMapping("/music/null")
 		public Map<String, Object> getNull() {
 			Map<String, Object> map = new LinkedHashMap<>();
+
 			map.put("value", null);
+
 			return map;
 		}
 	}

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/client/JsonPathAssertionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/client/JsonPathAssertionTests.java
@@ -17,9 +17,9 @@
 package org.springframework.test.web.servlet.client;
 
 import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.LinkedHashMap;
 
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
fix https://github.com/spring-projects/spring-framework/issues/35445

This PR adds the @Nullable annotation to the parameter of 
AbstractJsonPathAssertions.isEqualTo(Object expectedValue).

Also adds a test to verify that passing null works as expected.