### PR TITLE
Consistently declare `@Nullable` on  parameter in `equals()` implementations

### DIFF
--- a/spring-aop/src/main/java/org/springframework/aop/framework/AdvisedSupport.java
+++ b/spring-aop/src/main/java/org/springframework/aop/framework/AdvisedSupport.java
@@ -731,7 +731,7 @@ public class AdvisedSupport extends ProxyConfig implements Advised {
 		}
 
 		@Override
-		public boolean equals(Object other) {
+		public boolean equals(@Nullable Object other) {
 			return (this == other || (other instanceof AdvisorKeyEntry that &&
 					this.adviceType == that.adviceType &&
 					ObjectUtils.nullSafeEquals(this.classFilterKey, that.classFilterKey) &&

--- a/spring-aop/src/main/java/org/springframework/aop/support/ClassFilters.java
+++ b/spring-aop/src/main/java/org/springframework/aop/support/ClassFilters.java
@@ -198,7 +198,7 @@ public abstract class ClassFilters {
 		}
 
 		@Override
-		public boolean equals(Object other) {
+		public boolean equals(@Nullable Object other) {
 			return (this == other || (other instanceof NegateClassFilter that &&
 					this.original.equals(that.original)));
 		}

--- a/spring-aop/src/main/java/org/springframework/aop/support/MethodMatchers.java
+++ b/spring-aop/src/main/java/org/springframework/aop/support/MethodMatchers.java
@@ -378,7 +378,7 @@ public abstract class MethodMatchers {
 		}
 
 		@Override
-		public boolean equals(Object other) {
+		public boolean equals(@Nullable Object other) {
 			return (this == other || (other instanceof NegateMethodMatcher that &&
 					this.original.equals(that.original)));
 		}

--- a/spring-context/src/main/java/org/springframework/scheduling/support/BitsCronField.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/support/BitsCronField.java
@@ -247,7 +247,7 @@ final class BitsCronField extends CronField {
 
 
 	@Override
-	public boolean equals(Object other) {
+	public boolean equals(@Nullable Object other) {
 		return (this == other || (other instanceof BitsCronField that &&
 				type() == that.type() && this.bits == that.bits));
 	}

--- a/spring-core/src/main/java/org/springframework/core/io/buffer/JettyDataBuffer.java
+++ b/spring-core/src/main/java/org/springframework/core/io/buffer/JettyDataBuffer.java
@@ -300,7 +300,7 @@ public final class JettyDataBuffer implements PooledDataBuffer {
 
 
 	@Override
-	public boolean equals(Object other) {
+	public boolean equals(@Nullable Object other) {
 		return (this == other || (other instanceof JettyDataBuffer otherBuffer &&
 				this.delegate.equals(otherBuffer.delegate)));
 	}

--- a/spring-test/src/main/java/org/springframework/test/context/bean/override/BeanOverrideContextCustomizer.java
+++ b/spring-test/src/main/java/org/springframework/test/context/bean/override/BeanOverrideContextCustomizer.java
@@ -18,6 +18,8 @@ package org.springframework.test.context.bean.override;
 
 import java.util.Set;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.test.context.ContextCustomizer;
@@ -69,7 +71,7 @@ class BeanOverrideContextCustomizer implements ContextCustomizer {
 	}
 
 	@Override
-	public boolean equals(Object other) {
+	public boolean equals(@Nullable Object other) {
 		if (other == this) {
 			return true;
 		}

--- a/spring-test/src/main/java/org/springframework/test/context/bean/override/BeanOverrideHandler.java
+++ b/spring-test/src/main/java/org/springframework/test/context/bean/override/BeanOverrideHandler.java
@@ -369,7 +369,7 @@ public abstract class BeanOverrideHandler {
 	}
 
 	@Override
-	public boolean equals(Object other) {
+	public boolean equals(@Nullable Object other) {
 		if (other == this) {
 			return true;
 		}

--- a/spring-web/src/main/java/org/springframework/http/ETag.java
+++ b/spring-web/src/main/java/org/springframework/http/ETag.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.util.StringUtils;
 
@@ -68,7 +69,7 @@ public record ETag(String tag, boolean weak) {
 	}
 
 	@Override
-	public boolean equals(Object other) {
+	public boolean equals(@Nullable Object other) {
 		return (this == other ||
 				(other instanceof ETag oet && this.tag.equals(oet.tag) && this.weak == oet.weak));
 	}

--- a/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
@@ -2331,7 +2331,7 @@ public class HttpHeaders implements Serializable {
 			}
 
 			@Override
-			public boolean equals(Object o) {
+			public boolean equals(@Nullable Object o) {
 				if (this == o) {
 					return true;
 				}

--- a/spring-web/src/main/java/org/springframework/web/accept/SemanticApiVersionParser.java
+++ b/spring-web/src/main/java/org/springframework/web/accept/SemanticApiVersionParser.java
@@ -19,6 +19,8 @@ package org.springframework.web.accept;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.util.Assert;
 
 /**
@@ -106,7 +108,7 @@ public class SemanticApiVersionParser implements ApiVersionParser<SemanticApiVer
 		}
 
 		@Override
-		public boolean equals(Object other) {
+		public boolean equals(@Nullable Object other) {
 			return (this == other || (other instanceof Version otherVersion &&
 					this.major == otherVersion.major &&
 					this.minor == otherVersion.minor &&

--- a/spring-web/src/main/java/org/springframework/web/service/invoker/HttpServiceMethod.java
+++ b/spring-web/src/main/java/org/springframework/web/service/invoker/HttpServiceMethod.java
@@ -364,7 +364,7 @@ final class HttpServiceMethod {
 			}
 
 			@Override
-			public boolean equals(Object obj) {
+			public boolean equals(@Nullable Object obj) {
 				return (obj instanceof AnnotationDescriptor that && this.httpExchange.equals(that.httpExchange));
 			}
 

--- a/spring-web/src/main/java/org/springframework/web/util/WhatWgUrlParser.java
+++ b/spring-web/src/main/java/org/springframework/web/util/WhatWgUrlParser.java
@@ -2019,7 +2019,7 @@ final class WhatWgUrlParser {
 		}
 
 		@Override
-		public boolean equals(Object obj) {
+		public boolean equals(@Nullable Object obj) {
 			if (obj == this) {
 				return true;
 			}
@@ -2160,7 +2160,7 @@ final class WhatWgUrlParser {
 		}
 
 		@Override
-		public boolean equals(Object o) {
+		public boolean equals(@Nullable Object o) {
 			if (o == this) {
 				return true;
 			}
@@ -2207,7 +2207,7 @@ final class WhatWgUrlParser {
 		}
 
 		@Override
-		public boolean equals(Object obj) {
+		public boolean equals(@Nullable Object obj) {
 			if (obj == this) {
 				return true;
 			}
@@ -2271,7 +2271,7 @@ final class WhatWgUrlParser {
 		}
 
 		@Override
-		public boolean equals(Object obj) {
+		public boolean equals(@Nullable Object obj) {
 			if (obj == this) {
 				return true;
 			}
@@ -2304,7 +2304,7 @@ final class WhatWgUrlParser {
 		}
 
 		@Override
-		public boolean equals(Object obj) {
+		public boolean equals(@Nullable Object obj) {
 			return obj == this || obj != null && getClass() == obj.getClass();
 		}
 
@@ -2503,7 +2503,7 @@ final class WhatWgUrlParser {
 
 
 		@Override
-		public boolean equals(Object o) {
+		public boolean equals(@Nullable Object o) {
 			if (o == this) {
 				return true;
 			}
@@ -2812,7 +2812,7 @@ final class WhatWgUrlParser {
 		}
 
 		@Override
-		public boolean equals(Object obj) {
+		public boolean equals(@Nullable Object obj) {
 			if (obj == this) {
 				return true;
 			}
@@ -2978,7 +2978,7 @@ final class WhatWgUrlParser {
 		}
 
 		@Override
-		public boolean equals(Object o) {
+		public boolean equals(@Nullable Object o) {
 			if (o == this) {
 				return true;
 			}
@@ -3073,7 +3073,7 @@ final class WhatWgUrlParser {
 		}
 
 		@Override
-		public boolean equals(Object o) {
+		public boolean equals(@Nullable Object o) {
 			if (o == this) {
 				return true;
 			}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestMappingHandlerMapping.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/RequestMappingHandlerMapping.java
@@ -529,7 +529,7 @@ public class RequestMappingHandlerMapping extends RequestMappingInfoHandlerMappi
 		}
 
 		@Override
-		public boolean equals(Object obj) {
+		public boolean equals(@Nullable Object obj) {
 			return (obj instanceof AnnotationDescriptor that && this.annotation.equals(that.annotation));
 		}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMapping.java
@@ -582,7 +582,7 @@ public class RequestMappingHandlerMapping extends RequestMappingInfoHandlerMappi
 		}
 
 		@Override
-		public boolean equals(Object obj) {
+		public boolean equals(@Nullable Object obj) {
 			return (obj instanceof AnnotationDescriptor that && this.annotation.equals(that.annotation));
 		}
 


### PR DESCRIPTION
String found: org.springframework.cglib.core.EmitUtils/KeyFactory
I don't know if they should be changed.

Reason: https://youtrack.jetbrains.com/projects/KT/issues/KT-83314/JSpecify-NullMarked-changes-Java-equalsObject-to-equalsAny-causing-override-conflict-in-Kotlin-2.3