### PR TITLE
Introduce `queryParamPredicate` in `AbstractRequestLoggingFilter`

### DIFF
--- a/spring-web/src/test/java/org/springframework/web/filter/RequestLoggingFilterTests.java
+++ b/spring-web/src/test/java/org/springframework/web/filter/RequestLoggingFilterTests.java
@@ -108,13 +108,14 @@ class RequestLoggingFilterTests {
 
 	@Test
 	void queryStringIncluded() throws Exception {
-		request.setQueryString("booking=42");
+		request.setQueryString("booking=42&code=73&category=hotel&code=37&category=resort");
 		filter.setIncludeQueryString(true);
+		filter.setQueryParamPredicate(name -> !name.equals("code") && !name.equals("ignore"));
 
 		applyFilter();
 
-		assertThat(filter.beforeRequestMessage).contains("/hotels?booking=42");
-		assertThat(filter.afterRequestMessage).contains("/hotels?booking=42");
+		assertThat(filter.beforeRequestMessage).contains("/hotels?booking=42&code=masked&category=hotel&category=resort");
+		assertThat(filter.afterRequestMessage).contains("/hotels?booking=42&code=masked&category=hotel&category=resort");
 	}
 
 	@Test


### PR DESCRIPTION
Addresses:
* https://github.com/spring-projects/spring-framework/issues/35596

These changes add a `queryParamPredicate` to the `AbstractRequestLoggingFilter`, similar to the `headerPredicate`.

This can be used to mask given query params.