### PR TITLE
Improve `HttpServiceMethod` support for Kotlin suspending functions returning `Flow`

### DIFF
--- a/spring-web/src/test/kotlin/org/springframework/web/service/invoker/HttpServiceMethodKotlinTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/web/service/invoker/HttpServiceMethodKotlinTests.kt
@@ -56,6 +56,10 @@ class KotlinHttpServiceMethodTests {
 		assertThat(flowBody.toList()).containsExactly("exchange", "For", "Body", "Flux")
 		verifyClientInvocation("exchangeForBodyFlux", object : ParameterizedTypeReference<String>() {})
 
+		val suspendingFlowBody = service.suspendingFlowBody()
+		assertThat(suspendingFlowBody.toList()).containsExactly("exchange", "For", "Body", "Flux")
+		verifyClientInvocation("exchangeForBodyFlux", object : ParameterizedTypeReference<String>() {})
+
 		val stringEntity = service.stringEntity()
 		assertThat(stringEntity).isEqualTo(ResponseEntity.ok<String>("exchangeForEntityMono"))
 		verifyClientInvocation("exchangeForEntityMono", object : ParameterizedTypeReference<String>() {})
@@ -126,6 +130,9 @@ class KotlinHttpServiceMethodTests {
 
 		@GetExchange
 		suspend fun listBody(): MutableList<String>
+
+		@GetExchange
+		suspend fun suspendingFlowBody(): Flow<String>
 
 		@GetExchange
 		suspend fun stringEntity(): ResponseEntity<String>


### PR DESCRIPTION
In https://github.com/spring-projects/spring-framework/pull/35473#discussion_r2359835039 it was noted that the HTTP Interface does not support Kotlin suspending functions returning `Flow`.

While this technically works, the issue is that such invocations are handled via `ReactorHttpExchangeAdapter#exchangeForBodyMono` instead of `ReactorHttpExchangeAdapter#exchangeForBodyFlux`.

This PR fixes the issue by adapting `HttpServiceMethod` in a similar way to the improvements made to `RSocketServiceMethod` in #35473.

cc @sdeleuze 