### PR TITLE
Improve documentaton on controller return values for file downloads

### DIFF
--- a/framework-docs/modules/ROOT/pages/web/webflux/controller/ann-methods/responseentity.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webflux/controller/ann-methods/responseentity.adoc
@@ -33,6 +33,8 @@ Kotlin::
 ----
 ======
 
+A `ResponseEntity<Resource>` can be returned for file content, as same as in Spring MVC,
+
 WebFlux supports using a single value xref:web-reactive.adoc#webflux-reactive-libraries[reactive type] to
 produce the `ResponseEntity` asynchronously, and/or single and multi-value reactive types
 for the body. This allows a variety of async responses with `ResponseEntity` as follows:

--- a/framework-docs/modules/ROOT/pages/web/webflux/controller/ann-methods/return-types.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webflux/controller/ann-methods/return-types.adoc
@@ -84,6 +84,13 @@ Reactor provides a dedicated operator for that, `Flux#collectList()`.
   to be written (however, `text/event-stream` must be requested or declared in the mapping
   through the `produces` attribute).
 
+| `Flux<DataBuffer>`
+| Write raw data buffers to the response, for example, when handling file
+  downloads or proxying data.
+
+| `Resource`
+| Return a single resource that is written to the response using xref:web/webflux/reactive-spring.adoc#webflux-codecs-resource[ResourceHttpMessageWriter].
+
 | Other return values
 | If a return value remains unresolved in any other way, it is treated as a model
   attribute, unless it is a simple type as determined by

--- a/framework-docs/modules/ROOT/pages/web/webflux/reactive-spring.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webflux/reactive-spring.adoc
@@ -611,6 +611,12 @@ and from higher level objects, or unless they choose to create custom codecs. Fo
 cases please review the information in xref:core/databuffer-codec.adoc[Data Buffers and Codecs],
 especially the section on xref:core/databuffer-codec.adoc#databuffers-using[Using DataBuffer].
 
+[[webflux-codecs-resource]]
+=== `Resource`
+
+`Resource` is a general abstraction for file-like resources in Spring. WebFlux applications can use the `ResourceHttpMessageReader` and `ResourceHttpMessageWriter` to read and write `Resource` instances to and from HTTP requests and responses.
+
+Notice, the `ResourceHttpMessageWriter` automatically detects the media type by the filename of the `Resource` and uses it to override your response's `Content-Type` header. If the detection fails, `application/octet-stream` is used as a fallback. Don't return `Resource` type if you want to control the media type of the response.
 
 [[webflux-logging]]
 == Logging

--- a/framework-docs/modules/ROOT/pages/web/webmvc/message-converters.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc/message-converters.adoc
@@ -83,4 +83,9 @@ content type. This requires the `com.google.protobuf:protobuf-java` dependency.
 | An `HttpMessageConverter` implementation that can read and write JSON documents to and from Protobuf messages.
 This requires the `com.google.protobuf:protobuf-java-util` dependency.
 
+| `ResourceHttpMessageConverter`
+| An `HttpMessageConverter` implementation that can read and write `org.springframework.core.io.Resource` instances from the HTTP request and response.
+
+Notice, the `ResourceHttpMessageWriter` automatically detects the media type by the filename of the `Resource` and uses it to override your response's `Content-Type` header. If the detection fails, `application/octet-stream` is used as a fallback. Don't return `Resource` type if you want to control the media type of the response.
+
 |===

--- a/framework-docs/modules/ROOT/pages/web/webmvc/mvc-controller/ann-methods/return-types.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc/mvc-controller/ann-methods/return-types.adoc
@@ -95,6 +95,9 @@ supported for all return values.
   collected to a List and rendered as a single value. See xref:web/webmvc/mvc-ann-async.adoc[Asynchronous Requests] and
   xref:web/webmvc/mvc-ann-async.adoc#mvc-ann-async-reactive-types[Reactive Types].
 
+| `Resource`
+| Return a single resource that is written to the response using `ResourceHttpMessageConverter` implementations.
+
 | Other return values
 | If a return value remains unresolved in any other way, it is treated as a model
   attribute, unless it is a simple type as determined by


### PR DESCRIPTION
I've updated the documentation to indicate that a ResponseEntity<Resource> can be returned from a WebFlux controller.

On a separate note, since file uploads and downloads are common requirements in the Spring framework, I believe it would be beneficial to create a dedicated page to guide developers through the process. I'd be happy to create one. What are your thoughts?