### PR TITLE
Retain application context between test classes

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/RetainApplicationContext.java
+++ b/spring-test/src/main/java/org/springframework/test/context/RetainApplicationContext.java
@@ -1,0 +1,28 @@
+package org.springframework.test.context;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that the {@link org.springframework.context.ApplicationContext}
+ * associated with the test should be retained between test classes and
+ * not paused when it is reused from the context cache.
+ *
+ * <p>This is an opt-in mechanism intended for tests that rely on expensive
+ * {@link org.springframework.context.SmartLifecycle} components whose
+ * stop/start cycles significantly impact test performance.
+ *
+ * <p>When a test class is annotated with {@code @RetainApplicationContext},
+ * the application context will <em>not</em> be paused or restarted between
+ * test classes, even if the context would normally be considered unused.
+ *
+ * @since 7.0
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface RetainApplicationContext {
+}


### PR DESCRIPTION
Problem:
Tests using @SpringBootTest are slower in Spring Boot 4.0 because
ApplicationContext is paused/restarted between test classes even
when they share the same context. This particularly affects tests
with expensive SmartLifecycle beans like Kafka consumers.

Solution:
Introduce @RetainApplicationContext annotation to mark test classes
whose context should not be paused/restarted. Update
DefaultTestContext.markApplicationContextUnused() to check for this
annotation before unregistering context usage.

Usage:
Annotate abstract test classes with @RetainApplicationContext to
retain context between subclasses, reducing overhead.

Closes gh-36044