### PR TITLE
Correct formatting for `Mono` type

### DIFF
--- a/framework-docs/modules/ROOT/pages/web/webmvc/mvc-ann-async.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc/mvc-ann-async.adoc
@@ -422,7 +422,7 @@ reactive types from the controller method.
 Reactive return values are handled as follows:
 
 * A single-value promise is adapted to, similar to using `DeferredResult`. Examples
-include `CompletionStage` (JDK), Mono` (Reactor), and `Single` (RxJava).
+include `CompletionStage` (JDK), `Mono` (Reactor), and `Single` (RxJava).
 * A multi-value stream with a streaming media type (such as `application/x-ndjson`
 or `text/event-stream`) is adapted to, similar to using `ResponseBodyEmitter` or
 `SseEmitter`. Examples include `Flux` (Reactor) or `Observable` (RxJava).


### PR DESCRIPTION
This PR fixes a minor formatting issue in the documentation where the Mono type was missing a closing backtick. The incorrect Markdown resulted in improper rendering. Refer below snippet for more details:

**Spring docs snippet:**

<img width="1377" height="278" alt="image" src="https://github.com/user-attachments/assets/e50ebb44-7913-4959-9154-650ca68c2d03" />
