### PR TITLE
Fix NoClassDefFoundError when kotlin-reflect is missing from classpath

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/BeanUtils.java
@@ -69,6 +69,7 @@ import org.springframework.util.StringUtils;
  * @author Rob Harrop
  * @author Sam Brannen
  * @author Sebastien Deleuze
+ * @author Wonyong Hwang
  */
 public abstract class BeanUtils {
 
@@ -186,7 +187,7 @@ public abstract class BeanUtils {
 		Assert.notNull(ctor, "Constructor must not be null");
 		try {
 			ReflectionUtils.makeAccessible(ctor);
-			if (KotlinDetector.isKotlinType(ctor.getDeclaringClass())) {
+			if (KotlinDetector.isKotlinType(ctor.getDeclaringClass()) && KotlinDetector.isKotlinReflectPresent()) {
 				return KotlinDelegate.instantiateClass(ctor, args);
 			}
 			else {
@@ -279,7 +280,7 @@ public abstract class BeanUtils {
 	 */
 	public static <T> @Nullable Constructor<T> findPrimaryConstructor(Class<T> clazz) {
 		Assert.notNull(clazz, "Class must not be null");
-		if (KotlinDetector.isKotlinType(clazz)) {
+		if (KotlinDetector.isKotlinType(clazz) && KotlinDetector.isKotlinReflectPresent()) {
 			return KotlinDelegate.findPrimaryConstructor(clazz);
 		}
 		if (clazz.isRecord()) {

--- a/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/BeanUtilsTests.java
@@ -61,6 +61,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
  * @author Chris Beams
  * @author Sebastien Deleuze
  * @author Sam Brannen
+ * @author Wonyong Hwang
  * @since 19.05.2003
  */
 class BeanUtilsTests {
@@ -531,6 +532,20 @@ class BeanUtilsTests {
 	void resolveMultipleRecordePackagePrivateConstructor() throws NoSuchMethodException {
 		assertThat(BeanUtils.getResolvableConstructor(RecordWithMultiplePackagePrivateConstructors.class))
 				.isEqualTo(RecordWithMultiplePackagePrivateConstructors.class.getDeclaredConstructor(String.class, String.class));
+	}
+
+	@Test
+	void instantiateClassWithJavaTypeWorksNormally() throws NoSuchMethodException {
+		Constructor<TestBean> ctor = TestBean.class.getDeclaredConstructor();
+		TestBean instance = BeanUtils.instantiateClass(ctor);
+		assertThat(instance).isNotNull();
+		assertThat(instance.getClass()).isEqualTo(TestBean.class);
+	}
+
+	@Test
+	void findPrimaryConstructorWithJavaTypeReturnsNull() {
+		Constructor<?> primaryConstructor = BeanUtils.findPrimaryConstructor(TestBean.class);
+		assertThat(primaryConstructor).isNull();
 	}
 
 	private void assertSignatureEquals(Method desiredMethod, String signature) {

--- a/spring-beans/src/test/kotlin/org/springframework/beans/BeanUtilsKotlinTests.kt
+++ b/spring-beans/src/test/kotlin/org/springframework/beans/BeanUtilsKotlinTests.kt
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test
  * Kotlin tests for [BeanUtils].
  * 
  * @author Sebastien Deleuze
+ * @author Wonyong Hwang
  */
 @Suppress("unused", "UNUSED_PARAMETER")
 class BeanUtilsKotlinTests {
@@ -192,6 +193,20 @@ class BeanUtilsKotlinTests {
 		assertThat(names).isEmpty()
 	}
 
+	@Test
+	fun `instantiateClass with Kotlin type works correctly`() {
+		val ctor = Foo::class.java.getDeclaredConstructor(String::class.java, Int::class.java)
+		val foo = BeanUtils.instantiateClass(ctor, "test", 42)
+		assertThat(foo.param1).isEqualTo("test")
+		assertThat(foo.param2).isEqualTo(42)
+	}
+
+	@Test
+	fun `findPrimaryConstructor with Kotlin type works correctly`() {
+		val primaryConstructor = BeanUtils.findPrimaryConstructor(Foo::class.java)
+		assertThat(primaryConstructor).isNotNull()
+		assertThat(primaryConstructor!!.parameterCount).isEqualTo(2)
+	}
 
 	class Foo(val param1: String, val param2: Int)
 


### PR DESCRIPTION
This pull request addresses the issue described in #35511


## Changes
Added `KotlinDetector.isKotlinReflectPresent()` checks before using `KotlinDelegate`:

1. **`BeanUtils.instantiateClass(Constructor, Object...)`**: Now checks both `isKotlinType()` and `isKotlinReflectPresent()` before delegating to `KotlinDelegate`
2. **`BeanUtils.findPrimaryConstructor(Class)`**: Same check added for consistency

When `kotlin-reflect` is not available, the methods fall back to regular Java instantiation instead of throwing `NoClassDefFoundError`.

## Testing

- All existing tests pass
- Added new test cases covering both Java and Kotlin scenarios
- Verified that existing Kotlin functionality still works when kotlin-reflect is present

## Testing without kotlin-reflect
To simulate an environment without kotlin-reflect, I added the following configuration locally:
```md
configurations {
    testWithoutKotlinReflect {
        extendsFrom testRuntimeClasspath
        exclude group: "org.jetbrains.kotlin", module: "kotlin-reflect"
    }
}
```

Using this setup, I confirmed that the code behaves correctly and falls back without errors.

This configuration was used for local verification only and is not part of the commit. If integrating this scenario into the test suite is desirable, I would appreciate your guidance, as I’m not sure how to approach it.