### PR TITLE
Fix single-check idiom in `UnmodifiableMultiValueMap`

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/UnmodifiableMultiValueMap.java
+++ b/spring-core/src/main/java/org/springframework/util/UnmodifiableMultiValueMap.java
@@ -141,26 +141,32 @@ final class UnmodifiableMultiValueMap<K,V> implements MultiValueMap<K,V>, Serial
 
 	@Override
 	public Set<K> keySet() {
-		if (this.keySet == null) {
-			this.keySet = Collections.unmodifiableSet(this.delegate.keySet());
+		Set<K> keySet = this.keySet;
+		if (keySet == null) {
+			keySet = Collections.unmodifiableSet(this.delegate.keySet());
+			this.keySet = keySet;
 		}
-		return this.keySet;
+		return keySet;
 	}
 
 	@Override
 	public Set<Entry<K, List<V>>> entrySet() {
-		if (this.entrySet == null) {
-			this.entrySet = new UnmodifiableEntrySet<>(this.delegate.entrySet());
+		Set<Entry<K, List<V>>> entrySet = this.entrySet;
+		if (entrySet == null) {
+			entrySet = new UnmodifiableEntrySet<>(this.delegate.entrySet());
+			this.entrySet = entrySet;
 		}
-		return this.entrySet;
+		return entrySet;
 	}
 
 	@Override
 	public Collection<List<V>> values() {
-		if (this.values == null) {
-			this.values = new UnmodifiableValueCollection<>(this.delegate.values());
+		Collection<List<V>> values = this.values;
+		if (values == null) {
+			values = new UnmodifiableValueCollection<>(this.delegate.values());
+			this.values = values;
 		}
-		return this.values;
+		return values;
 	}
 
 	// unsupported
@@ -405,7 +411,6 @@ final class UnmodifiableMultiValueMap<K,V> implements MultiValueMap<K,V>, Serial
 		public void clear() {
 			throw new UnsupportedOperationException();
 		}
-
 
 		private static class UnmodifiableEntrySpliterator<K,V> implements Spliterator<Entry<K,List<V>>> {
 


### PR DESCRIPTION
Read the respective fields only once in values, entrySet, and keySet methods.

See: https://javaagile.blogspot.com/2013/05/the-racy-single-check-idiom.html