### PR TITLE
Replace `kotlin-issues` attribute reference

### DIFF
--- a/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/expectations.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/expectations.adoc
@@ -182,7 +182,7 @@ Java::
 
 Kotlin::
 +
-[source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
+[source,kotlin,indent=0,subs="verbatim,quotes"]
 ----
 	standaloneSetup(SimpleController())
 		.alwaysExpect<StandaloneMockMvcBuilder>(MockMvcResultMatchers.status().isOk())

--- a/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/expectations.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/expectations.adoc
@@ -184,7 +184,10 @@ Kotlin::
 +
 [source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
 ----
-	// Not possible in Kotlin until {kotlin-issues}/KT-22208 is fixed
+	standaloneSetup(SimpleController())
+		.alwaysExpect<StandaloneMockMvcBuilder>(MockMvcResultMatchers.status().isOk())
+		.alwaysExpect<StandaloneMockMvcBuilder>(MockMvcResultMatchers.content().contentType("application/json;charset=UTF-8"))
+		.build()
 ----
 ======
 

--- a/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/expectations.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/expectations.adoc
@@ -182,7 +182,7 @@ Java::
 
 Kotlin::
 +
-[source,kotlin,indent=0,subs="verbatim,quotes"]
+[source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
 ----
 	// Not possible in Kotlin until {kotlin-issues}/KT-22208 is fixed
 ----

--- a/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/filters.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/filters.adoc
@@ -16,7 +16,7 @@ Java::
 
 Kotlin::
 +
-[source,kotlin,indent=0,subs="verbatim,quotes"]
+[source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
 ----
 	// Not possible in Kotlin until {kotlin-issues}/KT-22208 is fixed
 ----

--- a/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/filters.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/filters.adoc
@@ -16,7 +16,7 @@ Java::
 
 Kotlin::
 +
-[source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
+[source,kotlin,indent=0,subs="verbatim,quotes"]
 ----
 	mockMvc = standaloneSetup(PersonController()).addFilters<StandaloneMockMvcBuilder>(CharacterEncodingFilter()).build()
 ----

--- a/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/filters.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/filters.adoc
@@ -18,7 +18,7 @@ Kotlin::
 +
 [source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
 ----
-	// Not possible in Kotlin until {kotlin-issues}/KT-22208 is fixed
+	mockMvc = standaloneSetup(PersonController()).addFilters<StandaloneMockMvcBuilder>(CharacterEncodingFilter()).build()
 ----
 ======
 

--- a/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/requests.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/requests.adoc
@@ -157,7 +157,7 @@ Java::
 
 Kotlin::
 +
-[source,kotlin,indent=0,subs="verbatim,quotes"]
+[source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
 ----
 	// Not possible in Kotlin until {kotlin-issues}/KT-22208 is fixed
 ----

--- a/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/requests.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/requests.adoc
@@ -157,7 +157,7 @@ Java::
 
 Kotlin::
 +
-[source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
+[source,kotlin,indent=0,subs="verbatim,quotes"]
 ----
 	class MyWebTests {
 

--- a/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/requests.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/requests.adoc
@@ -159,7 +159,18 @@ Kotlin::
 +
 [source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
 ----
-	// Not possible in Kotlin until {kotlin-issues}/KT-22208 is fixed
+	class MyWebTests {
+
+		lateinit var mockMvc: MockMvc
+
+		@BeforeEach
+		fun setup() {
+			mockMvc = MockMvcBuilders.standaloneSetup(AccountController())
+				.defaultRequest<StandaloneMockMvcBuilder>(get("/")
+				.contextPath("/app").servletPath("/main")
+				.accept(MediaType.APPLICATION_JSON)).build()
+		}
+	}
 ----
 ======
 

--- a/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/setup-steps.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/setup-steps.adoc
@@ -25,7 +25,13 @@ Kotlin::
 +
 [source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
 ----
-	// Not possible in Kotlin until {kotlin-issues}/KT-22208 is fixed
+	// static import of MockMvcBuilders.standaloneSetup
+
+	val mockMvc = standaloneSetup(MusicController())
+		.defaultRequest<StandaloneMockMvcBuilder>(get("/").accept(MediaType.APPLICATION_JSON))
+		.alwaysExpect<StandaloneMockMvcBuilder>(status().isOk())
+		.alwaysExpect<StandaloneMockMvcBuilder>(content().contentType("application/json;charset=UTF-8"))
+		.build()
 ----
 ======
 
@@ -53,7 +59,13 @@ Kotlin::
 +
 [source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
 ----
-	// Not possible in Kotlin until {kotlin-issues}/KT-22208 is fixed
+	// static import of SharedHttpSessionConfigurer.sharedHttpSession
+
+	val mockMvc = MockMvcBuilders.standaloneSetup(TestController())
+			.apply<StandaloneMockMvcBuilder>(sharedHttpSession())
+			.build()
+
+	// Use mockMvc to perform requests...
 ----
 ======
 

--- a/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/setup-steps.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/setup-steps.adoc
@@ -23,7 +23,7 @@ Java::
 
 Kotlin::
 +
-[source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
+[source,kotlin,indent=0,subs="verbatim,quotes"]
 ----
 	// static import of MockMvcBuilders.standaloneSetup
 
@@ -57,7 +57,7 @@ Java::
 
 Kotlin::
 +
-[source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
+[source,kotlin,indent=0,subs="verbatim,quotes"]
 ----
 	// static import of SharedHttpSessionConfigurer.sharedHttpSession
 

--- a/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/setup-steps.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/mockmvc/hamcrest/setup-steps.adoc
@@ -23,7 +23,7 @@ Java::
 
 Kotlin::
 +
-[source,kotlin,indent=0,subs="verbatim,quotes"]
+[source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
 ----
 	// Not possible in Kotlin until {kotlin-issues}/KT-22208 is fixed
 ----
@@ -51,7 +51,7 @@ Java::
 
 Kotlin::
 +
-[source,kotlin,indent=0,subs="verbatim,quotes"]
+[source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
 ----
 	// Not possible in Kotlin until {kotlin-issues}/KT-22208 is fixed
 ----

--- a/framework-docs/modules/ROOT/pages/testing/mockmvc/htmlunit/mah.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/mockmvc/htmlunit/mah.adoc
@@ -267,7 +267,19 @@ Kotlin::
 +
 [source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
 ----
-	// Not possible in Kotlin until {kotlin-issues}/KT-22208 is fixed
+	val mockMvc = MockMvcBuilders
+			.webAppContextSetup(context)
+			.apply(springSecurity())
+			.build()
+
+	webClient = MockMvcWebClientBuilder
+			.mockMvcSetup(mockMvc)
+			// for illustration only - defaults to ""
+			.contextPath("")
+			// By default MockMvc is used for localhost only;
+			// the following will use MockMvc for example.com and example.org as well
+			.useMockMvcForHosts("example.com", "example.org")
+			.build()
 ----
 ======
 

--- a/framework-docs/modules/ROOT/pages/testing/mockmvc/htmlunit/mah.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/mockmvc/htmlunit/mah.adoc
@@ -265,7 +265,7 @@ Java::
 
 Kotlin::
 +
-[source,kotlin,indent=0,subs="verbatim,quotes"]
+[source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
 ----
 	// Not possible in Kotlin until {kotlin-issues}/KT-22208 is fixed
 ----

--- a/framework-docs/modules/ROOT/pages/testing/mockmvc/htmlunit/mah.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/mockmvc/htmlunit/mah.adoc
@@ -265,7 +265,7 @@ Java::
 
 Kotlin::
 +
-[source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
+[source,kotlin,indent=0,subs="verbatim,quotes"]
 ----
 	val mockMvc = MockMvcBuilders
 			.webAppContextSetup(context)

--- a/framework-docs/modules/ROOT/pages/testing/mockmvc/htmlunit/webdriver.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/mockmvc/htmlunit/webdriver.adoc
@@ -560,7 +560,7 @@ Java::
 
 Kotlin::
 +
-[source,kotlin,indent=0,subs="verbatim,quotes"]
+[source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
 ----
 	// Not possible in Kotlin until {kotlin-issues}/KT-22208 is fixed
 ----

--- a/framework-docs/modules/ROOT/pages/testing/mockmvc/htmlunit/webdriver.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/mockmvc/htmlunit/webdriver.adoc
@@ -560,7 +560,7 @@ Java::
 
 Kotlin::
 +
-[source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
+[source,kotlin,indent=0,subs="verbatim,quotes"]
 ----
 	val mockMvc: MockMvc = MockMvcBuilders
 			.webAppContextSetup(context)

--- a/framework-docs/modules/ROOT/pages/testing/mockmvc/htmlunit/webdriver.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/mockmvc/htmlunit/webdriver.adoc
@@ -562,7 +562,19 @@ Kotlin::
 +
 [source,kotlin,indent=0,subs="verbatim,quotes,attributes"]
 ----
-	// Not possible in Kotlin until {kotlin-issues}/KT-22208 is fixed
+	val mockMvc: MockMvc = MockMvcBuilders
+			.webAppContextSetup(context)
+			.apply(springSecurity())
+			.build()
+
+	driver = MockMvcHtmlUnitDriverBuilder
+			.mockMvcSetup(mockMvc)
+			// for illustration only - defaults to ""
+			.contextPath("")
+			// By default MockMvc is used for localhost only;
+			// the following will use MockMvc for example.com and example.org as well
+			.useMockMvcForHosts("example.com", "example.org")
+			.build()
 ----
 ======
 


### PR DESCRIPTION
Without `attributes`, the example will be shown

<img width="1205" height="134" alt="image" src="https://github.com/user-attachments/assets/5b289b6c-9a77-4639-8e72-7386e929fd00" />

Reference: https://docs.spring.io/spring-framework/reference/7.0-SNAPSHOT/testing/mockmvc/htmlunit/webdriver.html