### PR TITLE
Use empty array constants instead of repeatedly creating new ones

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/AdvisedSupport.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/AdvisedSupport.java
@@ -76,7 +76,8 @@ public class AdvisedSupport extends ProxyConfig implements Advised {
 	 * supplied by the advisors.
 	 */
 	public static final TargetSource EMPTY_TARGET_SOURCE = EmptyTargetSource.INSTANCE;
-
+	/** Empty advisor array constant. */
+	public static final Advisor[] EMPTY_ADVISORS = new Advisor[0];
 
 	/** Package-protected to allow direct access for efficiency. */
 	@SuppressWarnings("serial")
@@ -288,7 +289,7 @@ public class AdvisedSupport extends ProxyConfig implements Advised {
 
 	@Override
 	public final Advisor[] getAdvisors() {
-		return this.advisors.toArray(new Advisor[0]);
+		return this.advisors.toArray(EMPTY_ADVISORS);
 	}
 
 	@Override

--- a/spring-aop/src/main/java/org/springframework/aop/framework/adapter/DefaultAdvisorAdapterRegistry.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/adapter/DefaultAdvisorAdapterRegistry.java
@@ -39,6 +39,7 @@ import org.springframework.aop.support.DefaultPointcutAdvisor;
  */
 @SuppressWarnings("serial")
 public class DefaultAdvisorAdapterRegistry implements AdvisorAdapterRegistry, Serializable {
+	private static final MethodInterceptor [] EMPTY_INTERCEPTOR_ARRAY = new MethodInterceptor[0];
 
 	private final List<AdvisorAdapter> adapters = new ArrayList<>(3);
 
@@ -89,7 +90,7 @@ public class DefaultAdvisorAdapterRegistry implements AdvisorAdapterRegistry, Se
 		if (interceptors.isEmpty()) {
 			throw new UnknownAdviceTypeException(advisor.getAdvice());
 		}
-		return interceptors.toArray(new MethodInterceptor[0]);
+		return interceptors.toArray(EMPTY_INTERCEPTOR_ARRAY);
 	}
 
 	@Override

--- a/spring-beans/src/main/java/org/springframework/beans/MutablePropertyValues.java
+++ b/spring-beans/src/main/java/org/springframework/beans/MutablePropertyValues.java
@@ -44,6 +44,8 @@ import org.springframework.util.StringUtils;
 @SuppressWarnings("serial")
 public class MutablePropertyValues implements PropertyValues, Serializable {
 
+	private static final PropertyValue[] EMPTY_PROPERTY_VALUES = new PropertyValue[0];
+
 	private final List<PropertyValue> propertyValueList;
 
 	private @Nullable Set<String> processedProperties;
@@ -264,7 +266,7 @@ public class MutablePropertyValues implements PropertyValues, Serializable {
 
 	@Override
 	public PropertyValue[] getPropertyValues() {
-		return this.propertyValueList.toArray(new PropertyValue[0]);
+		return this.propertyValueList.toArray(EMPTY_PROPERTY_VALUES);
 	}
 
 	@Override

--- a/spring-beans/src/main/java/org/springframework/beans/factory/parsing/BeanComponentDefinition.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/parsing/BeanComponentDefinition.java
@@ -37,6 +37,9 @@ import org.springframework.beans.factory.config.BeanReference;
  */
 public class BeanComponentDefinition extends BeanDefinitionHolder implements ComponentDefinition {
 
+	private static final BeanDefinition[] EMPTY_BEAN_DEFINITIONS = new BeanDefinition[0];
+	private static final BeanReference[] EMPTY_BEAN_REFERENCES = new BeanReference[0];
+
 	private final BeanDefinition[] innerBeanDefinitions;
 
 	private final BeanReference[] beanReferences;
@@ -84,8 +87,8 @@ public class BeanComponentDefinition extends BeanDefinitionHolder implements Com
 				references.add(beanRef);
 			}
 		}
-		this.innerBeanDefinitions = innerBeans.toArray(new BeanDefinition[0]);
-		this.beanReferences = references.toArray(new BeanReference[0]);
+		this.innerBeanDefinitions = innerBeans.toArray(EMPTY_BEAN_DEFINITIONS);
+		this.beanReferences = references.toArray(EMPTY_BEAN_REFERENCES);
 	}
 
 

--- a/spring-core/src/main/java/org/springframework/core/annotation/MergedAnnotationsCollection.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/MergedAnnotationsCollection.java
@@ -40,6 +40,8 @@ import org.springframework.util.Assert;
  */
 final class MergedAnnotationsCollection implements MergedAnnotations {
 
+	private static final MergedAnnotation<?> [] EMPTY_ANNOTATIONS = new MergedAnnotation<?>[0];
+
 	private final MergedAnnotation<?>[] annotations;
 
 	private final AnnotationTypeMappings[] mappings;
@@ -47,7 +49,7 @@ final class MergedAnnotationsCollection implements MergedAnnotations {
 
 	private MergedAnnotationsCollection(Collection<MergedAnnotation<?>> annotations) {
 		Assert.notNull(annotations, "Annotations must not be null");
-		this.annotations = annotations.toArray(new MergedAnnotation<?>[0]);
+		this.annotations = annotations.toArray(EMPTY_ANNOTATIONS);
 		this.mappings = new AnnotationTypeMappings[this.annotations.length];
 		for (int i = 0; i < this.annotations.length; i++) {
 			MergedAnnotation<?> annotation = this.annotations[i];

--- a/spring-expression/src/main/java/org/springframework/expression/common/TemplateAwareExpressionParser.java
+++ b/spring-expression/src/main/java/org/springframework/expression/common/TemplateAwareExpressionParser.java
@@ -44,6 +44,8 @@ import org.springframework.util.Assert;
  */
 public abstract class TemplateAwareExpressionParser implements ExpressionParser {
 
+	private static final Expression [] EMPTY_EXPRESSION_ARRAY = new Expression[0];
+
 	@Override
 	public Expression parseExpression(String expressionString) throws ParseException {
 		return parseExpression(expressionString, null);
@@ -136,7 +138,7 @@ public abstract class TemplateAwareExpressionParser implements ExpressionParser 
 			}
 		}
 
-		return expressions.toArray(new Expression[0]);
+		return expressions.toArray(EMPTY_EXPRESSION_ARRAY);
 	}
 
 	/**


### PR DESCRIPTION
Refactor: use predefined empty arrays instead of creating new ones in places identified during runtime where unnecessary objects were frequently created.
