### PR TITLE
Add `serialVersionUID` in `LinkedCaseInsensitiveMap`

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/LinkedCaseInsensitiveMap.java
+++ b/spring-core/src/main/java/org/springframework/util/LinkedCaseInsensitiveMap.java
@@ -44,11 +44,13 @@ import org.jspecify.annotations.Nullable;
  *
  * @author Juergen Hoeller
  * @author Phillip Webb
+ * @author Yanming Zhou
  * @since 3.0
  * @param <V> the value type
  */
-@SuppressWarnings("serial")
 public class LinkedCaseInsensitiveMap<V> implements Map<String, V>, Serializable, Cloneable {
+
+	private static final long serialVersionUID = -1797561627545787622L;
 
 	private final LinkedHashMap<String, V> targetMap;
 


### PR DESCRIPTION
It's common to cache result of `JdbcTemplate::queryForMap` which is type of `LinkedCaseInsensitiveMap`, and Spring Cache Abstraction use Java serialization by default which rely on `serialVersionUID`.