### PR TITLE
Use provided ReactiveAdapterRegistry in BindingContext constructor

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/BindingContext.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/BindingContext.java
@@ -82,7 +82,7 @@ public class BindingContext {
 	 */
 	public BindingContext(@Nullable WebBindingInitializer initializer, ReactiveAdapterRegistry registry) {
 		this.initializer = initializer;
-		this.reactiveAdapterRegistry = new ReactiveAdapterRegistry();
+		this.reactiveAdapterRegistry = registry;
 	}
 
 


### PR DESCRIPTION
This PR uses provided ReactiveAdapterRegistry in BindingContext constructor introduced by <https://github.com/spring-projects/spring-framework/commit/74972fb75139d46fa6873717728eca15e49c0558>.

