### PR TITLE
Add jar validation and fix multi-release jar

### DIFF
--- a/buildSrc/src/main/java/org/springframework/build/multirelease/MultiReleaseJarPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/build/multirelease/MultiReleaseJarPlugin.java
@@ -27,6 +27,9 @@ import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.bundling.AbstractArchiveTask;
+import org.gradle.jvm.tasks.Jar;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 
 /**
@@ -57,5 +60,9 @@ public class MultiReleaseJarPlugin implements Plugin<Project> {
 				tasks,
 				dependencies,
 				objects);
+		TaskProvider<MultiReleaseJarValidateTask> validateJarTask = tasks.register("validateJar", MultiReleaseJarValidateTask.class, (task) -> {
+			task.getJar().set(tasks.named("jar", Jar.class).flatMap(AbstractArchiveTask::getArchiveFile));
+		});
+		tasks.named("check", task -> task.dependsOn(validateJarTask));
 	}
 }

--- a/buildSrc/src/main/java/org/springframework/build/multirelease/MultiReleaseJarValidateTask.java
+++ b/buildSrc/src/main/java/org/springframework/build/multirelease/MultiReleaseJarValidateTask.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.build.multirelease;
+
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.JavaExec;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+
+import java.util.List;
+
+@CacheableTask
+public abstract class MultiReleaseJarValidateTask extends JavaExec {
+	@InputFile
+	@PathSensitive(PathSensitivity.RELATIVE)
+	public abstract RegularFileProperty getJar();
+	public MultiReleaseJarValidateTask() {
+		getMainModule().set("jdk.jartool");
+		getArgumentProviders().add(() -> List.of("--validate", "--file", getJar().get().getAsFile().getAbsolutePath()));
+	}
+}

--- a/spring-core/src/main/java21/org/springframework/core/task/VirtualThreadDelegate.java
+++ b/spring-core/src/main/java21/org/springframework/core/task/VirtualThreadDelegate.java
@@ -30,6 +30,8 @@ final class VirtualThreadDelegate {
 
 	private final Thread.Builder threadBuilder = Thread.ofVirtual();
 
+	public VirtualThreadDelegate() { }
+
 	public ThreadFactory virtualThreadFactory() {
 		return this.threadBuilder.factory();
 	}

--- a/spring-core/src/main/java24/org/springframework/core/type/classreading/ClassFileMetadataReaderFactory.java
+++ b/spring-core/src/main/java24/org/springframework/core/type/classreading/ClassFileMetadataReaderFactory.java
@@ -30,7 +30,7 @@ import org.springframework.core.io.ResourceLoader;
  * @author Brian Clozel
  * @since 7.0
  */
-public class ClassFileMetadataReaderFactory extends AbstractMetadataReaderFactory {
+class ClassFileMetadataReaderFactory extends AbstractMetadataReaderFactory {
 
 	/**
 	 * Create a new ClassFileMetadataReaderFactory for the default class loader.


### PR DESCRIPTION
As per https://github.com/spring-projects/spring-framework/issues/35767, the existing multi-release jar contains two incorrect entries.

This mr fixes those entries and adds a validation task to avoid this in the future.