### PR TITLE
Introduce placeholder resolution support in `@ConcurrencyLimit`

### DIFF
--- a/spring-context/src/main/java/org/springframework/resilience/annotation/ConcurrencyLimit.java
+++ b/spring-context/src/main/java/org/springframework/resilience/annotation/ConcurrencyLimit.java
@@ -42,6 +42,7 @@ import org.springframework.aot.hint.annotation.Reflective;
  * {@link org.springframework.aop.interceptor.ConcurrencyThrottleInterceptor}.
  *
  * @author Juergen Hoeller
+ * @author Hyunsang Han
  * @since 7.0
  * @see EnableResilientMethods
  * @see ConcurrencyLimitBeanPostProcessor
@@ -61,5 +62,13 @@ public @interface ConcurrencyLimit {
 	 * the number of concurrent invocations similar to the upper bound of a pool.
 	 */
 	int value() default 1;
+
+	/**
+	 * The concurrency limit as a configurable String.
+	 * A non-empty value specified here overrides the {@link #value()} attribute.
+	 * <p>This supports Spring-style "${...}" placeholders as well as SpEL expressions.
+	 * @see #value()
+	 */
+	String valueString() default "";
 
 }


### PR DESCRIPTION
This change introduces property placeholder resolution support in `@ConcurrencyLimit`.
I tried to closely follow the approach used in `@Retryable`, and based this work on c9078bfe1473040e8ded7259d42a98bf7deaa6a0. 👀 

- Added `ConcurrencyLimit#valueString()` attribute with placeholder support
- Implemented `EmbeddedValueResolverAware` in `ConcurrencyLimitBeanPostProcessor`
- Added integration tests for property resolution  

Closes gh-35461
