### PR TITLE
useCaches option in PathMatchingResourcePatternResolver not applied in special case

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/support/PathMatchingResourcePatternResolver.java
+++ b/spring-core/src/main/java/org/springframework/core/io/support/PathMatchingResourcePatternResolver.java
@@ -392,7 +392,13 @@ public class PathMatchingResourcePatternResolver implements ResourcePatternResol
 			}
 			else {
 				// a single resource with the given name
-				return new Resource[] {getResourceLoader().getResource(locationPattern)};
+				Resource res = getResourceLoader().getResource(locationPattern);
+				if (this.useCaches != null) {
+					if (resource instanceof UrlResource urlResource) {
+						urlResource.setUseCaches(this.useCaches);
+					}
+				}
+				return new Resource[] {res};
 			}
 		}
 	}


### PR DESCRIPTION
Set useCaches on single resources obtained directly from the resource loader before returning it from the PathMatchingResourcePatternResolver

Targets main, but should actually go to 6.2.x IMHO.