### PR TITLE
SimpleAliasRegistry: extend test cases + small fix around alias overriding

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/SimpleAliasRegistry.java
+++ b/spring-core/src/main/java/org/springframework/core/SimpleAliasRegistry.java
@@ -59,6 +59,11 @@ public class SimpleAliasRegistry implements AliasRegistry {
 		Assert.hasText(alias, "'alias' must not be empty");
 		synchronized (this.aliasMap) {
 			if (alias.equals(name)) {
+				String registeredName = this.aliasMap.get(alias);
+				if (registeredName != null && !registeredName.equals(name) && !allowAliasOverriding()) {
+					throw new IllegalStateException("Cannot define alias '" + alias + "' for name '" +
+							name + "': It is already registered for name '" + registeredName + "'.");
+				}
 				this.aliasMap.remove(alias);
 				this.aliasNames.remove(alias);
 				if (logger.isDebugEnabled()) {


### PR DESCRIPTION
Hi, here is a Pull Request that:

1. extends the existing `SimpleAliasRegistryTests` to cover the `allowAliasOverriding` functionality.
2. updates the implementation to fix a corner case issue in the `SimpleAliasRegistry` (explanation below).

**Old behaviour was:**
- _register alias A -> B:_ :white_check_mark: OK
- _register alias A -> A_: :white_check_mark: OK
   - ⚠️ But alias A -> B was gone, which is not the expected behaviour as alias A -> B was overridden.

To my opinion, this should only be allowed if `allowAliasOverriding = true`, in exactly the same way as the existing implementation would only allow registering alias [A -> C] if `allowAliasOverriding = true`.

**New behaviour:**
- _register alias A -> B_: OK :white_check_mark:
- _register alias A -> A_:
   - :white_check_mark: OK if `allowAliasOverriding = true`
   - :x: Otherwise throws exception

**Behaviour covered the following test cases in this PR:** 
- `SimpleAliasRegistryTests.registerAliasWithSameName_GivenAliasOverridingAllowed_ThenReplacesExistingAlias `
- `SimpleAliasRegistryTests.registerAliasWithSameName_GivenAliasOverridingNotAllowed_ThenThrowsException`

Thank you for the review, and have a nice day.