### PR TITLE
  Fix ByteBuffer concurrency issue in ConcurrentWebSocketSessionDecorator for binary messages

### DIFF
--- a/spring-websocket/src/main/java/org/springframework/web/socket/handler/ConcurrentWebSocketSessionDecorator.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/handler/ConcurrentWebSocketSessionDecorator.java
@@ -17,6 +17,7 @@
 package org.springframework.web.socket.handler;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -28,6 +29,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.web.socket.BinaryMessage;
 import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.WebSocketMessage;
 import org.springframework.web.socket.WebSocketSession;
@@ -43,6 +45,7 @@ import org.springframework.web.socket.WebSocketSession;
  *
  * @author Rossen Stoyanchev
  * @author Juergen Hoeller
+ * @author xeroman.k
  * @since 4.0.3
  */
 public class ConcurrentWebSocketSessionDecorator extends WebSocketSessionDecorator {
@@ -170,7 +173,7 @@ public class ConcurrentWebSocketSessionDecorator extends WebSocketSessionDecorat
 			if (!tryFlushMessageBuffer()) {
 				if (logger.isTraceEnabled()) {
 					logger.trace(String.format("Another send already in progress: " +
-							"session id '%s':, \"in-progress\" send time %d (ms), buffer size %d bytes",
+									"session id '%s':, \"in-progress\" send time %d (ms), buffer size %d bytes",
 							getId(), getTimeSinceSendStarted(), getBufferSize()));
 				}
 				checkSessionLimits();
@@ -194,7 +197,7 @@ public class ConcurrentWebSocketSessionDecorator extends WebSocketSessionDecorat
 					}
 					this.bufferSize.addAndGet(-message.getPayloadLength());
 					this.sendStartTime = System.currentTimeMillis();
-					getDelegate().sendMessage(message);
+					getDelegate().sendMessage(prepareMessage(message));
 					this.sendStartTime = 0;
 				}
 			}
@@ -205,6 +208,14 @@ public class ConcurrentWebSocketSessionDecorator extends WebSocketSessionDecorat
 			return true;
 		}
 		return false;
+	}
+
+	private WebSocketMessage<?> prepareMessage(WebSocketMessage<?> message) {
+		if (message instanceof BinaryMessage) {
+			ByteBuffer payload = ((BinaryMessage) message).getPayload();
+			return new BinaryMessage(payload.duplicate(), message.isLast());
+		}
+		return message;
 	}
 
 	private void checkSessionLimits() {
@@ -238,7 +249,7 @@ public class ConcurrentWebSocketSessionDecorator extends WebSocketSessionDecorat
 						}
 						default ->
 							// Should never happen..
-							throw new IllegalStateException("Unexpected OverflowStrategy: " + this.overflowStrategy);
+								throw new IllegalStateException("Unexpected OverflowStrategy: " + this.overflowStrategy);
 					}
 				}
 			}


### PR DESCRIPTION
For reference, I'm not good at English, so I wrote this message using a translator. Please understand if my expressions are a bit awkward or if there are any issues.

## 📝 Summary

With Spring's growing adoption of **virtual threads (Project Loom)**, concurrency levels in applications have increased dramatically. This exposed a critical thread-safety issue in `ConcurrentWebSocketSessionDecorator` when handling binary messages.

**The Problem**: When multiple threads send the same `BinaryMessage` to different WebSocket sessions, they share a single `ByteBuffer` whose position gets corrupted during concurrent reads, resulting in data corruption or empty messages.

**Why This Is a Trap**: Developers using binary messages might not be aware that `ByteBuffer`'s position is mutable state. It's natural to assume that sending the same message to multiple sessions is safe - after all, we're just "reading" the data. This hidden implementation detail makes this bug easy to accidentally introduce and particularly challenging to diagnose.

I was also unaware of this implementation detail and only discovered it after spending two days debugging in production when concurrency levels increased dramatically. I hope this fix saves others from the same frustrating experience.

## 🔄 Changes

- Added `prepareMessage()` method to handle message preparation
- Use `ByteBuffer.duplicate()` for `BinaryMessage` to ensure thread-safe position tracking
- Each thread now gets its own independent buffer position while sharing underlying data

```java
private WebSocketMessage<?> prepareMessage(WebSocketMessage<?> message) {
    if (message instanceof BinaryMessage) {
        ByteBuffer payload = ((BinaryMessage) message).getPayload();
        return new BinaryMessage(payload.duplicate(), message.isLast());
    }
    return message;
}
```

## ✅ Testing

Added test `concurrentBinaryMessageSharingAcrossSessions()` that reproduces the issue and validates the fix.

- **Without fix**: Test fails with corrupted buffers
- **With fix**: All messages delivered correctly

## 📊 Impact

- **Performance**: Minimal - only creates buffer wrapper, no data copying
- **Compatibility**: Fully backwards compatible
- **Virtual Threads**: Essential for applications using virtual threads with high concurrency

## 🏗️ Why Fix in ConcurrentWebSocketSessionDecorator?

You might wonder why this fix was implemented in `ConcurrentWebSocketSessionDecorator` rather than the base `AbstractWebSocketSession`. The reasoning is architectural:

- **Blocking I/O Handles This Differently**: In traditional blocking I/O implementations (like Tomcat's `WsRemoteEndpointImplBase`), the `sendMessageBlockInternal` method calls `payload.clear()` after sending, resetting the buffer position. This automatic reset prevents position conflicts when reusing the same `BinaryMessage` in sequential operations.

- **Concurrent Decorator's Purpose**: `ConcurrentWebSocketSessionDecorator` was specifically designed to handle concurrent access scenarios. When multiple threads access the same message concurrently, there's no automatic buffer reset between operations. It's the appropriate layer to address these concurrency-related ByteBuffer position conflicts.

- **Separation of Concerns**: Keeping the fix in the decorator maintains clean separation - the base session handles core functionality while the decorator handles thread-safety concerns. The base implementation can rely on the underlying WebSocket container's behavior (like Tomcat's buffer clearing), while the decorator ensures safety in concurrent scenarios.

This design choice ensures the fix is applied exactly where it's needed - in concurrent scenarios - without adding overhead to single-threaded use cases where the container already handles buffer state management.

## 🎯 Why This Matters Now

As Spring applications increasingly adopt virtual threads:
- Concurrency levels can reach thousands of concurrent operations
- Traditional thread-safety assumptions may no longer hold
- Subtle race conditions become more prevalent

This fix ensures WebSocket handling remains robust in the virtual thread era.

---

**Note**: This issue only manifests under high concurrency, particularly with virtual threads, making it challenging to detect in traditional testing scenarios.