### PR TITLE
Upgrade to json-path 2.10.0

### DIFF
--- a/framework-platform/framework-platform.gradle
+++ b/framework-platform/framework-platform.gradle
@@ -33,7 +33,7 @@ dependencies {
 		api("com.google.code.gson:gson:2.13.2")
 		api("com.google.protobuf:protobuf-java-util:4.32.1")
 		api("com.h2database:h2:2.3.232")
-		api("com.jayway.jsonpath:json-path:2.9.0")
+		api("com.jayway.jsonpath:json-path:2.10.0")
 		api("com.networknt:json-schema-validator:1.5.3")
 		api("com.oracle.database.jdbc:ojdbc11:21.9.0.0")
 		api("com.rometools:rome:1.19.0")


### PR DESCRIPTION
## Summary
 
1. Why:
To remove CVEs:
     - [CVE-2024-57699](https://avd.aquasec.com/nvd/2024/cve-2024-57699/)
     - This CVE affects `json-smart` library and can lead to denial-of-service through stack exhaustion when parsing malicious JSON

2. What:

     - Upgrade  `json-path` to 2.10.0 to remove [CVE-2024-57699](https://avd.aquasec.com/nvd/2024/cve-2024-57699/)
     - `json-smart` is a transitive dependency of `json-path` and it needed 2.5.2+ version
     - By upgrading `json-path` to 2.10.0, `json-smart` was upgraded to 2.6.0
 
 ## Additional evidence
 
 Partial output from security scanner Trivy:
<img width="1395" height="75" alt="spring-framework cves json-smart" src="https://github.com/user-attachments/assets/692efe64-295b-4abe-bc1a-400426bcd344" />

 ## Categorization

- [x] security/CVE