### PR TITLE
docs(core): document ${…} placeholders & Ant-style patterns for @ComponentScan

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/beans/classpath-scanning.adoc
+++ b/framework-docs/modules/ROOT/pages/core/beans/classpath-scanning.adoc
@@ -323,6 +323,45 @@ sure that they are 'opened' (that is, that they use an `opens` declaration inste
 `exports` declaration in your `module-info` descriptor).
 ====
 
+==== Property placeholders and Ant-style patterns
+
+`@ComponentScan(basePackages)` supports `${…}` property placeholders resolved
+against the `Environment` and Ant-style package patterns such as `com.example.**`.
+Multiple packages and/or patterns may be specified.
+
+[tabs]
+======
+Java::
++
+[source,java,indent=0,subs="verbatim,quotes"]
+----
+@Configuration
+@ComponentScan(basePackages = "${app.scan.packages}")
+public class AppConfig {
+	// ...
+}
+----
+
+Kotlin::
++
+[source,kotlin,indent=0,subs="verbatim,quotes"]
+----
+@Configuration
+@ComponentScan(basePackages = ["\${app.scan.packages}"])
+class AppConfig {
+	// ...
+}
+----
+======
+
+[source,properties,indent=0,subs="verbatim,quotes"]
+----
+app.scan.packages=com.example.**,org.acme.*
+----
+
+NOTE: Ant-style patterns do not apply to `basePackageClasses`, which accepts concrete
+classes and derives packages from those classes.
+
 Furthermore, the `AutowiredAnnotationBeanPostProcessor` and
 `CommonAnnotationBeanPostProcessor` are both implicitly included when you use the
 component-scan element. That means that the two components are autodetected and

--- a/spring-context/src/main/java/org/springframework/context/annotation/ComponentScan.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ComponentScan.java
@@ -76,6 +76,10 @@ public @interface ComponentScan {
 	 * <p>Allows for more concise annotation declarations if no other attributes
 	 * are needed &mdash; for example, {@code @ComponentScan("org.my.pkg")}
 	 * instead of {@code @ComponentScan(basePackages = "org.my.pkg")}.
+	 * <p>This attribute has the same semantics as {@link #basePackages}, including
+	 * support for {@code ${...}} placeholders (resolved against the
+	 * {@link org.springframework.core.env.Environment Environment}) and
+	 * Ant-style package patterns (for example, {@code com.example.**}).
 	 */
 	@AliasFor("basePackages")
 	String[] value() default {};
@@ -86,6 +90,13 @@ public @interface ComponentScan {
 	 * attribute.
 	 * <p>Use {@link #basePackageClasses} for a type-safe alternative to
 	 * String-based package names.
+	 * <p>Supports {@code ${...}} placeholders resolved against the
+	 * {@link org.springframework.core.env.Environment Environment} as well as
+	 * Ant-style package patterns (for example, {@code com.example.**}).
+	 * Multiple packages and/or patterns may be specified.
+	 * <p><strong>Note:</strong> Ant-style patterns are <em>not</em> applicable to
+	 * {@link #basePackageClasses()}, which accepts concrete classes for type-safe
+	 * package selection.
 	 */
 	@AliasFor("value")
 	String[] basePackages() default {};
@@ -95,6 +106,8 @@ public @interface ComponentScan {
 	 * to scan for annotated components. The package of each class specified will be scanned.
 	 * <p>Consider creating a special no-op marker class or interface in each package
 	 * that serves no purpose other than being referenced by this attribute.
+	 * <p><strong>Note:</strong> Ant-style package patterns do not apply here; this
+	 * attribute accepts concrete classes only and derives packages from those classes.
 	 */
 	Class<?>[] basePackageClasses() default {};
 


### PR DESCRIPTION
@componentscan(basePackages) already supports:

Resolving ${…} property placeholders against the Spring Environment.
Ant-style package patterns (e.g., com.example.**, org.acme.*).
However, this behavior wasn’t explicitly called out in the JavaDoc or the reference docs, making it easy to miss. This PR documents those capabilities and clarifies where pattern support applies.

JavaDoc: clarify that basePackages/value resolve ${…} via the Environment and support Ant-style package patterns (e.g., com.example.**); note patterns do not apply to basePackageClasses.

Reference docs: add a short subsection in classpath-scanning.adoc with Java/Kotlin + properties examples.

Fixes https://github.com/spring-projects/spring-framework/issues/35288.