### PR TITLE
refactor(messaging): remove redundant else blocks after early return

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/core/AbstractMessageReceivingTemplate.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/core/AbstractMessageReceivingTemplate.java
@@ -57,9 +57,8 @@ public abstract class AbstractMessageReceivingTemplate<D> extends AbstractMessag
 		if (message != null) {
 			return doConvert(message, targetClass);
 		}
-		else {
-			return null;
-		}
+
+		return null;
 	}
 
 	/**

--- a/spring-messaging/src/main/java/org/springframework/messaging/core/GenericMessagingTemplate.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/core/GenericMessagingTemplate.java
@@ -263,9 +263,8 @@ public class GenericMessagingTemplate extends AbstractDestinationResolvingMessag
 		else if (headerValue instanceof String text) {
 			return Long.parseLong(text);
 		}
-		else {
-			return null;
-		}
+
+		return null;
 	}
 
 


### PR DESCRIPTION
This PR simplifies control flow by removing redundant `else` blocks that follow early `return` statements in `org.springframework.messaging.core`.

Files:
- AbstractMessageReceivingTemplate.receiveAndConvert
- GenericMessagingTemplate.headerToLong

Built locally with :spring-messaging:check.