### PR TITLE
AbstractMockHttpServletRequestBuilder#buildRequest is not idempotent

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/request/AbstractMockHttpServletRequestBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/request/AbstractMockHttpServletRequestBuilder.java
@@ -77,6 +77,7 @@ import org.springframework.web.util.UrlPathHelper;
  * @author Arjen Poutsma
  * @author Sam Brannen
  * @author Kamill Sokol
+ * @author Réda Housni Alaoui
  * @since 6.2
  * @param <B> a self reference to the builder type
  */
@@ -898,16 +899,17 @@ public abstract class AbstractMockHttpServletRequestBuilder<B extends AbstractMo
 		request.setContextPath(this.contextPath);
 		request.setServletPath(this.servletPath);
 
-		if ("".equals(this.pathInfo)) {
+		String pathInfoToUse = this.pathInfo;
+		if ("".equals(pathInfoToUse)) {
 			if (!requestUri.startsWith(this.contextPath + this.servletPath)) {
 				throw new IllegalArgumentException(
 						"Invalid servlet path [" + this.servletPath + "] for request URI [" + requestUri + "]");
 			}
 			String extraPath = requestUri.substring(this.contextPath.length() + this.servletPath.length());
-			this.pathInfo = (StringUtils.hasText(extraPath) ?
+			pathInfoToUse = (StringUtils.hasText(extraPath) ?
 					UrlPathHelper.defaultInstance.decodeRequestString(request, extraPath) : null);
 		}
-		request.setPathInfo(this.pathInfo);
+		request.setPathInfo(pathInfoToUse);
 	}
 
 	private void addRequestParams(MockHttpServletRequest request, MultiValueMap<String, String> map) {

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/request/AbstractMockHttpServletRequestBuilderTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/request/AbstractMockHttpServletRequestBuilderTests.java
@@ -32,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for {@link AbstractMockHttpServletRequestBuilder}
  *
  * @author Stephane Nicoll
+ * @author Réda Housni Alaoui
  */
 class AbstractMockHttpServletRequestBuilderTests {
 
@@ -126,6 +127,14 @@ class AbstractMockHttpServletRequestBuilderTests {
 				.apiVersionInserter(ApiVersionInserter.useHeader("API-Version")));
 
 		assertThat(buildRequest(builder).getHeader("API-Version")).isEqualTo("1.1");
+	}
+
+	@Test
+	void pathInfoIsNotMutatedByBuildMethod() {
+		TestRequestBuilder builder = new TestRequestBuilder(HttpMethod.GET).uri("/b");
+		assertThat(buildRequest(builder).getPathInfo()).isEqualTo("/b");
+		builder.uri("/a");
+		assertThat(buildRequest(builder).getPathInfo()).isEqualTo("/a");
 	}
 
 	private MockHttpServletRequest buildRequest(AbstractMockHttpServletRequestBuilder<?> builder) {


### PR DESCRIPTION
I have testing components making use of `MockHttpServletRequestBuilder`. These components should be able to mutate the builder but also to check the builder state (e.g. "what is the http method currently stored by the builder?").

By design, the only way to access `MockHttpServletRequestBuilder` state is to invoke `buildRequest` to retrieve a `MockHttpServletRequest` that will allow to check the state via its getters. 
I am fine with that. 

But I discovered that invoking `buildRequest` mutates the value of `MockHttpServletRequestBuilder#pathInfo`:
https://github.com/spring-projects/spring-framework/blob/88812edc3501bd7287dba6409418d745da8236d0/spring-test/src/main/java/org/springframework/test/web/servlet/request/AbstractMockHttpServletRequestBuilder.java#L901-L909

This mutation can break the builder once you try to pass it to `MockMvc#perform`.
An example of scenario:
1. Make sure `MockMvc` has a non null `defaultRequestBuilder` that will be merged in the consumer's provided `MockHttpServletRequestBuilder`
2. Create `MockHttpServletRequestBuilder` instance `foo`
3. Invoke `MockHttpServletRequestBuilder#buildRequest` on `foo` (with the injectable ServletContext)
4. Now invoke `MockMvc#perform` with `foo` as argument
5. You may end up with a 404 not found

TLDR: calling `buildRequest` twice on the `MockHttpServletRequestBuilder` is not safe. This pull request fixes this.