### PR TITLE
Improve i18n-support for NoResourceFoundException

### DIFF
--- a/framework-docs/modules/ROOT/pages/web/webmvc/mvc-ann-rest-exceptions.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc/mvc-ann-rest-exceptions.adoc
@@ -171,7 +171,7 @@ Message codes and arguments for each error are also resolved via `MessageSource`
 
 | `NoResourceFoundException`
 | (default)
-|
+| `+{0}+` the resource
 
 | `TypeMismatchException`
 | (default)

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/NoResourceFoundException.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/NoResourceFoundException.java
@@ -78,4 +78,8 @@ public class NoResourceFoundException extends ServletException implements ErrorR
 		return this.body;
 	}
 
+	@Override
+	public Object[] getDetailMessageArguments() {
+		return new String[]{this.resourcePath};
+	}
 }

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/resource/NoResourceFoundExceptionTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/resource/NoResourceFoundExceptionTests.java
@@ -40,4 +40,9 @@ class NoResourceFoundExceptionTests {
 		assertThat(noResourceFoundException.getBody().getDetail()).isEqualTo("No static resource /resource.");
 	}
 
+	@Test
+	void messageArgumentsShouldContainResourcePath() {
+		var noResourceFoundException = new NoResourceFoundException(HttpMethod.GET, "/context/resource", "/resource");
+		assertThat(noResourceFoundException.getDetailMessageArguments()).containsExactly("/resource");
+	}
 }


### PR DESCRIPTION
Return the requested resource as
ErrorResponse.getDetailMessageArguments, making it usable with message customization and i18n.