### PR TITLE
Update to NullAway 0.12.15 and fix new warnings

### DIFF
--- a/gradle/spring-module.gradle
+++ b/gradle/spring-module.gradle
@@ -105,6 +105,10 @@ tasks.register('javadocJar', Jar) {
 	from javadoc
 }
 
+nullability {
+    nullAwayVersion = "0.12.15"
+}
+
 publishing {
 	publications {
 		mavenJava(MavenPublication) {

--- a/spring-core/src/main/java/org/springframework/core/codec/Decoder.java
+++ b/spring-core/src/main/java/org/springframework/core/codec/Decoder.java
@@ -93,7 +93,7 @@ public interface Decoder<T> {
 	default @Nullable T decode(DataBuffer buffer, ResolvableType targetType,
 			@Nullable MimeType mimeType, @Nullable Map<String, Object> hints) throws DecodingException {
 
-		CompletableFuture<T> future = decodeToMono(Mono.just(buffer), targetType, mimeType, hints).toFuture();
+		CompletableFuture<@Nullable T> future = decodeToMono(Mono.just(buffer), targetType, mimeType, hints).toFuture();
 		Assert.state(future.isDone(), "DataBuffer decoding should have completed");
 
 		try {

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompBrokerRelayMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompBrokerRelayMessageHandler.java
@@ -96,7 +96,7 @@ public class StompBrokerRelayMessageHandler extends AbstractBrokerMessageHandler
 
 	private static final byte[] EMPTY_PAYLOAD = new byte[0];
 
-	private static final CompletableFuture<Void> EMPTY_TASK = CompletableFuture.completedFuture(null);
+	private static final CompletableFuture<@Nullable Void> EMPTY_TASK = CompletableFuture.completedFuture(null);
 
 	private static final StompHeaderAccessor HEART_BEAT_ACCESSOR;
 
@@ -851,7 +851,7 @@ public class StompBrokerRelayMessageHandler extends AbstractBrokerMessageHandler
 		 * @return a future to wait for the result
 		 */
 		@SuppressWarnings("unchecked")
-		public CompletableFuture<Void> forward(final Message<?> message, final StompHeaderAccessor accessor) {
+		public CompletableFuture<@Nullable Void> forward(final Message<?> message, final StompHeaderAccessor accessor) {
 			TcpConnection<byte[]> conn = this.tcpConnection;
 
 			if (!this.isStompConnected || conn == null) {
@@ -887,7 +887,7 @@ public class StompBrokerRelayMessageHandler extends AbstractBrokerMessageHandler
 				logger.trace("Forwarding " + accessor.getDetailedLogMessage(message.getPayload()));
 			}
 
-			CompletableFuture<Void> future = conn.sendAsync((Message<byte[]>) messageToSend);
+			CompletableFuture<@Nullable Void> future = conn.sendAsync((Message<byte[]>) messageToSend);
 			future.whenComplete((unused, throwable) -> {
 				if (throwable == null) {
 					if (accessor.getCommand() == StompCommand.DISCONNECT) {
@@ -1067,9 +1067,9 @@ public class StompBrokerRelayMessageHandler extends AbstractBrokerMessageHandler
 		}
 
 		@Override
-		public CompletableFuture<Void> forward(Message<?> message, StompHeaderAccessor accessor) {
+		public CompletableFuture<@Nullable Void> forward(Message<?> message, StompHeaderAccessor accessor) {
 			try {
-				CompletableFuture<Void> future = super.forward(message, accessor);
+				CompletableFuture<@Nullable Void> future = super.forward(message, accessor);
 				if (message.getHeaders().get(SimpMessageHeaderAccessor.IGNORE_ERROR) == null) {
 					future.get();
 				}

--- a/spring-messaging/src/main/java/org/springframework/messaging/tcp/TcpConnection.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/tcp/TcpConnection.java
@@ -19,6 +19,8 @@ package org.springframework.messaging.tcp;
 import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.messaging.Message;
 
 /**
@@ -37,7 +39,7 @@ public interface TcpConnection<P> extends Closeable {
 	 * message was successfully sent
 	 * @since 6.0
 	 */
-	CompletableFuture<Void> sendAsync(Message<P> message);
+	CompletableFuture<@Nullable Void> sendAsync(Message<P> message);
 
 	/**
 	 * Register a task to invoke after a period of read inactivity.

--- a/spring-messaging/src/main/java/org/springframework/messaging/tcp/TcpOperations.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/tcp/TcpOperations.java
@@ -18,6 +18,9 @@ package org.springframework.messaging.tcp;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.jspecify.annotations.Nullable;
+
+
 /**
  * A contract for establishing TCP connections.
  *
@@ -34,7 +37,7 @@ public interface TcpOperations<P> {
 	 * connection is successfully established
 	 * @since 6.0
 	 */
-	CompletableFuture<Void> connectAsync(TcpConnectionHandler<P> connectionHandler);
+	CompletableFuture<@Nullable Void> connectAsync(TcpConnectionHandler<P> connectionHandler);
 
 	/**
 	 * Open a new connection and a strategy for reconnecting if the connection fails.
@@ -44,7 +47,7 @@ public interface TcpOperations<P> {
 	 * initial connection is successfully established
 	 * @since 6.0
 	 */
-	CompletableFuture<Void> connectAsync(TcpConnectionHandler<P> connectionHandler, ReconnectStrategy reconnectStrategy);
+	CompletableFuture<@Nullable Void> connectAsync(TcpConnectionHandler<P> connectionHandler, ReconnectStrategy reconnectStrategy);
 
 	/**
 	 * Shut down and close any open connections.
@@ -52,6 +55,6 @@ public interface TcpOperations<P> {
 	 * connection is successfully closed
 	 * @since 6.0
 	 */
-	CompletableFuture<Void> shutdownAsync();
+	CompletableFuture<@Nullable Void> shutdownAsync();
 
 }

--- a/spring-messaging/src/main/java/org/springframework/messaging/tcp/reactor/ReactorNettyTcpClient.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/tcp/reactor/ReactorNettyTcpClient.java
@@ -172,7 +172,7 @@ public class ReactorNettyTcpClient<P> implements TcpOperations<P> {
 
 
 	@Override
-	public CompletableFuture<Void> connectAsync(TcpConnectionHandler<P> handler) {
+	public CompletableFuture<@Nullable Void> connectAsync(TcpConnectionHandler<P> handler) {
 		Assert.notNull(handler, "TcpConnectionHandler is required");
 
 		if (this.stopping) {
@@ -200,7 +200,7 @@ public class ReactorNettyTcpClient<P> implements TcpOperations<P> {
 	}
 
 	@Override
-	public CompletableFuture<Void> connectAsync(TcpConnectionHandler<P> handler, ReconnectStrategy strategy) {
+	public CompletableFuture<@Nullable Void> connectAsync(TcpConnectionHandler<P> handler, ReconnectStrategy strategy) {
 		Assert.notNull(handler, "TcpConnectionHandler is required");
 		Assert.notNull(strategy, "ReconnectStrategy is required");
 
@@ -209,7 +209,7 @@ public class ReactorNettyTcpClient<P> implements TcpOperations<P> {
 		}
 
 		// Report first connect to the ListenableFuture
-		CompletableFuture<Void> connectFuture = new CompletableFuture<>();
+		CompletableFuture<@Nullable Void> connectFuture = new CompletableFuture<>();
 
 		extendTcpClient(this.tcpClient, handler)
 				.handle(new ReactorNettyHandler(handler))
@@ -228,7 +228,7 @@ public class ReactorNettyTcpClient<P> implements TcpOperations<P> {
 		return connectFuture;
 	}
 
-	private CompletableFuture<Void> handleShuttingDownConnectFailure(TcpConnectionHandler<P> handler) {
+	private CompletableFuture<@Nullable Void> handleShuttingDownConnectFailure(TcpConnectionHandler<P> handler) {
 		IllegalStateException ex = new IllegalStateException("Shutting down.");
 		handler.afterConnectFailure(ex);
 		return Mono.<Void>error(ex).toFuture();
@@ -240,7 +240,7 @@ public class ReactorNettyTcpClient<P> implements TcpOperations<P> {
 	}
 
 	@Override
-	public CompletableFuture<Void> shutdownAsync() {
+	public CompletableFuture<@Nullable Void> shutdownAsync() {
 		if (this.stopping) {
 			return CompletableFuture.completedFuture(null);
 		}

--- a/spring-messaging/src/main/java/org/springframework/messaging/tcp/reactor/ReactorNettyTcpConnection.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/tcp/reactor/ReactorNettyTcpConnection.java
@@ -19,6 +19,7 @@ package org.springframework.messaging.tcp.reactor;
 import java.util.concurrent.CompletableFuture;
 
 import io.netty.buffer.ByteBuf;
+import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Mono;
 import reactor.core.publisher.Sinks;
 import reactor.netty.NettyInbound;
@@ -56,7 +57,7 @@ public class ReactorNettyTcpConnection<P> implements TcpConnection<P> {
 
 
 	@Override
-	public CompletableFuture<Void> sendAsync(Message<P> message) {
+	public CompletableFuture<@Nullable Void> sendAsync(Message<P> message) {
 		ByteBuf byteBuf = this.outbound.alloc().buffer();
 		this.codec.encode(message, byteBuf);
 		return this.outbound.send(Mono.just(byteBuf))

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/SyncInvocableHandlerMethod.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/SyncInvocableHandlerMethod.java
@@ -100,7 +100,7 @@ public class SyncInvocableHandlerMethod extends HandlerMethod {
 	public @Nullable HandlerResult invokeForHandlerResult(ServerWebExchange exchange,
 			BindingContext bindingContext, Object... providedArgs) {
 
-		CompletableFuture<HandlerResult> future =
+		CompletableFuture<@Nullable HandlerResult> future =
 				this.delegate.invoke(exchange, bindingContext, providedArgs).toFuture();
 
 		if (!future.isDone()) {

--- a/spring-websocket/src/main/java/org/springframework/web/socket/messaging/WebSocketStompClient.java
+++ b/spring-websocket/src/main/java/org/springframework/web/socket/messaging/WebSocketStompClient.java
@@ -387,9 +387,9 @@ public class WebSocketStompClient extends StompClientSupport implements SmartLif
 		// TcpConnection implementation
 
 		@Override
-		public CompletableFuture<Void> sendAsync(Message<byte[]> message) {
+		public CompletableFuture<@Nullable Void> sendAsync(Message<byte[]> message) {
 			updateLastWriteTime();
-			CompletableFuture<Void> future = new CompletableFuture<>();
+			CompletableFuture<@Nullable Void> future = new CompletableFuture<>();
 			try {
 				WebSocketSession session = this.session;
 				Assert.state(session != null, "No WebSocketSession available");


### PR DESCRIPTION
The new warnings are a consequence of https://github.com/uber/NullAway/pull/1371, which better detects annotations on type arguments in return types.  

Fortunately, the fixes are straightforward.  Note that writing `@Nullable Void` is required by JSpecify (see https://github.com/jspecify/jspecify/issues/51).  This is not yet checked exhaustively by NullAway, but some instances were caught here.