### PR TITLE
Make StringUtils::pathEquals Null-Safe

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -825,7 +825,7 @@ public abstract class StringUtils {
 	 * @return whether the two paths are equivalent after normalization
 	 */
 	public static boolean pathEquals(String path1, String path2) {
-		return (path1 == null || path2 == null) ? false : cleanPath(path1).equals(cleanPath(path2));
+		return (path1 != null && path2 != null) && cleanPath(path1).equals(cleanPath(path2));
 	}
 
 	/**

--- a/spring-core/src/main/java/org/springframework/util/StringUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/StringUtils.java
@@ -818,13 +818,14 @@ public abstract class StringUtils {
 	}
 
 	/**
-	 * Compare two paths after normalization of them.
+	 * Compare two paths after normalization of them. Results in false if any or both of
+	 * the supplied path values are {@code null}.
 	 * @param path1 first path for comparison
 	 * @param path2 second path for comparison
 	 * @return whether the two paths are equivalent after normalization
 	 */
 	public static boolean pathEquals(String path1, String path2) {
-		return cleanPath(path1).equals(cleanPath(path2));
+		return (path1 == null || path2 == null) ? false : cleanPath(path1).equals(cleanPath(path2));
 	}
 
 	/**

--- a/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/StringUtilsTests.java
@@ -448,6 +448,9 @@ class StringUtilsTests {
 		assertThat(StringUtils.pathEquals("/dummy1/bin/tmp/../dummy2/dummy3", "/dummy1/dummy2/dummy3")).as("Must be false for one false path on 1").isFalse();
 		assertThat(StringUtils.pathEquals("C:\\dummy1\\dummy2\\dummy3", "C:\\dummy1\\bin\\tmp\\..\\dummy2\\dummy3")).as("Must be false for one false win top path on 2").isFalse();
 		assertThat(StringUtils.pathEquals("/dummy1/bin/../dummy2/dummy3", "/dummy1/dummy2/dummy4")).as("Must be false for top path on 1 + difference").isFalse();
+		assertThat(StringUtils.pathEquals(null, null)).as("Must be false for both null parameters").isFalse();
+		assertThat(StringUtils.pathEquals(null, "/dummy1/dummy2/dummy3")).as("Must be false for first null parameter").isFalse();
+		assertThat(StringUtils.pathEquals("/dummy1/dummy2/dummy3", null)).as("Must be false for second null parameter").isFalse();
 	}
 
 	@Test


### PR DESCRIPTION
This PR introduces a tiny patch for the method `StringUtils.pathEquals()` that short-circuits into a `false` result if any or both of the parameters of path are `null`. This aims to prevent a `NullPointerException` when `cleanPath()` returns `null` when the supplied path String does not have any length.