### PR TITLE
Fix code snippets in Javadoc for `exchangeSuccessfully()`

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
@@ -709,7 +709,7 @@ public interface WebTestClient {
 		 * Variant of {@link #exchange()} that expects a successful response.
 		 * Effectively, a shortcut for:
 		 * <pre class="code">
-		 * exchange().is2xxSuccessful()
+		 * exchange().expectStatus().is2xxSuccessful()
 		 * </pre>
 		 * @return a spec for expectations on the response
 		 * @since 7.0

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/RestTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/RestTestClient.java
@@ -523,7 +523,7 @@ public interface RestTestClient {
 		 * Variant of {@link #exchange()} that expects a successful response.
 		 * Effectively, a shortcut for:
 		 * <pre class="code">
-		 * exchange().is2xxSuccessful()
+		 * exchange().expectStatus().is2xxSuccessful()
 		 * </pre>
 		 * @return a spec for expectations on the response
 		 */


### PR DESCRIPTION
You can verify that the code snippets are incorrect by comparing them with the [method implementations](https://github.com/spring-projects/spring-framework/commit/00190a1111535fd7302a60e4c8d314344a14198a)
