### PR TITLE
Nullability fixes for AtomicReference

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/buffer/OutputStreamPublisher.java
+++ b/spring-core/src/main/java/org/springframework/core/io/buffer/OutputStreamPublisher.java
@@ -137,7 +137,7 @@ final class OutputStreamPublisher<T> implements Publisher<T> {
 
 		private final AtomicLong requested = new AtomicLong();
 
-		private final AtomicReference<Object> parkedThread = new AtomicReference<>();
+		private final AtomicReference<@Nullable Object> parkedThread = new AtomicReference<>();
 
 		private volatile @Nullable Throwable error;
 

--- a/spring-core/src/main/java/org/springframework/core/io/buffer/SubscriberInputStream.java
+++ b/spring-core/src/main/java/org/springframework/core/io/buffer/SubscriberInputStream.java
@@ -72,7 +72,7 @@ final class SubscriberInputStream extends InputStream implements Subscriber<Data
 
 	private final Queue<DataBuffer> queue;
 
-	private final AtomicReference<Object> parkedThread = new AtomicReference<>();
+	private final AtomicReference<@Nullable Object> parkedThread = new AtomicReference<>();
 
 	private final AtomicInteger workAmount = new AtomicInteger();
 

--- a/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/SingleConnectionFactory.java
+++ b/spring-r2dbc/src/main/java/org/springframework/r2dbc/connection/SingleConnectionFactory.java
@@ -73,7 +73,7 @@ public class SingleConnectionFactory extends DelegatingConnectionFactory
 	private @Nullable Boolean autoCommit;
 
 	/** Wrapped Connection. */
-	private final AtomicReference<Connection> target = new AtomicReference<>();
+	private final AtomicReference<@Nullable Connection> target = new AtomicReference<>();
 
 	/** Proxy Connection. */
 	private @Nullable Connection connection;

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/DefaultMvcResult.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/DefaultMvcResult.java
@@ -54,7 +54,7 @@ class DefaultMvcResult implements MvcResult {
 
 	private @Nullable Exception resolvedException;
 
-	private final AtomicReference<Object> asyncResult = new AtomicReference<>(RESULT_NONE);
+	private final AtomicReference<@Nullable Object> asyncResult = new AtomicReference<>(RESULT_NONE);
 
 	private @Nullable CountDownLatch asyncDispatchLatch;
 

--- a/spring-web/src/main/java/org/springframework/http/client/OutputStreamPublisher.java
+++ b/spring-web/src/main/java/org/springframework/http/client/OutputStreamPublisher.java
@@ -135,7 +135,7 @@ final class OutputStreamPublisher<T> implements Flow.Publisher<T> {
 
 		private final AtomicLong requested = new AtomicLong();
 
-		private final AtomicReference<Object> parkedThread = new AtomicReference<>();
+		private final AtomicReference<@Nullable Object> parkedThread = new AtomicReference<>();
 
 		private volatile @Nullable Throwable error;
 

--- a/spring-web/src/main/java/org/springframework/http/client/ReactorClientHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/client/ReactorClientHttpRequest.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -131,13 +132,13 @@ final class ReactorClientHttpRequest extends AbstractStreamingClientHttpRequest 
 			return Mono.empty();
 		}
 
-		AtomicReference<Executor> executorRef = new AtomicReference<>();
+		AtomicReference<@Nullable Executor> executorRef = new AtomicReference<>();
 
 		return outbound
 				.withConnection(connection -> executorRef.set(connection.channel().eventLoop()))
 				.send(FlowAdapters.toPublisher(new OutputStreamPublisher<>(
 						os -> body.writeTo(StreamUtils.nonClosing(os)), new ByteBufMapper(outbound),
-						executorRef.getAndSet(null), null)));
+						Objects.requireNonNull(executorRef.getAndSet(null)), null)));
 	}
 
 	static IOException convertException(RuntimeException ex) {

--- a/spring-web/src/main/java/org/springframework/http/client/SubscriberInputStream.java
+++ b/spring-web/src/main/java/org/springframework/http/client/SubscriberInputStream.java
@@ -81,7 +81,7 @@ final class SubscriberInputStream<T> extends InputStream implements Flow.Subscri
 
 	private final Queue<T> queue;
 
-	private final AtomicReference<Object> parkedThread = new AtomicReference<>();
+	private final AtomicReference<@Nullable Object> parkedThread = new AtomicReference<>();
 
 	private final AtomicInteger workAmount = new AtomicInteger();
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ReactiveTypeHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ReactiveTypeHandler.java
@@ -256,7 +256,7 @@ class ReactiveTypeHandler {
 
 		private @Nullable Subscription subscription;
 
-		private final AtomicReference<Object> elementRef = new AtomicReference<>();
+		private final AtomicReference<@Nullable Object> elementRef = new AtomicReference<>();
 
 		private @Nullable Throwable error;
 


### PR DESCRIPTION
Make the contents of some `AtomicReference` variables `@Nullable`.  This is in preparation for uber/NullAway#1298 which causes new errors to be reported for these variables.  
