### PR TITLE
Fix typos

### DIFF
--- a/spring-beans/src/test/java/org/springframework/beans/AbstractPropertyAccessorTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/AbstractPropertyAccessorTests.java
@@ -472,7 +472,7 @@ abstract class AbstractPropertyAccessorTests {
 		assertThat(target.getAge()).as("age is OK").isEqualTo(age);
 		assertThat(name).as("name is OK").isEqualTo(target.getName());
 		accessor.setPropertyValues(new MutablePropertyValues());
-		// Check its unchanged
+		// Check it's unchanged
 		assertThat(target.getAge()).as("age is OK").isEqualTo(age);
 		assertThat(name).as("name is OK").isEqualTo(target.getName());
 	}

--- a/spring-core/src/main/java/org/springframework/cglib/proxy/BridgeMethodResolver.java
+++ b/spring-core/src/main/java/org/springframework/cglib/proxy/BridgeMethodResolver.java
@@ -110,7 +110,7 @@ class BridgeMethodResolver {
                                 && currentMethod != null) {
                             Signature target = new Signature(name, desc);
                             // If the target signature is the same as the current,
-                            // we shouldn't change our bridge becaues invokespecial
+                            // we shouldn't change our bridge because invokespecial
                             // is the only way to make progress (otherwise we'll
                             // get infinite recursion).  This would typically
                             // only happen when a bridge method is created to widen

--- a/spring-core/src/main/java/org/springframework/core/codec/Hints.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/Hints.java
@@ -50,7 +50,7 @@ public abstract class Hints {
 
 
 	/**
-	 * Create a map wit a single hint via {@link Collections#singletonMap}.
+	 * Create a map with a single hint via {@link Collections#singletonMap}.
 	 * @param hintName the hint name
 	 * @param value the hint value
 	 * @return the created map


### PR DESCRIPTION
This pull request fixes a few minor typos found in source code comments.

- `its` -> `it's` in `AbstractPropertyAccessorTests.java`
- `becaues` -> `because` in `BridgeMethodResolver.java`
- `wit` -> `with` in `Hints.java`