### PR TITLE
Polish formatting in DefaultEntityResponseBuilder

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/DefaultEntityResponseBuilder.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/DefaultEntityResponseBuilder.java
@@ -264,7 +264,7 @@ final class DefaultEntityResponseBuilder<T> implements EntityResponse.Builder<T>
 				HttpServletResponse servletResponse, Context context)
 				throws ServletException, IOException {
 
-			writeEntityWithMessageConverters(this.entity, servletRequest,servletResponse, context);
+			writeEntityWithMessageConverters(this.entity, servletRequest, servletResponse, context);
 			return null;
 		}
 


### PR DESCRIPTION
This PR applies a minor formatting polish in `DefaultEntityResponseBuilder`
by adding a missing space after a comma for improved readability.

```java
- writeEntityWithMessageConverters(this.entity, servletRequest,servletResponse, context);
+ writeEntityWithMessageConverters(this.entity, servletRequest, servletResponse, context);
