### PR TITLE
Introduce `shouldFilter` flag in `OncePerRequestFilter`

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/filter/OncePerRequestFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/OncePerRequestFilter.java
@@ -121,7 +121,8 @@ public abstract class OncePerRequestFilter extends GenericFilterBean {
 				// Remove the "already filtered" request attribute for this request.
 				request.removeAttribute(alreadyFilteredAttributeName);
 			}
-		} else {
+		}
+		else {
 			// Proceed without invoking this filter...
 			filterChain.doFilter(request, response);
 		}

--- a/spring-web/src/main/java/org/springframework/web/filter/OncePerRequestFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/OncePerRequestFilter.java
@@ -121,6 +121,9 @@ public abstract class OncePerRequestFilter extends GenericFilterBean {
 				// Remove the "already filtered" request attribute for this request.
 				request.removeAttribute(alreadyFilteredAttributeName);
 			}
+		} else {
+			// Proceed without invoking this filter...
+			filterChain.doFilter(request, response);
 		}
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/filter/OncePerRequestFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/OncePerRequestFilter.java
@@ -65,6 +65,7 @@ import org.springframework.web.util.WebUtils;
  * @author Juergen Hoeller
  * @author Rossen Stoyanchev
  * @author Sam Brannen
+ * @author Simone Conte
  * @since 06.12.2003
  */
 public abstract class OncePerRequestFilter extends GenericFilterBean {
@@ -83,6 +84,7 @@ public abstract class OncePerRequestFilter extends GenericFilterBean {
 	 * attribute is already there.
 	 * @see #getAlreadyFilteredAttributeName
 	 * @see #shouldNotFilter
+	 * @see #shouldFilter
 	 * @see #doFilterInternal
 	 */
 	@Override
@@ -109,7 +111,7 @@ public abstract class OncePerRequestFilter extends GenericFilterBean {
 			// Proceed without invoking this filter...
 			filterChain.doFilter(request, response);
 		}
-		else {
+		else if (shouldFilter(httpRequest)) {
 			// Do invoke this filter...
 			request.setAttribute(alreadyFilteredAttributeName, Boolean.TRUE);
 			try {
@@ -171,6 +173,24 @@ public abstract class OncePerRequestFilter extends GenericFilterBean {
 			name = getClass().getName();
 		}
 		return name + ALREADY_FILTERED_SUFFIX;
+	}
+
+	/**
+	 * Can be overridden in subclasses for custom filtering control,
+	 * returning {@code true} to allow filtering of the given request.
+	 * <p>This method is called after {@link #shouldNotFilter(HttpServletRequest)}
+	 * and only if that method returns {@code false}. Both methods provide
+	 * complementary ways to control filter execution.
+	 * <p>The default implementation always returns {@code true}, meaning
+	 * all requests will be filtered unless explicitly excluded by
+	 * {@link #shouldNotFilter(HttpServletRequest)}.
+	 * @param request current HTTP request
+	 * @return whether the given request should be filtered
+	 * @throws ServletException in case of errors
+	 * @since 7.0
+	 */
+	protected boolean shouldFilter(HttpServletRequest request) throws ServletException {
+		return true;
 	}
 
 	/**

--- a/spring-web/src/test/java/org/springframework/web/filter/OncePerRequestFilterTests.java
+++ b/spring-web/src/test/java/org/springframework/web/filter/OncePerRequestFilterTests.java
@@ -135,9 +135,11 @@ class OncePerRequestFilterTests {
 		return Stream.of(
 				Arguments.of("/skip", false),
 				Arguments.of("/skip/something", false),
+				Arguments.of("//skip", true),
 				Arguments.of("", true),
 				Arguments.of("/", true),
-				Arguments.of("/do_not_skip", true)
+				Arguments.of("/do_not_skip", true),
+				Arguments.of("//do_not_skip", true)
 		);
 	}
 
@@ -157,9 +159,12 @@ class OncePerRequestFilterTests {
 		return Stream.of(
 				Arguments.of("/skip", false),
 				Arguments.of("/skip/something", false),
+				Arguments.of("//skip", false),
 				Arguments.of("", false),
 				Arguments.of("/", false),
-				Arguments.of("/do_not_skip", true)
+				Arguments.of("/do_not_skip", true),
+				Arguments.of("//do_not_skip", false),
+				Arguments.of("/do_not_skip/something", true)
 		);
 	}
 

--- a/spring-web/src/test/java/org/springframework/web/filter/OncePerRequestFilterTests.java
+++ b/spring-web/src/test/java/org/springframework/web/filter/OncePerRequestFilterTests.java
@@ -37,6 +37,9 @@ import org.springframework.web.testfixture.servlet.MockHttpServletResponse;
 import org.springframework.web.util.WebUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * Tests for {@link OncePerRequestFilter}.
@@ -121,14 +124,18 @@ class OncePerRequestFilterTests {
 
 	@ParameterizedTest
 	@MethodSource
-	public void shouldNotFilterForUri(String uri, boolean shouldFilter) throws ServletException, IOException {
+	public void shouldNotFilterForUri(String uri, boolean shouldFilterInternal) throws ServletException, IOException {
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockFilterChain filterChain = spy(new MockFilterChain(new HttpServlet() {}));
+
 		ShouldNotFilterRequestFilter filter = new ShouldNotFilterRequestFilter();
 
 		this.request.setRequestURI(uri);
 
-		filter.doFilter(this.request, new MockHttpServletResponse(), this.filterChain);
+		filter.doFilter(this.request, response, filterChain);
 
-		assertThat(filter.didFilter).isEqualTo(shouldFilter);
+		assertThat(filter.didFilter).isEqualTo(shouldFilterInternal);
+		verify(filterChain, times(shouldFilterInternal ? 0 : 1)).doFilter(this.request, response);
 	}
 
 	static Stream<Arguments> shouldNotFilterForUri() {
@@ -145,14 +152,18 @@ class OncePerRequestFilterTests {
 
 	@ParameterizedTest
 	@MethodSource
-	public void shouldFilterForUri(String uri, boolean shouldFilter) throws ServletException, IOException {
+	public void shouldFilterForUri(String uri, boolean shouldFilterInternal) throws ServletException, IOException {
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		MockFilterChain filterChain = spy(new MockFilterChain(new HttpServlet() {}));
+
 		ShouldFilterRequestFilter filter = new ShouldFilterRequestFilter();
 
 		this.request.setRequestURI(uri);
 
-		filter.doFilter(this.request, new MockHttpServletResponse(), this.filterChain);
+		filter.doFilter(this.request, response, filterChain);
 
-		assertThat(filter.didFilter).isEqualTo(shouldFilter);
+		assertThat(filter.didFilter).isEqualTo(shouldFilterInternal);
+		verify(filterChain, times(shouldFilterInternal ? 0 : 1)).doFilter(this.request, response);
 	}
 
 	static Stream<Arguments> shouldFilterForUri() {

--- a/spring-web/src/test/java/org/springframework/web/filter/OncePerRequestFilterTests.java
+++ b/spring-web/src/test/java/org/springframework/web/filter/OncePerRequestFilterTests.java
@@ -17,6 +17,7 @@
 package org.springframework.web.filter;
 
 import java.io.IOException;
+import java.util.stream.Stream;
 
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.FilterChain;
@@ -24,13 +25,12 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
 import org.springframework.web.testfixture.servlet.MockFilterChain;
 import org.springframework.web.testfixture.servlet.MockHttpServletRequest;
 import org.springframework.web.testfixture.servlet.MockHttpServletResponse;


### PR DESCRIPTION
The introduction of `shouldFilter` allows for intentional filtering.

Usage example:
```java
public class BookingsFilter extends OncePerRequestFilter {

    @Override
    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
				FilterChain filterChain) { ... }

    @Override
    protected boolean shouldFilter(HttpServletRequest request) throws ServletException {
        return request.getRequestURI().startsWith("/booking");
    }
}
```

Closes gh-35605