### PR TITLE
Fix HtmlUtils unescape for supplementary chars

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/HtmlCharacterEntityDecoder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/HtmlCharacterEntityDecoder.java
@@ -124,7 +124,10 @@ class HtmlCharacterEntityDecoder {
 			int value = (!isHexNumberedReference ?
 					Integer.parseInt(getReferenceSubstring(2)) :
 					Integer.parseInt(getReferenceSubstring(3), 16));
-			this.decodedMessage.append((char) value);
+			if (value > Character.MAX_CODE_POINT) {
+				return false;
+			}
+			this.decodedMessage.appendCodePoint(value);
 			return true;
 		}
 		catch (NumberFormatException ex) {

--- a/spring-web/src/test/java/org/springframework/web/util/HtmlCharacterEntityDecoderTest.java
+++ b/spring-web/src/test/java/org/springframework/web/util/HtmlCharacterEntityDecoderTest.java
@@ -1,0 +1,26 @@
+package org.springframework.web.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HtmlCharacterEntityDecoderTest {
+
+	@Test
+	@DisplayName("Should correctly unescape Unicode supplementary characters")
+	void unescapeHandlesSupplementaryCharactersCorrectly() {
+		// Arrange: Prepare test cases with the 'grinning face' emoji (😀, U+1F600).
+		String expectedCharacter = "😀";
+		String decimalEntity = "&#128512;";
+		String hexEntity = "&#x1F600;";
+
+		// Act: Call the HtmlUtils.htmlUnescape method to get the actual results.
+		String actualResultFromDecimal = HtmlUtils.htmlUnescape(decimalEntity);
+		String actualResultFromHex = HtmlUtils.htmlUnescape(hexEntity);
+
+		// Assert: Verify that the actual results match the expected character.
+		assertEquals(expectedCharacter, actualResultFromDecimal, "Decimal entity was not converted correctly.");
+		assertEquals(expectedCharacter, actualResultFromHex, "Hexadecimal entity was not converted correctly.");
+	}
+}

--- a/spring-web/src/test/java/org/springframework/web/util/HtmlCharacterEntityDecoderTest.java
+++ b/spring-web/src/test/java/org/springframework/web/util/HtmlCharacterEntityDecoderTest.java
@@ -37,4 +37,6 @@ class HtmlCharacterEntityDecoderTest {
 		// Assert
 		assertEquals(expectedOutput, actualOutput, "Basic HTML entities were not unescaped correctly.");
 	}
+
 }
+

--- a/spring-web/src/test/java/org/springframework/web/util/HtmlCharacterEntityDecoderTest.java
+++ b/spring-web/src/test/java/org/springframework/web/util/HtmlCharacterEntityDecoderTest.java
@@ -23,4 +23,18 @@ class HtmlCharacterEntityDecoderTest {
 		assertEquals(expectedCharacter, actualResultFromDecimal, "Decimal entity was not converted correctly.");
 		assertEquals(expectedCharacter, actualResultFromHex, "Hexadecimal entity was not converted correctly.");
 	}
+
+	@Test
+	@DisplayName("Should correctly unescape basic and named HTML entities")
+	void unescapeHandlesBasicEntities() {
+		// Arrange
+		String input = "&lt;p&gt;Tom &amp; Jerry&#39;s &quot;Show&quot;&lt;/p&gt;";
+		String expectedOutput = "<p>Tom & Jerry's \"Show\"</p>";
+
+		// Act
+		String actualOutput = HtmlUtils.htmlUnescape(input);
+
+		// Assert
+		assertEquals(expectedOutput, actualOutput, "Basic HTML entities were not unescaped correctly.");
+	}
 }


### PR DESCRIPTION
Closes: #35426 

Currently, `HtmlUtils.htmlUnescape()` does not correctly handle numeric character references for Unicode supplementary characters (e.g., emojis).

For example, an entity like `&#128512;` (😀) is incorrectly converted to a garbled character corresponding to `U+F600` due to data truncation.
## Step to Reproduce
``` 
public static void main(String[] args) {
        // Test character: 'Grinning Face' emoji (😀)
        // Unicode code point: U+1F600
        // Hexadecimal: 1F600
        // Decimal: 128512

        // 1. Input value as a decimal HTML entity
        String inputDecimal = "&#128512;";

        // 2. Input value as a hexadecimal HTML entity
        String inputHex = "&#x1F600;";

        // 3. The expected result after correct conversion
        String expectedOutput = "😀";

        System.out.println("--- Decimal HTML Entity Test ---");
        System.out.println("Input: " + inputDecimal);

        // Call the HtmlUtils.htmlUnescape() method
        String actualOutputDecimal = HtmlUtils.htmlUnescape(inputDecimal);

        System.out.println("Actual Output: " + actualOutputDecimal);
        System.out.println("Expected Output: " + expectedOutput);
        System.out.println("Result matches expected: " + expectedOutput.equals(actualOutputDecimal));

        System.out.println("\n--- Hexadecimal HTML Entity Test ---");
        System.out.println("Input: " + inputHex);

        // Call the HtmlUtils.htmlUnescape() method
        String actualOutputHex = HtmlUtils.htmlUnescape(inputHex);

        System.out.println("Actual Output: " + actualOutputHex);
        System.out.println("Expected Output: " + expectedOutput);
        System.out.println("Result matches expected: " + expectedOutput.equals(actualOutputHex));
    }
```
<img width="641" height="273" alt="스크린샷 2025-09-13 오후 11 29 37" src="https://github.com/user-attachments/assets/25f37727-161c-4340-87e1-e3a85f0447bd" />

## Cause

The root cause was a problematic cast to a 16-bit `char` in the `HtmlCharacterEntityDecoder`. This operation truncated any Unicode code point value greater than `U+FFFF`, leading to the loss of the most significant bits.

## Solution

This PR resolves the issue by replacing the direct `(char)` cast with a call to `StringBuilder.appendCodePoint()`.

The `appendCodePoint()` method is designed to handle the full range of Unicode code points. It correctly converts supplementary characters into a two-character surrogate pair, ensuring that all characters are unescaped without data loss. A corresponding unit test has been added to verify this fix.