### PR TITLE
RestTestClient.mutate() should not have side effects

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/DefaultRestTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/DefaultRestTestClient.java
@@ -132,7 +132,7 @@ class DefaultRestTestClient implements RestTestClient {
 	@SuppressWarnings("unchecked")
 	@Override
 	public <B extends Builder<B>> Builder<B> mutate() {
-		return new DefaultRestTestClientBuilder<B>((DefaultRestTestClientBuilder<B>) this.restTestClientBuilder);
+		return new DefaultRestTestClientBuilder<>((DefaultRestTestClientBuilder<B>) this.restTestClientBuilder);
 	}
 
 

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/DefaultRestTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/DefaultRestTestClient.java
@@ -132,7 +132,7 @@ class DefaultRestTestClient implements RestTestClient {
 	@SuppressWarnings("unchecked")
 	@Override
 	public <B extends Builder<B>> Builder<B> mutate() {
-		return (Builder<B>) this.restTestClientBuilder;
+		return new DefaultRestTestClientBuilder<B>((DefaultRestTestClientBuilder<B>) this.restTestClientBuilder);
 	}
 
 

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/DefaultRestTestClientBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/DefaultRestTestClientBuilder.java
@@ -166,7 +166,7 @@ class DefaultRestTestClientBuilder<B extends RestTestClient.Builder<B>> implemen
 		}
 
 		return new DefaultRestTestClient(
-				this.restClientBuilder, this.entityResultConsumer, new DefaultRestTestClientBuilder<>(this));
+				this.restClientBuilder, this.entityResultConsumer, this);
 	}
 
 

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/client/DefaultRestTestClientBuilderTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/client/DefaultRestTestClientBuilderTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.test.web.servlet.client;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultRestTestClientBuilderTests {
+
+	@Test
+	void testMutateHasNoSideEffects() {
+		RestTestClient baseTestClient = new DefaultRestTestClientBuilder().baseUrl("http://localhost").build();
+		baseTestClient.mutate().defaultHeader("foo", "bar").build();
+		baseTestClient.mutate().defaultHeaders(headers -> assertThat(headers.containsHeader("foo")).isFalse());
+	}
+
+}


### PR DESCRIPTION
Before this change, `DefaultRestTestClient.mutate()` was reusing the underlying builder all calls.

Building a new builder for each call clones the `RestTestClientBuilder`, protecting from side effects.