### PR TITLE
Configure HttpMessageConverters as a list

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/DefaultHttpMessageConverters.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/DefaultHttpMessageConverters.java
@@ -122,6 +122,8 @@ class DefaultHttpMessageConverters implements HttpMessageConverters {
 
 		@Nullable Consumer<HttpMessageConverter<?>> configurer;
 
+		@Nullable Consumer<List<HttpMessageConverter<?>>> convertersListConfigurer;
+
 		@Nullable HttpMessageConverter<?> kotlinJsonConverter;
 
 		@Nullable HttpMessageConverter<?> jsonConverter;
@@ -224,6 +226,10 @@ class DefaultHttpMessageConverters implements HttpMessageConverters {
 
 		void addMessageConverterConfigurer(Consumer<HttpMessageConverter<?>> configurer) {
 			this.configurer = (this.configurer != null) ? configurer.andThen(this.configurer) : configurer;
+		}
+
+		void addMessageConvertersListConfigurer(Consumer<List<HttpMessageConverter<?>>> configurer) {
+			this.convertersListConfigurer = (this.convertersListConfigurer != null) ? this.convertersListConfigurer.andThen(this.convertersListConfigurer) : configurer;
 		}
 
 		List<HttpMessageConverter<?>> getBaseConverters() {
@@ -443,6 +449,12 @@ class DefaultHttpMessageConverters implements HttpMessageConverters {
 		}
 
 		@Override
+		public ClientBuilder configureMessageConvertersList(Consumer<List<HttpMessageConverter<?>>> configurer) {
+			addMessageConvertersListConfigurer(configurer);
+			return this;
+		}
+
+		@Override
 		public HttpMessageConverters build() {
 			if (this.registerDefaults) {
 				this.resourceConverter = new ResourceHttpMessageConverter(false);
@@ -466,6 +478,10 @@ class DefaultHttpMessageConverters implements HttpMessageConverters {
 			if (this.configurer != null) {
 				allConverters.forEach(this.configurer);
 			}
+			if (this.convertersListConfigurer != null) {
+				this.convertersListConfigurer.accept(allConverters);
+			}
+
 			return new DefaultHttpMessageConverters(allConverters);
 		}
 	}
@@ -540,6 +556,12 @@ class DefaultHttpMessageConverters implements HttpMessageConverters {
 		}
 
 		@Override
+		public ServerBuilder configureMessageConvertersList(Consumer<List<HttpMessageConverter<?>>> configurer) {
+			addMessageConvertersListConfigurer(configurer);
+			return this;
+		}
+
+		@Override
 		public HttpMessageConverters build() {
 			if (this.registerDefaults) {
 				this.resourceConverter = new ResourceHttpMessageConverter();
@@ -567,6 +589,10 @@ class DefaultHttpMessageConverters implements HttpMessageConverters {
 			if (this.configurer != null) {
 				allConverters.forEach(this.configurer);
 			}
+			if (this.convertersListConfigurer != null) {
+				this.convertersListConfigurer.accept(allConverters);
+			}
+
 			return new DefaultHttpMessageConverters(allConverters);
 		}
 	}

--- a/spring-web/src/main/java/org/springframework/http/converter/HttpMessageConverters.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/HttpMessageConverters.java
@@ -16,6 +16,7 @@
 
 package org.springframework.http.converter;
 
+import java.util.List;
 import java.util.function.Consumer;
 
 /**
@@ -171,6 +172,12 @@ public interface HttpMessageConverters extends Iterable<HttpMessageConverter<?>>
 		 * @param configurer the configurer to use
 		 */
 		T configureMessageConverters(Consumer<HttpMessageConverter<?>> configurer);
+
+		/**
+		 * Add a consumer for configuring the message converters list just before it's returned.
+		 * @param configurer the configurer to use
+		 */
+		T configureMessageConvertersList(Consumer<List<HttpMessageConverter<?>>> configurer);
 
 		/**
 		 * Build and return the {@link HttpMessageConverters} instance configured by this builder.

--- a/spring-web/src/test/java/org/springframework/http/converter/DefaultHttpMessageConvertersTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/DefaultHttpMessageConvertersTests.java
@@ -17,9 +17,11 @@
 package org.springframework.http.converter;
 
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
+import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -211,6 +213,27 @@ class DefaultHttpMessageConvertersTests {
 			assertThat(customConverter.processed).isTrue();
 		}
 
+		@Test
+		void shouldConfigureConverterOrder() {
+			var customConverter = new CustomHttpMessageConverter();
+			var converted = HttpMessageConverters.forClient()
+					.addCustomConverter(customConverter)
+					.configureMessageConvertersList(converter -> converter.sort(Comparator.comparing(s -> s.getClass().equals(CustomHttpMessageConverter.class) ? 1 : -1))).build();
+
+			var messageConvertersBack = Lists.newArrayList(converted);
+			assertThat(messageConvertersBack.size()).isGreaterThan(1);
+			assertThat(messageConvertersBack.get(messageConvertersBack.size() - 1).getClass()).isEqualTo(CustomHttpMessageConverter.class);
+
+			var convertedFront = HttpMessageConverters.forClient()
+					.addCustomConverter(customConverter)
+					.configureMessageConvertersList(converter -> converter.sort(Comparator.comparing(s -> s.getClass().equals(CustomHttpMessageConverter.class) ? -1 : 1))).build();
+
+			var messageConvertersFront = Lists.newArrayList(convertedFront);
+			assertThat(messageConvertersFront.get(0).getClass()).isEqualTo(CustomHttpMessageConverter.class);
+			assertThat(messageConvertersFront.size()).isGreaterThan(1);
+
+		}
+
 	}
 
 
@@ -318,6 +341,27 @@ class DefaultHttpMessageConvertersTests {
 					}).build();
 
 			assertThat(customConverter.processed).isTrue();
+		}
+
+		@Test
+		void shouldConfigureConverterOrder() {
+			var customConverter = new CustomHttpMessageConverter();
+			var converted = HttpMessageConverters.forServer()
+					.addCustomConverter(customConverter)
+					.configureMessageConvertersList(converter -> converter.sort(Comparator.comparing(s -> s.getClass().equals(CustomHttpMessageConverter.class) ? 1 : -1))).build();
+
+			var messageConvertersBack = Lists.newArrayList(converted);
+			assertThat(messageConvertersBack.size()).isGreaterThan(1);
+			assertThat(messageConvertersBack.get(messageConvertersBack.size() - 1).getClass()).isEqualTo(CustomHttpMessageConverter.class);
+
+			var convertedFront = HttpMessageConverters.forServer()
+					.addCustomConverter(customConverter)
+					.configureMessageConvertersList(converter -> converter.sort(Comparator.comparing(s -> s.getClass().equals(CustomHttpMessageConverter.class) ? -1 : 1))).build();
+
+			var messageConvertersFront = Lists.newArrayList(convertedFront);
+			assertThat(messageConvertersFront.size()).isGreaterThan(1);
+			assertThat(messageConvertersFront.get(0).getClass()).isEqualTo(CustomHttpMessageConverter.class);
+
 		}
 	}
 


### PR DESCRIPTION
    Adds ability to add message converter at specific index to builders, and propagates through to java.util.List.add(idx, ...)