### PR TITLE
Polish async test by removing sleep in DefaultAsyncServerResponseTests

### DIFF
--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/function/DefaultAsyncServerResponseTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/function/DefaultAsyncServerResponseTests.java
@@ -39,16 +39,10 @@ class DefaultAsyncServerResponseTests {
 	@Test
 	void blockNotCompleted() {
 		ServerResponse wrappee = ServerResponse.ok().build();
-		CompletableFuture<ServerResponse> future = CompletableFuture.supplyAsync(() -> {
-			try {
-				Thread.sleep(500);
-				return wrappee;
-			}
-			catch (InterruptedException ex) {
-				throw new RuntimeException(ex);
-			}
-		});
+		CompletableFuture<ServerResponse> future = new CompletableFuture<>();
 		AsyncServerResponse response = AsyncServerResponse.create(future);
+
+		new Thread(() -> future.complete(wrappee)).start();
 
 		assertThat(response.block()).isSameAs(wrappee);
 	}


### PR DESCRIPTION
This PR removes Thread.sleep from async tests in DefaultAsyncServerResponseTests
and replaces it with a non-blocking CompletableFuture pattern. This makes the
test more deterministic and avoids timing-based flakiness.

### 🔍 What was changed
- Removed `Thread.sleep(500)` inside `CompletableFuture.supplyAsync`
- Replaced it with a non-blocking test pattern:
  - Created an incomplete `CompletableFuture`
  - Completed it asynchronously using `new Thread(() -> future.complete(...))`
- This makes the test more deterministic and avoids relying on timing-based behavior

### 💡 Why this change
Using `Thread.sleep` in tests is generally discouraged because:
- It increases test execution time
- It may lead to unstable test results depending on system timing
- It does not reflect real asynchronous behavior

The updated approach ensures:
- Faster test execution
- More reliable async behavior
- Clearer test intent

### 📌 Notes
No functional changes were made to production code.  
This update improves the internal test quality and stability.
