### PR TITLE
Fix `@Import` with multiple bean registrars

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassParser.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/ConfigurationClassParser.java
@@ -615,7 +615,7 @@ class ConfigurationClassParser {
 						if (registrar instanceof ImportAware importAware) {
 							importAware.setImportMetadata(metadata);
 						}
-						configClass.addBeanRegistrar(metadata.getClassName(), registrar);
+						configClass.addBeanRegistrar(candidateClass.getName(), registrar);
 					}
 					else if (candidate.isAssignable(ImportBeanDefinitionRegistrar.class)) {
 						// Candidate class is an ImportBeanDefinitionRegistrar ->

--- a/spring-context/src/test/java/org/springframework/context/annotation/ConfigurationClassPostProcessorAotContributionTests.java
+++ b/spring-context/src/test/java/org/springframework/context/annotation/ConfigurationClassPostProcessorAotContributionTests.java
@@ -511,7 +511,7 @@ public class ConfigurationClassPostProcessorAotContributionTests {
 				initializer.accept(freshContext);
 				freshContext.refresh();
 				assertThat(freshContext.getBean(ClassNameHolder.class).className())
-						.isEqualTo(ImportAwareBeanRegistrarConfiguration.class.getName());
+						.isEqualTo(ImportAwareBeanRegistrar.class.getName());
 				freshContext.close();
 			});
 		}

--- a/spring-context/src/test/kotlin/org/springframework/context/annotation/BeanRegistrarDslConfigurationTests.kt
+++ b/spring-context/src/test/kotlin/org/springframework/context/annotation/BeanRegistrarDslConfigurationTests.kt
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.InitializingBean
 import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.beans.factory.config.BeanDefinition
 import org.springframework.beans.factory.getBean
+import org.springframework.beans.factory.getBeanProvider
 import org.springframework.beans.factory.support.RootBeanDefinition
 import org.springframework.mock.env.MockEnvironment
 import java.util.function.Supplier
@@ -77,6 +78,13 @@ class BeanRegistrarDslConfigurationTests {
 		assertThat(context.getBean<Bar>().foo).isEqualTo(context.getBean<Foo>())
 	}
 
+	@Test
+	fun multipleBeanRegistrar() {
+		val context = AnnotationConfigApplicationContext(MultipleBeanRegistrarKotlinConfiguration::class.java)
+		assertThat(context.getBeanProvider<Foo>().singleOrNull()).isNotNull
+		assertThat(context.getBeanProvider<Bar>().singleOrNull()).isNotNull
+	}
+
 	class Foo
 	data class Bar(val foo: Foo)
 	data class Baz(val message: String = "")
@@ -89,6 +97,18 @@ class BeanRegistrarDslConfigurationTests {
 		}
 
 	}
+
+	@Configuration
+	@Import(value = [FooRegistrar::class, BarRegistrar::class])
+	internal class MultipleBeanRegistrarKotlinConfiguration
+
+	private class FooRegistrar : BeanRegistrarDsl({
+		registerBean<Foo>()
+	})
+
+	private class BarRegistrar : BeanRegistrarDsl({
+		registerBean<Bar>()
+	})
 
 	@Configuration
 	@Import(SampleBeanRegistrar::class)


### PR DESCRIPTION
fix ConfigurationClassParser so that `@Import`ed BeanRegistrars use their own class name rather than the class they are imported to

This allows multiple BeanRegistrars to be imported from the same Configuration class

fixes #35652