### PR TITLE
Fix memory leak in CaffeineCacheManager static mode

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/cache/caffeine/CaffeineCacheManager.java
+++ b/spring-context-support/src/main/java/org/springframework/cache/caffeine/CaffeineCacheManager.java
@@ -106,9 +106,16 @@ public class CaffeineCacheManager implements CacheManager {
 	 * with no creation of further cache regions at runtime.
 	 * <p>Calling this with a {@code null} collection argument resets the
 	 * mode to 'dynamic', allowing for further creation of caches again.
+	 * <p><b>Note:</b> Switching to static mode will remove all dynamically created
+	 * caches, while preserving custom caches registered via
+	 * {@link #registerCustomCache(String, com.github.benmanes.caffeine.cache.Cache)}.
 	 */
 	public void setCacheNames(@Nullable Collection<String> cacheNames) {
 		if (cacheNames != null) {
+			// Remove all non-custom caches before setting up static caches
+			this.cacheMap.keySet().retainAll(this.customCacheNames);
+
+			// Add the specified static caches
 			for (String name : cacheNames) {
 				this.cacheMap.put(name, createCaffeineCache(name));
 			}


### PR DESCRIPTION
## Description
This PR fixes a memory leak in `CaffeineCacheManager` where dynamically created caches were not removed when switching to static mode via `setCacheNames()`.

## Changes

### Core Fix
- Modified `CaffeineCacheManager.setCacheNames()` to clear dynamically created caches while preserving custom caches
- Updated Javadoc to clarify the behavior

### Tests Added
- `setCacheNamesShouldRemovePreviousDynamicCaches()`: Verifies dynamic caches are cleared
- `setCacheNamesShouldPreserveCustomCaches()`: Ensures custom caches are not affected
- `switchingBetweenDynamicAndStaticMode()`: Tests mode transitions

## Backward Compatibility

This is a **potentially breaking change** for users who rely on the (undocumented) behavior of dynamic caches persisting after `setCacheNames()`.

However:
1. The current behavior violates the documented contract
2. The memory leak justifies the fix
3. The typical use case (setting static caches at startup) is unaffected