### PR TITLE
Annotate CGLIB `Transformer` interface with `@FunctionalInterface`

### DIFF
--- a/spring-core/src/main/java/org/springframework/cglib/core/Transformer.java
+++ b/spring-core/src/main/java/org/springframework/cglib/core/Transformer.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.cglib.core;
 
+@FunctionalInterface
 public interface Transformer {
     Object transform(Object value);
 }


### PR DESCRIPTION
### Summary

Add the `@FunctionalInterface` annotation to `Transformer`.

### Details

`Transformer` already has a single abstract method, so marking it as a functional interface clarifies its intended use and provides better compile-time checks and IDE support.

### Compatibility

No behavior changes; fully backward-compatible.