### PR TITLE
Fix: type matching for request-scope generic beans

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
@@ -580,6 +580,27 @@ public abstract class AbstractBeanFactory extends FactoryBeanRegistrySupport imp
 				// Generics potentially only match on the target class, not on the proxy...
 				RootBeanDefinition mbd = getMergedLocalBeanDefinition(beanName);
 				Class<?> targetType = mbd.getTargetType();
+
+				String scope = mbd.getScope();
+				if (targetType == null && scope != null && !scope.isEmpty()) {
+					String targetBeanName = "scopedTarget." + beanName;
+					if (containsBeanDefinition(targetBeanName)) {
+						RootBeanDefinition targetMbd = getMergedLocalBeanDefinition(targetBeanName);
+
+						ResolvableType targetResolvableType = targetMbd.targetType;
+						if (targetResolvableType == null) {
+							targetResolvableType = targetMbd.factoryMethodReturnType;
+							if (targetResolvableType == null) {
+								targetResolvableType = ResolvableType.forClass(targetMbd.getBeanClass());
+							}
+						}
+
+						if (typeToMatch.isAssignableFrom(targetResolvableType)) {
+							return true;
+						}
+					}
+				}
+
 				if (targetType != null && targetType != ClassUtils.getUserClass(beanInstance)) {
 					// Check raw class match as well, making sure it's exposed on the proxy.
 					Class<?> classToMatch = typeToMatch.resolve();

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java.rej
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java.rej
@@ -1,0 +1,9 @@
+diff a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java	(rejected hunks)
+@@ -29,6 +29,7 @@
+ import java.util.concurrent.ConcurrentHashMap;
+ import java.util.concurrent.CopyOnWriteArrayList;
+ import java.util.function.Predicate;
++import java.util.function.Supplier;
+ import java.util.function.UnaryOperator;
+ 
+ import org.springframework.beans.BeanUtils;

--- a/spring-beans/src/test/java/org/springframework/beans/factory/support/GenericTypeMatchingTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/support/GenericTypeMatchingTests.java
@@ -1,0 +1,46 @@
+package org.springframework.beans.factory.support;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.ResolvableType;
+
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link AbstractBeanFactory#isTypeMatch} with scoped proxy beans that use generic types.
+ */
+class ScopedProxyGenericTypeMatchTests {
+
+	@Test
+	void scopedProxyBeanTypeMatching() {
+		DefaultListableBeanFactory factory = new DefaultListableBeanFactory();
+
+		String proxyBeanName = "wordBean-" + UUID.randomUUID();
+		String targetBeanName = "scopedTarget." + proxyBeanName;
+
+		RootBeanDefinition targetDef = new RootBeanDefinition(SomeGenericSupplier.class);
+		targetDef.setScope("request");
+		factory.registerBeanDefinition(targetBeanName, targetDef);
+
+		RootBeanDefinition proxyDef = new RootBeanDefinition();
+		proxyDef.setScope("singleton");
+		proxyDef.setTargetType(ResolvableType.forClassWithGenerics(Supplier.class, String.class));
+		proxyDef.setAttribute("targetBeanName", targetBeanName);
+		factory.registerBeanDefinition(proxyBeanName, proxyDef);
+
+		ResolvableType supplierType = ResolvableType.forClassWithGenerics(Supplier.class, String.class);
+
+		assertThat(factory.isTypeMatch(proxyBeanName, supplierType)).isTrue();
+
+		assertThat(factory.getBeanNamesForType(supplierType)).contains(proxyBeanName);
+	}
+
+	static class SomeGenericSupplier implements Supplier<String> {
+		@Override
+		public String get() {
+			return "value";
+		}
+	}
+}


### PR DESCRIPTION
This PR fixes an issue where @MockBean fails to work with request-scoped Supplier<T> without explicit bean name.

Issue
When using @MockBean with a request-scoped generic bean (especially Supplier<T>), Spring fails to match the bean by type unless the bean name is explicitly specified. This happens because the type matching algorithm doesn't properly handle the generic type information for scoped proxy beans.

Solution
The solution enhances AbstractBeanFactory.isTypeMatch method to check for beans with a scope and look up their corresponding target bean definitions. When a scoped proxy bean is found, the method tries to match the type against the target bean's resolvable type.

Testing
Added a test case that verifies type matching works correctly for scoped proxy beans with generic types.

Fixes https://github.com/spring-projects/spring-framework/issues/30043