### PR TITLE
Defer the API version validation error

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/HandlerMapping.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/HandlerMapping.java
@@ -90,6 +90,13 @@ public interface HandlerMapping {
 	 */
 	String API_VERSION_ATTRIBUTE = HandlerMapping.class.getName() + ".apiVersion";
 
+	/**
+	 * Name of the {@link ServerWebExchange#getAttributes() attribute} containing
+	 * the {@link RuntimeException} raised during API version validation.
+	 * @since 7.0.3
+	 */
+	String API_VERSION_VALIDATION_ERROR_ATTRIBUTE = HandlerMapping.class.getName() + ".apiVersionValidationError";
+
 
 	/**
 	 * Return a handler for this request.

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/RequestPredicates.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/RequestPredicates.java
@@ -652,6 +652,10 @@ public abstract class RequestPredicates {
 			PathPattern.PathMatchInfo info = this.pattern.matchAndExtract(pathContainer);
 			traceMatch("Pattern", this.pattern.getPatternString(), request.path(), info != null);
 			if (info != null) {
+				RuntimeException error = (RuntimeException) request.attribute(HandlerMapping.API_VERSION_VALIDATION_ERROR_ATTRIBUTE).orElse(null);
+				if (error != null) {
+					throw error;
+				}
 				return Result.of(true, attributes -> modifyAttributes(attributes, request, info.getUriVariables()));
 			}
 			else {

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/handler/AbstractHandlerMapping.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/handler/AbstractHandlerMapping.java
@@ -216,8 +216,14 @@ public abstract class AbstractHandlerMapping extends ApplicationObjectSupport
 	private void initApiVersion(ServerWebExchange exchange) {
 		if (this.apiVersionStrategy != null) {
 			Comparable<?> version = exchange.getAttribute(API_VERSION_ATTRIBUTE);
-			if (version == null) {
-				version = this.apiVersionStrategy.resolveParseAndValidateVersion(exchange);
+			if (version == null && exchange.getAttribute(API_VERSION_VALIDATION_ERROR_ATTRIBUTE) == null) {
+				try {
+					version = this.apiVersionStrategy.resolveParseAndValidateVersion(exchange);
+				}
+				catch (RuntimeException ex) {
+					exchange.getAttributes().put(API_VERSION_VALIDATION_ERROR_ATTRIBUTE, ex);
+					return;
+				}
 				if (version != null) {
 					exchange.getAttributes().put(API_VERSION_ATTRIBUTE, version);
 				}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/AbstractHandlerMethodMapping.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/AbstractHandlerMethodMapping.java
@@ -320,6 +320,10 @@ public abstract class AbstractHandlerMethodMapping<T> extends AbstractHandlerMap
 		List<Match> matches = new ArrayList<>();
 		List<T> directPathMatches = this.mappingRegistry.getMappingsByDirectPath(exchange);
 		if (directPathMatches != null) {
+			RuntimeException error = exchange.getAttribute(HandlerMapping.API_VERSION_VALIDATION_ERROR_ATTRIBUTE);
+			if (error != null) {
+				throw error;
+			}
 			addMatchingMappings(directPathMatches, matches, exchange);
 		}
 		if (matches.isEmpty()) {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/HandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/HandlerMapping.java
@@ -142,6 +142,13 @@ public interface HandlerMapping {
 	 */
 	String API_VERSION_ATTRIBUTE = HandlerMapping.class.getName() + ".apiVersion";
 
+	/**
+	 * Name of the {@link HttpServletRequest} attribute that contains the
+	 * {@link RuntimeException} raised during API version validation.
+	 * @since 7.0.3
+	 */
+	String API_VERSION_VALIDATION_ERROR_ATTRIBUTE = HandlerMapping.class.getName() + ".apiVersionValidationError";
+
 
 	/**
 	 * Whether this {@code HandlerMapping} instance has been enabled to use parsed

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/RequestPredicates.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/RequestPredicates.java
@@ -650,6 +650,10 @@ public abstract class RequestPredicates {
 			PathPattern.PathMatchInfo info = this.pattern.matchAndExtract(pathContainer);
 			traceMatch("Pattern", this.pattern.getPatternString(), request.path(), info != null);
 			if (info != null) {
+				RuntimeException error = (RuntimeException) request.attribute(HandlerMapping.API_VERSION_VALIDATION_ERROR_ATTRIBUTE).orElse(null);
+				if (error != null) {
+					throw error;
+				}
 				return Result.of(true, attributes -> modifyAttributes(attributes, request, info.getUriVariables()));
 			}
 			else {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMapping.java
@@ -587,8 +587,14 @@ public abstract class AbstractHandlerMapping extends WebApplicationObjectSupport
 	private void initApiVersion(HttpServletRequest request) {
 		if (this.versionStrategy != null) {
 			Comparable<?> version = (Comparable<?>) request.getAttribute(API_VERSION_ATTRIBUTE);
-			if (version == null) {
-				version = this.versionStrategy.resolveParseAndValidateVersion(request);
+			if (version == null && request.getAttribute(API_VERSION_VALIDATION_ERROR_ATTRIBUTE) == null) {
+				try {
+					version = this.versionStrategy.resolveParseAndValidateVersion(request);
+				}
+				catch (RuntimeException ex) {
+					request.setAttribute(API_VERSION_VALIDATION_ERROR_ATTRIBUTE, ex);
+					return;
+				}
 				if (version != null) {
 					request.setAttribute(API_VERSION_ATTRIBUTE, version);
 				}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMethodMapping.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/handler/AbstractHandlerMethodMapping.java
@@ -394,6 +394,10 @@ public abstract class AbstractHandlerMethodMapping<T> extends AbstractHandlerMap
 		List<Match> matches = new ArrayList<>();
 		List<T> directPathMatches = this.mappingRegistry.getMappingsByDirectPath(lookupPath);
 		if (directPathMatches != null) {
+			RuntimeException error = (RuntimeException) request.getAttribute(HandlerMapping.API_VERSION_VALIDATION_ERROR_ATTRIBUTE);
+			if (error != null) {
+				throw error;
+			}
 			addMatchingMappings(directPathMatches, matches, request);
 		}
 		if (matches.isEmpty()) {


### PR DESCRIPTION
This change defers the API version validation error.

As a result, the `versionRequired` option (e.g., `spring.mvc.apiversion.required=true`) is evaluated for each `HandlerMapping`, and only applies when a `HandlerMapping` both configures an `ApiVersionStrategy` and is matched by the URL.

Closes gh-36059