### PR TITLE
Modernize `java.time` API usages

### DIFF
--- a/spring-context/src/main/java/org/springframework/format/datetime/standard/DateTimeConverters.java
+++ b/spring-context/src/main/java/org/springframework/format/datetime/standard/DateTimeConverters.java
@@ -81,8 +81,7 @@ final class DateTimeConverters {
 			return gc.toZonedDateTime();
 		}
 		else {
-			return ZonedDateTime.ofInstant(Instant.ofEpochMilli(source.getTimeInMillis()),
-					source.getTimeZone().toZoneId());
+			return Instant.ofEpochMilli(source.getTimeInMillis()).atZone(source.getTimeZone().toZoneId());
 		}
 	}
 

--- a/spring-context/src/main/java/org/springframework/scheduling/support/CronTrigger.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/support/CronTrigger.java
@@ -115,7 +115,7 @@ public class CronTrigger implements Trigger {
 	public @Nullable Instant nextExecution(TriggerContext triggerContext) {
 		Instant timestamp = determineLatestTimestamp(triggerContext);
 		ZoneId zone = (this.zoneId != null ? this.zoneId : triggerContext.getClock().getZone());
-		ZonedDateTime zonedTimestamp = ZonedDateTime.ofInstant(timestamp, zone);
+		ZonedDateTime zonedTimestamp = timestamp.atZone(zone);
 		ZonedDateTime nextTimestamp = this.expression.next(zonedTimestamp);
 		return (nextTimestamp != null ? nextTimestamp.toInstant() : null);
 	}

--- a/spring-context/src/test/java/org/springframework/scheduling/concurrent/DefaultManagedTaskSchedulerTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/concurrent/DefaultManagedTaskSchedulerTests.java
@@ -18,7 +18,6 @@ package org.springframework.scheduling.concurrent;
 
 import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Test;
@@ -53,28 +52,28 @@ class DefaultManagedTaskSchedulerTests {
 	void scheduleAtFixedRateWithStartTimeAndDurationAndNoScheduledExecutorProvidesDedicatedException() {
 		DefaultManagedTaskScheduler scheduler = new DefaultManagedTaskScheduler();
 		assertNoExecutorException(() -> scheduler.scheduleAtFixedRate(
-				NO_OP, Instant.now(), Duration.of(1, ChronoUnit.MINUTES)));
+				NO_OP, Instant.now(), Duration.ofMinutes(1)));
 	}
 
 	@Test
 	void scheduleAtFixedRateWithDurationAndNoScheduledExecutorProvidesDedicatedException() {
 		DefaultManagedTaskScheduler scheduler = new DefaultManagedTaskScheduler();
 		assertNoExecutorException(() -> scheduler.scheduleAtFixedRate(
-				NO_OP, Duration.of(1, ChronoUnit.MINUTES)));
+				NO_OP, Duration.ofMinutes(1)));
 	}
 
 	@Test
 	void scheduleWithFixedDelayWithStartTimeAndDurationAndNoScheduledExecutorProvidesDedicatedException() {
 		DefaultManagedTaskScheduler scheduler = new DefaultManagedTaskScheduler();
 		assertNoExecutorException(() -> scheduler.scheduleWithFixedDelay(
-				NO_OP, Instant.now(), Duration.of(1, ChronoUnit.MINUTES)));
+				NO_OP, Instant.now(), Duration.ofMinutes(1)));
 	}
 
 	@Test
 	void scheduleWithFixedDelayWithDurationAndNoScheduledExecutorProvidesDedicatedException() {
 		DefaultManagedTaskScheduler scheduler = new DefaultManagedTaskScheduler();
 		assertNoExecutorException(() -> scheduler.scheduleWithFixedDelay(
-				NO_OP, Duration.of(1, ChronoUnit.MINUTES)));
+				NO_OP, Duration.ofMinutes(1)));
 	}
 
 	private void assertNoExecutorException(ThrowingCallable callable) {

--- a/spring-test/src/main/java/org/springframework/test/http/HttpHeadersAssert.java
+++ b/spring-test/src/main/java/org/springframework/test/http/HttpHeadersAssert.java
@@ -18,6 +18,7 @@ package org.springframework.test.http;
 
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -42,7 +43,7 @@ import org.springframework.http.HttpHeaders;
  */
 public class HttpHeadersAssert extends AbstractObjectAssert<HttpHeadersAssert, HttpHeaders> {
 
-	private static final ZoneId GMT = ZoneId.of("GMT");
+	private static final ZoneId GMT = ZoneOffset.UTC;
 
 
 	private final AbstractCollectionAssert<?, Collection<? extends String>, String, ObjectAssert<String>> namesAssert;
@@ -173,7 +174,7 @@ public class HttpHeadersAssert extends AbstractObjectAssert<HttpHeadersAssert, H
 		containsHeader(name);
 		Assertions.assertThat(this.actual.getFirstZonedDateTime(name))
 				.as("check primary date value for HTTP header '%s'", name)
-				.isCloseTo(ZonedDateTime.ofInstant(value, GMT), Assertions.within(999, ChronoUnit.MILLIS));
+				.isCloseTo(value.atZone(GMT), Assertions.within(999, ChronoUnit.MILLIS));
 		return this.myself;
 	}
 

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/client/RestTestClientTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/client/RestTestClientTests.java
@@ -18,7 +18,7 @@ package org.springframework.test.web.servlet.client;
 
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Map;
 
@@ -263,7 +263,7 @@ class RestTestClientTests {
 		@Test
 		void testIfModifiedSince() {
 			RestTestClientTests.this.client.get().uri("/test")
-					.ifModifiedSince(ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.of("GMT")))
+					.ifModifiedSince(ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC))
 					.exchange()
 					.expectStatus().isOk()
 					.expectBody().jsonPath("$.headers.If-Modified-Since").isEqualTo("Thu, 01 Jan 1970 00:00:00 GMT");

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/result/HeaderResultMatchersTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/result/HeaderResultMatchersTests.java
@@ -16,7 +16,7 @@
 
 package org.springframework.test.web.servlet.result;
 
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 
 import org.junit.jupiter.api.Test;
@@ -45,7 +45,7 @@ public class HeaderResultMatchersTests {
 	@Test // SPR-17330
 	public void matchDateFormattedWithHttpHeaders() throws Exception {
 
-		long epochMilli = ZonedDateTime.of(2018, 10, 5, 0, 0, 0, 0, ZoneId.of("GMT")).toInstant().toEpochMilli();
+		long epochMilli = ZonedDateTime.of(2018, 10, 5, 0, 0, 0, 0, ZoneOffset.UTC).toInstant().toEpochMilli();
 		HttpHeaders headers = new HttpHeaders();
 		headers.setDate("myDate", epochMilli);
 		this.response.setHeader("d", headers.getFirst("myDate"));

--- a/spring-test/src/test/java/org/springframework/test/web/support/HeaderAssertionTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/support/HeaderAssertionTests.java
@@ -17,7 +17,7 @@
 package org.springframework.test.web.support;
 
 import java.net.URI;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.concurrent.TimeUnit;
 
@@ -272,7 +272,7 @@ class HeaderAssertionTests {
 	@Test
 	void expires() {
 		HttpHeaders headers = new HttpHeaders();
-		ZonedDateTime expires = ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC"));
+		ZonedDateTime expires = ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
 		headers.setExpires(expires);
 		TestHeaderAssertions assertions = new TestHeaderAssertions(headers);
 		assertions.expires(expires.toInstant().toEpochMilli());
@@ -285,7 +285,7 @@ class HeaderAssertionTests {
 	@Test
 	void lastModified() {
 		HttpHeaders headers = new HttpHeaders();
-		ZonedDateTime lastModified = ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC"));
+		ZonedDateTime lastModified = ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
 		headers.setLastModified(lastModified.toInstant().toEpochMilli());
 		TestHeaderAssertions assertions = new TestHeaderAssertions(headers);
 		assertions.lastModified(lastModified.toInstant().toEpochMilli());

--- a/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
@@ -27,6 +27,7 @@ import java.text.DecimalFormatSymbols;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -414,7 +415,7 @@ public class HttpHeaders implements Serializable {
 
 	private static final DecimalFormatSymbols DECIMAL_FORMAT_SYMBOLS = new DecimalFormatSymbols(Locale.ROOT);
 
-	private static final ZoneId GMT = ZoneId.of("GMT");
+	private static final ZoneId GMT = ZoneOffset.UTC;
 
 	/**
 	 * Date formats with time zone as specified in the HTTP RFC to use for formatting.
@@ -1516,7 +1517,7 @@ public class HttpHeaders implements Serializable {
 	 * @since 5.1.4
 	 */
 	public void setInstant(String headerName, Instant date) {
-		setZonedDateTime(headerName, ZonedDateTime.ofInstant(date, GMT));
+		setZonedDateTime(headerName, date.atZone(GMT));
 	}
 
 	/**
@@ -2172,7 +2173,7 @@ public class HttpHeaders implements Serializable {
 	// Package-private: used in ResponseCookie
 	static String formatDate(long date) {
 		Instant instant = Instant.ofEpochMilli(date);
-		ZonedDateTime time = ZonedDateTime.ofInstant(instant, GMT);
+		ZonedDateTime time = instant.atZone(GMT);
 		return DATE_FORMATTER.format(time);
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/server/session/InMemoryWebSessionStore.java
+++ b/spring-web/src/main/java/org/springframework/web/server/session/InMemoryWebSessionStore.java
@@ -19,7 +19,6 @@ package org.springframework.web.server.session;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Iterator;
@@ -51,7 +50,7 @@ public class InMemoryWebSessionStore implements WebSessionStore {
 
 	private int maxSessions = 10000;
 
-	private Clock clock = Clock.system(ZoneId.of("GMT"));
+	private Clock clock = Clock.systemUTC();
 
 	private final Map<String, InMemoryWebSession> sessions = new ConcurrentHashMap<>();
 

--- a/spring-web/src/test/java/org/springframework/http/HttpHeadersTests.java
+++ b/spring-web/src/test/java/org/springframework/http/HttpHeadersTests.java
@@ -20,7 +20,7 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -370,7 +370,7 @@ class HttpHeadersTests {
 
 	@Test
 	void expiresZonedDateTime() {
-		ZonedDateTime zonedDateTime = ZonedDateTime.of(2008, 12, 18, 10, 20, 0, 0, ZoneId.of("GMT"));
+		ZonedDateTime zonedDateTime = ZonedDateTime.of(2008, 12, 18, 10, 20, 0, 0, ZoneOffset.UTC);
 		headers.setExpires(zonedDateTime);
 		assertThat(headers.getExpires()).as("Invalid Expires header").isEqualTo(zonedDateTime.toInstant().toEpochMilli());
 		assertThat(headers.getFirst("expires")).as("Invalid Expires header").isEqualTo("Thu, 18 Dec 2008 10:20:00 GMT");
@@ -605,7 +605,7 @@ class HttpHeadersTests {
 
 	@Test
 	void firstZonedDateTime() {
-		ZonedDateTime date = ZonedDateTime.of(2017, 6, 2, 2, 22, 0, 0, ZoneId.of("GMT"));
+		ZonedDateTime date = ZonedDateTime.of(2017, 6, 2, 2, 22, 0, 0, ZoneOffset.UTC);
 		headers.setZonedDateTime(HttpHeaders.DATE, date);
 		assertThat(headers.getFirst(HttpHeaders.DATE)).isEqualTo("Fri, 02 Jun 2017 02:22:00 GMT");
 		assertThat(headers.getFirstZonedDateTime(HttpHeaders.DATE).isEqual(date)).isTrue();

--- a/spring-web/src/test/java/org/springframework/http/client/reactive/ClientHttpConnectorTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/reactive/ClientHttpConnectorTests.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -184,7 +184,7 @@ class ClientHttpConnectorTests {
 
 	@ParameterizedConnectorTest
 	void cookieExpireValueSetAsMaxAge(ClientHttpConnector connector) {
-		ZonedDateTime tomorrow = ZonedDateTime.now(ZoneId.of("UTC")).plusDays(1);
+		ZonedDateTime tomorrow = ZonedDateTime.now(ZoneOffset.UTC).plusDays(1);
 		String formattedDate = tomorrow.format(DateTimeFormatter.RFC_1123_DATE_TIME);
 
 		prepareResponse(builder -> builder

--- a/spring-web/src/test/java/org/springframework/web/server/i18n/FixedLocaleContextResolverTests.java
+++ b/spring-web/src/test/java/org/springframework/web/server/i18n/FixedLocaleContextResolverTests.java
@@ -16,7 +16,7 @@
 
 package org.springframework.web.server.i18n;
 
-import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Locale;
 import java.util.TimeZone;
 
@@ -61,7 +61,7 @@ class FixedLocaleContextResolverTests {
 
 	@Test
 	void resolveCustomizedAndTimeZoneLocale() {
-		TimeZone timeZone = TimeZone.getTimeZone(ZoneId.of("UTC"));
+		TimeZone timeZone = TimeZone.getTimeZone(ZoneOffset.UTC);
 		FixedLocaleContextResolver resolver = new FixedLocaleContextResolver(FRANCE, timeZone);
 		TimeZoneAwareLocaleContext context = (TimeZoneAwareLocaleContext) resolver.resolveLocaleContext(exchange());
 		assertThat(context.getLocale()).isEqualTo(FRANCE);

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/server/DefaultRenderingResponseTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/server/DefaultRenderingResponseTests.java
@@ -19,7 +19,6 @@ package org.springframework.web.reactive.function.server;
 import java.time.Duration;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -165,7 +164,7 @@ class DefaultRenderingResponseTests {
 		RenderingResponse renderingResponse = RenderingResponse.create("view")
 				.status(HttpStatus.FOUND)
 				.modelAttributes(model)
-				.build().block(Duration.of(5, ChronoUnit.MILLIS));
+				.build().block(Duration.ofMillis(5));
 		assertThat(renderingResponse).isNotNull();
 
 		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("http://localhost"));

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessorMockTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessorMockTests.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
@@ -97,7 +98,7 @@ import static org.springframework.web.servlet.HandlerMapping.PRODUCIBLE_MEDIA_TY
  */
 class HttpEntityMethodProcessorMockTests {
 
-	private static final ZoneId GMT = ZoneId.of("GMT");
+	private static final ZoneId GMT = ZoneOffset.UTC;
 
 
 	private HttpEntityMethodProcessor processor;


### PR DESCRIPTION

I’d kindly like to suggest considering Error Prone integration featuring the [TimeRules](https://error-prone.picnic.tech/refasterrules/TimeRules/) findings:

As discussed in:

- https://github.com/spring-projects/spring-framework/issues/35270

PS: 

Congratulations on the recent major release — a lot of work has clearly gone into it.
I'm sure Spring Boot will continue to succeed as well.

```
Changes have been made to spring-context/src/main/java/org/springframework/scheduling/support/CronTrigger.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$InstantAtZoneRecipe
Changes have been made to spring-context/src/main/java/org/springframework/format/datetime/standard/DateTimeConverters.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$InstantAtZoneRecipe
Changes have been made to spring-context/src/test/java/org/springframework/scheduling/concurrent/DefaultManagedTaskSchedulerTests.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$DurationOfMinutesRecipe
Changes have been made to spring-test/src/main/java/org/springframework/test/http/HttpHeadersAssert.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$UtcConstantRecipe
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$InstantAtZoneRecipe
Changes have been made to spring-test/src/test/java/org/springframework/test/web/servlet/result/HeaderResultMatchersTests.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$UtcConstantRecipe
Changes have been made to spring-test/src/test/java/org/springframework/test/web/servlet/client/RestTestClientTests.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$UtcConstantRecipe
Changes have been made to spring-test/src/test/java/org/springframework/test/web/support/HeaderAssertionTests.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$UtcConstantRecipe
Changes have been made to spring-web/src/main/java/org/springframework/web/server/session/InMemoryWebSessionStore.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$UtcConstantRecipe
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$UtcClockRecipe
Changes have been made to spring-web/src/main/java/org/springframework/http/HttpHeaders.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$UtcConstantRecipe
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$InstantAtZoneRecipe
Changes have been made to spring-web/src/test/java/org/springframework/web/server/i18n/FixedLocaleContextResolverTests.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$UtcConstantRecipe
Changes have been made to spring-web/src/test/java/org/springframework/http/HttpHeadersTests.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$UtcConstantRecipe
Changes have been made to spring-web/src/test/java/org/springframework/http/client/reactive/ClientHttpConnectorTests.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$UtcConstantRecipe
Changes have been made to spring-webflux/src/test/java/org/springframework/web/reactive/function/server/DefaultRenderingResponseTests.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$DurationOfMillisRecipe
Changes have been made to spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessorMockTests.java by:
    tech.picnic.errorprone.refasterrules.TimeRulesRecipes
        tech.picnic.errorprone.refasterrules.TimeRulesRecipes$UtcConstantRecipe
Please review and commit the results.
Estimate time saved: 1h 10m
```

