### PR TITLE
StopWatchTests: improve test cases

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/StopWatch.java
+++ b/spring-core/src/main/java/org/springframework/util/StopWatch.java
@@ -76,7 +76,7 @@ public class StopWatch {
 	private long totalTimeNanos;
 
 	/**
-	 * The {@link NanoClock} to compute execution times of tasks.
+	 * The {@link NanoClock} used to compute execution times of tasks.
 	 * <br/>
 	 * Defaults to {@link System#nanoTime()}, other implementations can be injected for unit testing.
 	 */
@@ -107,7 +107,7 @@ public class StopWatch {
 	 * to distinguish between them.
 	 * <p>Does not start any task.
 	 * @param id identifier for this stop watch
-	 * @param nanoClock the {@link NanoClock} to compute execution times of tasks
+	 * @param nanoClock the {@link NanoClock} used to compute execution times of tasks
 	 */
 	public StopWatch(String id, NanoClock nanoClock) {
 		this.id = id;

--- a/spring-core/src/main/java/org/springframework/util/StopWatch.java
+++ b/spring-core/src/main/java/org/springframework/util/StopWatch.java
@@ -75,6 +75,12 @@ public class StopWatch {
 	/** Total running time. */
 	private long totalTimeNanos;
 
+	/**
+	 * The {@link NanoClock} to compute execution times of tasks.
+	 * <br/>
+	 * Defaults to {@link System#nanoTime()}, other implementations can be injected for unit testing.
+	 */
+	private final NanoClock nanoClock;
 
 	/**
 	 * Construct a new {@code StopWatch}.
@@ -92,9 +98,21 @@ public class StopWatch {
 	 * @param id identifier for this stop watch
 	 */
 	public StopWatch(String id) {
-		this.id = id;
+		this(id, System::nanoTime);
 	}
 
+	/**
+	 * Construct a new {@code StopWatch} with the given id.
+	 * <p>The id is handy when we have output from multiple stop watches and need
+	 * to distinguish between them.
+	 * <p>Does not start any task.
+	 * @param id identifier for this stop watch
+	 * @param nanoClock the {@link NanoClock} to compute execution times of tasks
+	 */
+	public StopWatch(String id, NanoClock nanoClock) {
+		this.id = id;
+		this.nanoClock = nanoClock;
+	}
 
 	/**
 	 * Get the id of this {@code StopWatch}, as specified on construction.
@@ -141,7 +159,7 @@ public class StopWatch {
 			throw new IllegalStateException("Can't start StopWatch: it's already running");
 		}
 		this.currentTaskName = taskName;
-		this.startTimeNanos = System.nanoTime();
+		this.startTimeNanos = nanoClock.nanoTime();
 	}
 
 	/**
@@ -155,7 +173,7 @@ public class StopWatch {
 		if (this.currentTaskName == null) {
 			throw new IllegalStateException("Can't stop StopWatch: it's not running");
 		}
-		long lastTime = System.nanoTime() - this.startTimeNanos;
+		long lastTime = nanoClock.nanoTime() - this.startTimeNanos;
 		this.totalTimeNanos += lastTime;
 		this.lastTaskInfo = new TaskInfo(this.currentTaskName, lastTime);
 		if (this.taskList != null) {
@@ -389,6 +407,14 @@ public class StopWatch {
 		return sb.toString();
 	}
 
+	/**
+	 * An abstraction of a clock that provides nanosecond precision and that can be used to compute relative times.
+	 */
+	public interface NanoClock {
+
+		long nanoTime();
+
+	}
 
 	/**
 	 * Nested class to hold data about one task executed within the {@code StopWatch}.

--- a/spring-core/src/test/java/org/springframework/util/StopWatchTests.java
+++ b/spring-core/src/test/java/org/springframework/util/StopWatchTests.java
@@ -95,7 +95,7 @@ class StopWatchTests {
 
 		assertThat(stopWatch.lastTaskInfo().getTimeNanos())
 				.as("last task time in nanoseconds for task #1")
-				.isEqualTo(1_000_000_000L);;
+				.isEqualTo(1_000_000_000L);
 		assertThat(stopWatch.getTotalTimeMillis())
 				.as("total time in milliseconds")
 				.isEqualTo(1_000L);

--- a/spring-core/src/test/java/org/springframework/util/StopWatchTests.java
+++ b/spring-core/src/test/java/org/springframework/util/StopWatchTests.java
@@ -23,7 +23,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.util.StopWatch.TaskInfo;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.Mockito.when;
 
 /**


### PR DESCRIPTION
Hi, here is a Pull Request that improves the test cases for `StopWatch` by:

- restoring and replacing flaky asserts by a deterministic implementation
- removing the need of running `Thread.sleep` in unit tests

Thank you for the review, and have a nice day.