### PR TITLE
Fix non-pattern package prefix check in `CandidateComponentsIndex`

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/index/CandidateComponentsIndex.java
+++ b/spring-context/src/main/java/org/springframework/context/index/CandidateComponentsIndex.java
@@ -150,7 +150,7 @@ public class CandidateComponentsIndex {
 			return pathMatcher.match(basePackage, packageName);
 		}
 		else {
-			return packageName.startsWith(basePackage);
+			return packageName.equals(basePackage) || packageName.startsWith(basePackage + ".");
 		}
 	}
 


### PR DESCRIPTION
the non-pattern package prefix check uses packageName.startsWith(basePackage) which incorrectly treats "com.example2.foo" as a subpackage of "com.example"