### PR TITLE
Fix case-insensitive semantics for LinkedCaseInsensitiveMap entrySet

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/LinkedCaseInsensitiveMap.java
+++ b/spring-core/src/main/java/org/springframework/util/LinkedCaseInsensitiveMap.java
@@ -448,7 +448,18 @@ public class LinkedCaseInsensitiveMap<V> implements Map<String, V>, Serializable
 
 		@Override
 		public boolean contains(Object o) {
-			return this.delegate.contains(o);
+			if (!(o instanceof Map.Entry<?, ?> entry)) {
+				return false;
+			}
+			Object key = entry.getKey();
+			if (!(key instanceof String stringKey)) {
+				return false;
+			}
+			if (!LinkedCaseInsensitiveMap.this.containsKey(stringKey)) {
+				return false;
+			}
+			V value = LinkedCaseInsensitiveMap.this.get(stringKey);
+			return ObjectUtils.nullSafeEquals(value, entry.getValue());
 		}
 
 		@Override
@@ -457,13 +468,23 @@ public class LinkedCaseInsensitiveMap<V> implements Map<String, V>, Serializable
 		}
 
 		@Override
-		@SuppressWarnings("unchecked")
 		public boolean remove(Object o) {
-			if (this.delegate.remove(o)) {
-				removeCaseInsensitiveKey(((Map.Entry<String, V>) o).getKey());
-				return true;
+			if (!(o instanceof Map.Entry<?, ?> entry)) {
+				return false;
 			}
-			return false;
+			Object key = entry.getKey();
+			if (!(key instanceof String stringKey)) {
+				return false;
+			}
+			if (!LinkedCaseInsensitiveMap.this.containsKey(stringKey)) {
+				return false;
+			}
+			V value = LinkedCaseInsensitiveMap.this.get(stringKey);
+			if (!ObjectUtils.nullSafeEquals(value, entry.getValue())) {
+				return false;
+			}
+			LinkedCaseInsensitiveMap.this.remove(stringKey);
+			return true;
 		}
 
 		@Override

--- a/spring-core/src/test/java/org/springframework/util/LinkedCaseInsensitiveMapTests.java
+++ b/spring-core/src/test/java/org/springframework/util/LinkedCaseInsensitiveMapTests.java
@@ -17,6 +17,7 @@
 package org.springframework.util;
 
 import java.util.Iterator;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -216,6 +217,21 @@ class LinkedCaseInsensitiveMapTests {
 		assertThat(map).isEmpty();
 		map.computeIfAbsent("key", k -> "newvalue");
 		assertThat(map.get("key")).isEqualTo("newvalue");
+	}
+
+	@Test
+	void entrySetContainsIsCaseInsensitive() {
+		map.put("Key", "value");
+		assertThat(map.entrySet().contains(Map.entry("KEY", "value"))).isTrue();
+		assertThat(map.entrySet().contains(Map.entry("key", "value"))).isTrue();
+		assertThat(map.entrySet().contains(Map.entry("Key", "value"))).isTrue();
+	}
+
+	@Test
+	void entrySetRemoveIsCaseInsensitive() {
+		map.put("Key", "value");
+		assertThat(map.entrySet().remove(Map.entry("KEY", "value"))).isTrue();
+		assertThat(map).isEmpty();
 	}
 
 	private void nextAndRemove(Iterator<?> iterator) {


### PR DESCRIPTION
### Summary
Align `LinkedCaseInsensitiveMap`’s `entrySet()` view with the map’s case-insensitive key contract by making `entrySet().contains(..)` and `entrySet().remove(..)` perform case-insensitive key resolution.

### Background
`LinkedCaseInsensitiveMap` provides case-insensitive behavior for `containsKey/get/remove`. However, `entrySet()` operations previously delegated to the backing map’s entry set, which performs case-sensitive key comparisons. As a result, entry-based operations could miss existing mappings when callers used different key casing.

### Example
```java
LinkedCaseInsensitiveMap<String> map = new LinkedCaseInsensitiveMap<>();
map.put("Key", "value");

assertThat(map.containsKey("KEY")).isTrue();
assertThat(map.entrySet()).contains(Map.entry("KEY", "value")); // previously failed
assertThat(map.entrySet().remove(Map.entry("key", "value"))).isTrue();
assertThat(map).isEmpty();
```

### Changes
- Implement case-insensitive key lookup for EntrySet.contains(Object) and EntrySet.remove(Object) via containsKey/get/remove
- Preserve Map.Entry semantics by requiring value equality (using ObjectUtils.nullSafeEquals) before removing

### Tests
- `./gradlew :spring-core:test --tests org.springframework.util.LinkedCaseInsensitiveMapTests`
- `./gradlew :spring-core:test`