### PR TITLE
Allow WebFlux ApiVersionResolver to return a Mono

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/accept/ApiVersionResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/accept/ApiVersionResolver.java
@@ -17,6 +17,7 @@
 package org.springframework.web.reactive.accept;
 
 import org.jspecify.annotations.Nullable;
+import reactor.core.publisher.Mono;
 
 import org.springframework.web.server.ServerWebExchange;
 
@@ -24,6 +25,7 @@ import org.springframework.web.server.ServerWebExchange;
  * Contract to extract the version from a request.
  *
  * @author Rossen Stoyanchev
+ * @author Jonathan Kaplan
  * @since 7.0
  */
 @FunctionalInterface
@@ -36,5 +38,16 @@ interface ApiVersionResolver {
 	 * @return the version value, or {@code null} if not found
 	 */
 	@Nullable String resolveVersion(ServerWebExchange exchange);
+
+	/**
+	 * Asynchronously resolve the version for the given request exchange.
+	 * This method wraps the synchronous {@code resolveVersion} method
+	 * and provides a reactive alternative.
+	 * @param exchange the current request exchange
+	 * @return a {@code Mono} emitting the version value, or an empty {@code Mono} if no version is found
+	 */
+	default Mono<String> resolveVersionAsync(ServerWebExchange exchange){
+		return Mono.justOrEmpty(this.resolveVersion(exchange));
+	}
 
 }

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/accept/DefaultApiVersionStrategy.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/accept/DefaultApiVersionStrategy.java
@@ -20,9 +20,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.function.Function;
 import java.util.function.Predicate;
 
 import org.jspecify.annotations.Nullable;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import org.springframework.util.Assert;
 import org.springframework.web.accept.ApiVersionParser;
@@ -152,6 +155,7 @@ public class DefaultApiVersionStrategy implements ApiVersionStrategy {
 		}
 	}
 
+	@SuppressWarnings("removal")
 	@Override
 	public @Nullable String resolveVersion(ServerWebExchange exchange) {
 		for (ApiVersionResolver resolver : this.versionResolvers) {
@@ -161,6 +165,14 @@ public class DefaultApiVersionStrategy implements ApiVersionStrategy {
 			}
 		}
 		return null;
+	}
+
+	@Override
+	public Mono<String> resolveVersionAsync(ServerWebExchange exchange) {
+		return Flux.fromIterable(this.versionResolvers)
+				.mapNotNull(resolver -> resolver.resolveVersionAsync(exchange))
+				.flatMap(Function.identity())
+				.next();
 	}
 
 	@Override


### PR DESCRIPTION
The current WebFlux API resolution returned a nullable String, this prevented custom API resolvers to be based on values which would need to be blocked. 
For example, creating an API version resolver based on the Authorized Principal. Since this is returned as a Mono in a server exchange.