### PR TITLE
SubscriberInputStream#resume misuses parked thread reference

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/buffer/SubscriberInputStream.java
+++ b/spring-core/src/main/java/org/springframework/core/io/buffer/SubscriberInputStream.java
@@ -185,7 +185,7 @@ final class SubscriberInputStream extends InputStream implements Subscriber<Data
 	}
 
 	private void resume() {
-		if (this.parkedThread != READY) {
+		if (this.parkedThread.get() != READY) {
 			Object old = this.parkedThread.getAndSet(READY);
 			if (old != READY) {
 				LockSupport.unpark((Thread)old);


### PR DESCRIPTION
This PR tries to fix the `SubscriberInputStream.resume()`.

See gh-35468