### PR TITLE
Use StringBuilder in JdbcTemplate for batch updates

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -605,14 +605,20 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 						rowsAffected = stmt.executeBatch();
 					}
 					catch (BatchUpdateException ex) {
-						String batchExceptionSql = null;
-						for (int i = 0; i < ex.getUpdateCounts().length; i++) {
-							if (ex.getUpdateCounts()[i] == Statement.EXECUTE_FAILED) {
-								batchExceptionSql = appendSql(batchExceptionSql, sql[i]);
+						int[] updateCounts = ex.getUpdateCounts();
+						StringBuilder batchExceptionSql = new StringBuilder();
+
+						for (int i = 0; i < Math.min(updateCounts.length, sql.length); i++) {
+							if (updateCounts[i] == Statement.EXECUTE_FAILED) {
+								if (batchExceptionSql.length() > 0) {
+									batchExceptionSql.append("; ");
+								}
+								batchExceptionSql.append(sql[i]);
 							}
 						}
-						if (StringUtils.hasLength(batchExceptionSql)) {
-							this.currSql = batchExceptionSql;
+
+						if (batchExceptionSql.length() > 0) {
+							this.currSql = batchExceptionSql.toString();
 						}
 						throw ex;
 					}


### PR DESCRIPTION

### Description
As discussed in issue #36030, this PR refactors the exception handling logic within
`JdbcTemplate.batchUpdate(String... sql)`.

Currently, String concatenation is used inside a loop when constructing the error
message for a `BatchUpdateException`. This PR replaces it with `StringBuilder` to
avoid unnecessary temporary object allocation in the failure path.

### Changes
- **Replaced String concatenation with `StringBuilder`**: avoids unnecessary temporary
  object allocation for loop-based SQL accumulation.
- **Added Safety Check**: uses `Math.min(updateCounts.length, sql.length)` to safely
  handle edge cases where JDBC drivers may return fewer update counts than the number
  of SQL statements.
- **Preserved Existing Behavior**: the happy path logic remains unchanged, and the
  resulting error message format is identical to the previous implementation.

### Verification
Verified by the existing CI test suite.
