### PR TITLE
Make HttpStatus.resolve return non-deprecated one

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpStatus.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpStatus.java
@@ -221,6 +221,13 @@ public enum HttpStatus implements HttpStatusCode {
 	 */
 	PRECONDITION_FAILED(412, Series.CLIENT_ERROR, "Precondition Failed"),
 	/**
+	 * {@code 413 Content Too Large}.
+	 * @since 7.0
+	 * @see <a href="https://datatracker.ietf.org/doc/html/rfc9110#name-413-content-too-large">
+	 *     HTTP Semantics, section 15.5.14</a>
+	 */
+	CONTENT_TOO_LARGE(413, Series.CLIENT_ERROR, "Content Too Large"),
+	/**
 	 * {@code 413 Payload Too Large}.
 	 * @since 4.1
 	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.11">
@@ -229,13 +236,6 @@ public enum HttpStatus implements HttpStatusCode {
 	 */
 	@Deprecated(since = "7.0")
 	PAYLOAD_TOO_LARGE(413, Series.CLIENT_ERROR, "Payload Too Large"),
-	/**
-	 * {@code 413 Content Too Large}.
-	 * @since 7.0
-	 * @see <a href="https://datatracker.ietf.org/doc/html/rfc9110#name-413-content-too-large">
-	 *     HTTP Semantics, section 15.5.14</a>
-	 */
-	CONTENT_TOO_LARGE(413, Series.CLIENT_ERROR, "Content Too Large"),
 	/**
 	 * {@code 414 URI Too Long}.
 	 * @since 4.1


### PR DESCRIPTION
### Summary

Reorder `HttpStatus.CONTENT_TOO_LARGE` to appear before its deprecated counterpart `PAYLOAD_TOO_LARGE` to align with existing ordering conventions.

### Details

In previous versions, `HttpStatus.resolve` (or `valueOf`) always returned non-deprecated HTTP status for given code. This was ensured implicitly, by placing non-deprecated enum entries before their respective deprecations. This was not ensured for `413 Content Too Large`.

You can see this lower in this enum - `422 Unprocessable Content` is **before** its deprecated `422 Unprocessable Entity` and in previous versions, `414 URI Too Long` was before its deprecated `414 Request-URI Too Long`.

Even JavaDoc (from `6.2.x`) for `414` used to explitly state, that non-deprecated one will be returned:

```java
	/**
	 * {@code 414 URI Too Long}.
	 * @since 4.1
	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-6.5.12">
	 *     HTTP/1.1: Semantics and Content, section 6.5.12</a>
	 */
	URI_TOO_LONG(414, Series.CLIENT_ERROR, "URI Too Long"),
	/**
	 * {@code 414 Request-URI Too Long}.
	 * @see <a href="https://tools.ietf.org/html/rfc2616#section-10.4.15">HTTP/1.1, section 10.4.15</a>
	 * @deprecated in favor of {@link #URI_TOO_LONG} which will be returned from {@code HttpStatus.valueOf(414)}
	 */
	@Deprecated
	REQUEST_URI_TOO_LONG(414, Series.CLIENT_ERROR, "Request-URI Too Long"),
```

Therefore I believe that `CONTENT_TOO_LARGE` enum entry should be moved before `PAYLOAD_TOO_LARGE` to match that.