### PR TITLE
Optimize single-char wildcard path matching performance

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/pattern/SingleCharWildcardedPathElement.java
+++ b/spring-web/src/main/java/org/springframework/web/util/pattern/SingleCharWildcardedPathElement.java
@@ -85,8 +85,11 @@ class SingleCharWildcardedPathElement extends PathElement {
 		else {
 			for (int i = 0; i < this.len; i++) {
 				char ch = this.text[i];
-				// TODO revisit performance if doing a lot of case insensitive matching
-				if ((ch != '?') && (ch != Character.toLowerCase(value.charAt(i)))) {
+				char valCh = value.charAt(i);
+				if (ch == valCh || ch == '?') {
+					continue;
+				}
+				if (ch != Character.toLowerCase(valCh)) {
 					return false;
 				}
 			}


### PR DESCRIPTION
Uses lazy evaluation in SingleCharWildcardedPathElement to avoid unnecessary Character.toLowerCase() calls. 
Best-case scenarios (lowercase URLs, wildcard matches) now require zero conversion calls.

Resolves performance TODO from 2017.
