### PR TITLE
Use String instead of long for JFR event IDs to support JMC filtering.

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/metrics/jfr/FlightRecorderStartupEvent.java
+++ b/spring-core/src/main/java/org/springframework/core/metrics/jfr/FlightRecorderStartupEvent.java
@@ -29,6 +29,7 @@ import jdk.jfr.Label;
  * as a single {@code String}, since Flight Recorder events do not support complex types.
  *
  * @author Brian Clozel
+ * @author Huang Xiao
  * @since 5.3
  */
 @Category("Spring Application")
@@ -36,9 +37,11 @@ import jdk.jfr.Label;
 @Description("Spring Application Startup")
 class FlightRecorderStartupEvent extends Event {
 
-	public final long eventId;
+	@Label("EventId")
+	public final String eventId;
 
-	public final long parentId;
+	@Label("ParentId")
+	public final String parentId;
 
 	@Label("Name")
 	public final String name;
@@ -48,8 +51,8 @@ class FlightRecorderStartupEvent extends Event {
 
 	public FlightRecorderStartupEvent(long eventId, String name, long parentId) {
 		this.name = name;
-		this.eventId = eventId;
-		this.parentId = parentId;
+		this.eventId = String.valueOf(eventId);
+		this.parentId = String.valueOf(parentId);
 	}
 
 	public void setTags(String tags) {

--- a/spring-core/src/main/java/org/springframework/core/metrics/jfr/FlightRecorderStartupStep.java
+++ b/spring-core/src/main/java/org/springframework/core/metrics/jfr/FlightRecorderStartupStep.java
@@ -55,12 +55,12 @@ class FlightRecorderStartupStep implements StartupStep {
 
 	@Override
 	public long getId() {
-		return this.event.eventId;
+		return Long.parseLong(this.event.eventId);
 	}
 
 	@Override
 	public Long getParentId() {
-		return this.event.parentId;
+		return Long.parseLong(this.event.parentId);
 	}
 
 	@Override


### PR DESCRIPTION
Because "eventId" and "parentId" are of type "long", they cannot be selected in the context filter menu in "JMC":
<img width="1210" height="681" alt="image" src="https://github.com/user-attachments/assets/2d3453f5-3f9b-446b-8989-d098dc62b91f" />

But sometimes it is powerless when filtering by eventId or parentId is required.


Avoid this problem by modifying the field type:
<img width="1187" height="620" alt="image" src="https://github.com/user-attachments/assets/ea720758-971c-485d-ac9e-9a060b2b9bea" />

<img width="1996" height="778" alt="7e5fefce-08dd-4085-b5f5-c1a8e1ebd29e" src="https://github.com/user-attachments/assets/4628598c-f623-4de3-8703-d81170c5e405" />
