### PR TITLE
Retain order of `produces` media types in `@ExceptionHandler`

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/method/annotation/ExceptionHandlerMethodResolver.java
+++ b/spring-web/src/main/java/org/springframework/web/method/annotation/ExceptionHandlerMethodResolver.java
@@ -21,7 +21,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -121,7 +121,7 @@ public class ExceptionHandlerMethodResolver {
 		if (exceptions.isEmpty()) {
 			throw new IllegalStateException("No exception types mapped to " + method);
 		}
-		Set<MediaType> mediaTypes = new HashSet<>();
+		Set<MediaType> mediaTypes = new LinkedHashSet<>();
 		for (String mediaType : exceptionHandler.produces()) {
 			try {
 				mediaTypes.add(MediaType.parseMediaType(mediaType));

--- a/spring-web/src/test/java/org/springframework/web/method/annotation/ExceptionHandlerMethodResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/method/annotation/ExceptionHandlerMethodResolverTests.java
@@ -118,6 +118,13 @@ class ExceptionHandlerMethodResolverTests {
 	}
 
 	@Test
+	void shouldKeepProduceMediaTypesOrder() {
+		ExceptionHandlerMethodResolver resolver = new ExceptionHandlerMethodResolver(MediaTypeController.class);
+		assertThat(resolver.resolveExceptionMapping(new IllegalArgumentException(), MediaType.TEXT_HTML).getProducibleTypes().toString()).isEqualTo("[text/html, */*]");
+	}
+	
+	
+	@Test
 	void shouldResolveMethodWithCompatibleMediaType() {
 		ExceptionHandlerMethodResolver resolver = new ExceptionHandlerMethodResolver(MediaTypeController.class);
 		assertThat(resolver.resolveExceptionMapping(new IllegalArgumentException(), MediaType.parseMediaType("application/*")).getHandlerMethod().getName()).isEqualTo("handleJson");


### PR DESCRIPTION
Fix error when corrupt order of `produces` media types for `@ExceptionHandler`.

For example, the following returns xml by default.

```java
@ExceptionHandler(exception = Exception.class,
    produces = {"application/json", "application/xml"})
```

