### PR TITLE
Update CI documentation reference in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ See the [Build from Source](https://github.com/spring-projects/spring-framework/
 
 ## Continuous Integration Builds
 
-Information regarding CI builds can be found in the [Spring Framework Concourse pipeline](ci/README.adoc) documentation.
+Information regarding CI builds can be found in the [GitHub Actions workflows](.github/workflows).
 
 ## Stay in Touch
 


### PR DESCRIPTION
Replace obsolete Concourse pipeline reference with GitHub Actions. The Concourse link returns 404.