### PR TITLE
Improve the deprecation experience for ContentResultMatchersDsl.json

### DIFF
--- a/spring-test/src/main/kotlin/org/springframework/test/web/servlet/result/ContentResultMatchersDsl.kt
+++ b/spring-test/src/main/kotlin/org/springframework/test/web/servlet/result/ContentResultMatchersDsl.kt
@@ -113,7 +113,13 @@ class ContentResultMatchersDsl internal constructor (private val actions: Result
 	/**
 	 * @see ContentResultMatchers.json
 	 */
-	@Deprecated(message = "Use JsonCompare mode instead")
+	@Deprecated(
+		message = "Use JsonCompare mode instead",
+		replaceWith = ReplaceWith(
+			expression = "json(jsonContent, if (strict) JsonCompareMode.STRICT else JsonCompareMode.LENIENT)",
+			imports = ["org.springframework.test.json.JsonCompareMode"],
+		),
+	)
 	fun json(jsonContent: String, strict: Boolean) {
 		val compareMode = (if (strict) JsonCompareMode.STRICT else JsonCompareMode.LENIENT)
 		actions.andExpect(matchers.json(jsonContent, compareMode))


### PR DESCRIPTION
## Problem Statement

It can be tedious to fix all of the deprecation warnings you get from using `json(jsonContent, strict = true)`. It's not as easy as a find-and-replace, because it requires an import. Also, in my experience, an AI agent will be extremely likely to mess it up somehow (at least Copilot on a large project).

## Solution

The Kotlin `@Deprecation` annotation has support for automatically replacing deprecated code with the new, supported code. I have modified the annotation on this method so that users can automatically upgrade.

## Testing evidence

Here are some screenshots showing how this works in Intellij Idea:

1. Original deprecated code.
<img width="469" height="232" alt="Screenshot From 2025-09-25 10-27-43" src="https://github.com/user-attachments/assets/d035343a-e96e-4386-8c98-f56af4015ee4" />

2. The deprecation message now has a button you can click to replace the code.
<img width="1140" height="456" alt="Screenshot From 2025-09-25 10-27-52" src="https://github.com/user-attachments/assets/e668ea88-9c6b-4d52-8d6a-bc3cb187c9f3" />

3. After performing the automatic replacement. Note that the code compiles, but has a warning.
<img width="736" height="232" alt="Screenshot From 2025-09-25 10-28-05" src="https://github.com/user-attachments/assets/8dc144a3-a1cc-4934-aa47-e4fe84e543e1" />

4. Intellij offers to automatically fix the warning. This can be applied to the entire file or project at once if there are multiple occurrences.
<img width="771" height="232" alt="Screenshot From 2025-09-25 10-28-18" src="https://github.com/user-attachments/assets/ab9ce6bb-99b8-497a-9553-aa1e0c315b56" />

5. Done.
<img width="466" height="232" alt="Screenshot From 2025-09-25 10-28-29" src="https://github.com/user-attachments/assets/f7fec8bc-092c-44da-8bfa-c8269589ccf4" />

