### PR TITLE
#34788 -   HierarchicalUriComponents can handle repeated params in a query

### DIFF
--- a/spring-test/src/test/java/org/springframework/mock/http/server/reactive/MockServerHttpRequestTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/http/server/reactive/MockServerHttpRequestTests.java
@@ -65,7 +65,7 @@ class MockServerHttpRequestTests {
 				.queryParam("name B", "value B1")
 				.build();
 
-		assertThat(request.getURI().toString()).isEqualTo("/foo%20bar?a=b&name%20A=value%20A1&name%20A=value%20A2&name%20B=value%20B1");
+		assertThat(request.getURI().toString()).isEqualTo("/foo%20bar?a=b&name%20B=value%20B1&name%20A=value%20A1&name%20A=value%20A2");
 	}
 
 	/**

--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -625,7 +625,14 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 	}
 
 	private void addAllToQueryParams(MultiValueMap<String, String> params) {
-		params.forEach((key, values) -> values.forEach(v -> this.queryParam(key, v)));
+		params.forEach((key, values) -> {
+			if (values.isEmpty()) {
+				this.queryParams.add(new HierarchicalUriComponents.QueryParam(key, null));
+			}
+			else{
+				values.forEach(v -> this.queryParams.add(new HierarchicalUriComponents.QueryParam(key, v)));
+			}
+		});
 	}
 
 	@Override

--- a/spring-web/src/test/java/org/springframework/web/filter/RequestLoggingFilterTests.java
+++ b/spring-web/src/test/java/org/springframework/web/filter/RequestLoggingFilterTests.java
@@ -114,8 +114,9 @@ class RequestLoggingFilterTests {
 
 		applyFilter();
 
-		assertThat(filter.beforeRequestMessage).contains("/hotels?booking=42&code=masked&category=hotel&category=resort&ignore=masked");
-		assertThat(filter.afterRequestMessage).contains("/hotels?booking=42&code=masked&category=hotel&category=resort&ignore=masked");
+		String expectedRequest = "/hotels?booking=42&code=masked&ignore=masked&category=hotel&category=resort";
+		assertThat(filter.beforeRequestMessage).contains(expectedRequest);
+		assertThat(filter.afterRequestMessage).contains(expectedRequest);
 	}
 
 	@Test

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -16,18 +16,26 @@
 
 package org.springframework.web.util;
 
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.EnumSource;
+
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder.ParserType;
-
-import java.net.URI;
-import java.util.*;
-import java.util.function.BiConsumer;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;


### PR DESCRIPTION
Use List<QueryParam> instead of MultiValueMap in  HierarchicalUriComponents to record query params