### PR TITLE
ResolvableType.getNested typeProvider was missing

### DIFF
--- a/framework-docs/modules/ROOT/pages/web/webmvc/mvc-servlet/localeresolver.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc/mvc-servlet/localeresolver.adoc
@@ -83,4 +83,4 @@ that contain a parameter named `siteLanguage` now changes the locale. So, for ex
 a request for the URL `https://domain.com/home.view?siteLanguage=nl` changes the site
 language to Dutch. The following example shows how to intercept the locale:
 
-include-code::./WebConfiguration[tag=snippet,indent=0]
+include-code::./WebConfiguration[tag=snippet,indent=0,chomp=-tags]

--- a/framework-docs/package.json
+++ b/framework-docs/package.json
@@ -1,11 +1,11 @@
 {
   "dependencies": {
-    "antora": "3.2.0-alpha.4",
-    "@antora/atlas-extension": "1.0.0-alpha.2",
-    "@antora/collector-extension": "1.0.0-alpha.3",
+    "antora": "3.2.0-alpha.11",
+    "@antora/atlas-extension": "1.0.0-alpha.5",
+    "@antora/collector-extension": "1.0.2",
     "@asciidoctor/tabs": "1.0.0-beta.6",
     "@springio/antora-extensions": "1.14.7",
     "fast-xml-parser": "4.5.2",
-    "@springio/asciidoctor-extensions": "1.0.0-alpha.10"
+    "@springio/asciidoctor-extensions": "1.0.0-alpha.17"
   }
 }

--- a/framework-docs/src/main/kotlin/org/springframework/docs/web/webmvc/mvcservlet/mvclocaleresolverinterceptor/WebConfiguration.kt
+++ b/framework-docs/src/main/kotlin/org/springframework/docs/web/webmvc/mvcservlet/mvclocaleresolverinterceptor/WebConfiguration.kt
@@ -37,7 +37,7 @@ class WebConfiguration {
 		setInterceptors(LocaleChangeInterceptor().apply {
 			paramName = "siteLanguage"
 		})
-		/* @chomp:line urlMap = mapOf("/**/*.view" to "someController") */urlMap = mapOf("/**/*.view" to "someController")
+		urlMap = mapOf("/**/*.view" to "someController")
 	}
 }
 // end::snippet[]

--- a/spring-core/src/main/java/org/springframework/core/ResolvableType.java
+++ b/spring-core/src/main/java/org/springframework/core/ResolvableType.java
@@ -1479,11 +1479,8 @@ public class ResolvableType implements Serializable {
 	 * @see #forType(Type)
 	 */
 	public static ResolvableType forType(@Nullable Type type, @Nullable ResolvableType owner) {
-		VariableResolver variableResolver = null;
-		if (owner != null) {
-			variableResolver = owner.asVariableResolver();
-		}
-		return forType(type, variableResolver);
+		return (owner == null ? forType(type, null, null) :
+			forType(type, owner.typeProvider, owner.asVariableResolver()));
 	}
 
 	/**

--- a/spring-core/src/main/java/org/springframework/core/ResolvableType.java
+++ b/spring-core/src/main/java/org/springframework/core/ResolvableType.java
@@ -802,7 +802,7 @@ public class ResolvableType implements Serializable {
 				if (actualTypeArguments.length > 0) {
 					generics = new ResolvableType[actualTypeArguments.length];
 					for (int i = 0; i < actualTypeArguments.length; i++) {
-						generics[i] = forType(actualTypeArguments[i], this.typeProvider, this.variableResolver);
+						generics[i] = forType(actualTypeArguments[i], this.variableResolver);
 					}
 				}
 				else {

--- a/spring-core/src/main/java/org/springframework/core/ResolvableType.java
+++ b/spring-core/src/main/java/org/springframework/core/ResolvableType.java
@@ -802,7 +802,7 @@ public class ResolvableType implements Serializable {
 				if (actualTypeArguments.length > 0) {
 					generics = new ResolvableType[actualTypeArguments.length];
 					for (int i = 0; i < actualTypeArguments.length; i++) {
-						generics[i] = forType(actualTypeArguments[i], this.variableResolver);
+						generics[i] = forType(actualTypeArguments[i], this.typeProvider, this.variableResolver);
 					}
 				}
 				else {

--- a/spring-core/src/test/java/org/springframework/core/ResolvableTypeTests.java
+++ b/spring-core/src/test/java/org/springframework/core/ResolvableTypeTests.java
@@ -1346,6 +1346,7 @@ class ResolvableTypeTests {
 		ResolvableType type = ResolvableType.forField(Fields.class.getField("stringList"));
 		ResolvableType narrow = ResolvableType.forType(ArrayList.class, type);
 		assertThat(narrow.getGeneric().resolve()).isEqualTo(String.class);
+		assertThat(type.getSource()).isSameAs(narrow.getSource());
 	}
 
 	@Test

--- a/spring-core/src/test/java/org/springframework/core/ResolvableTypeTests.java
+++ b/spring-core/src/test/java/org/springframework/core/ResolvableTypeTests.java
@@ -50,8 +50,6 @@ import org.mockito.Captor;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.core.ResolvableType.VariableResolver;
-import org.springframework.core.annotation.AnnotatedMethod;
-import org.springframework.util.ClassUtils;
 import org.springframework.util.MultiValueMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -501,18 +499,6 @@ class ResolvableTypeTests {
 		type = type.getNested(2);
 		assertThat(type.resolve()).isEqualTo(List.class);
 		assertThat(type.resolveGeneric()).isEqualTo(String.class);
-	}
-
-	@Test
-	void getNested() throws Exception {
-		Method method = MySimpleParameterizedController.class.getMethod("handleDto", List.class);
-		HandlerMethod handlerMethod = new HandlerMethod(new MySimpleParameterizedController(), method);
-		MethodParameter methodParam = handlerMethod.getMethodParameters()[0];
-
-		ResolvableType resolvable = ResolvableType.forMethodParameter(methodParam).getNested(2);
-
-		Class<?> contextClass = methodParam.getContainingClass();
-		assertThat(GenericTypeResolver.resolveType(resolvable.getType(), contextClass)).isEqualTo(SimpleBean.class);
 	}
 
 	@Test
@@ -1994,76 +1980,5 @@ class ResolvableTypeTests {
 			return type.getType() + ":" + type;
 		}
 	}
-
-
-	private static class HandlerMethod extends AnnotatedMethod {
-
-		private final Class<?> beanType;
-
-		/**
-		 * Create an instance from a bean instance and a method.
-		 */
-		public HandlerMethod(Object bean, Method method) {
-			super(method);
-			this.beanType = ClassUtils.getUserClass(bean);
-		}
-
-		@Override
-		protected Class<?> getContainingClass() {
-			return beanType;
-		}
-
-	}
-
-
-	@SuppressWarnings("unused")
-	private abstract static class MyParameterizedController<DTO extends Identifiable> {
-
-		public void handleDto(List<DTO> dto) {
-		}
-	}
-
-
-	@SuppressWarnings("unused")
-	private static class MySimpleParameterizedController extends MyParameterizedController<SimpleBean> {
-	}
-
-
-	private interface Identifiable extends Serializable {
-
-		Long getId();
-
-		void setId(Long id);
-	}
-
-
-	@SuppressWarnings({ "serial" })
-	private static class SimpleBean implements Identifiable {
-
-		private Long id;
-
-		private String name;
-
-		@Override
-		public Long getId() {
-			return id;
-		}
-
-		@Override
-		public void setId(Long id) {
-			this.id = id;
-		}
-
-		public String getName() {
-			return name;
-		}
-
-		@SuppressWarnings("unused")
-		public void setName(String name) {
-			this.name = name;
-		}
-	}
-
-
 
 }

--- a/spring-core/src/test/java/org/springframework/core/ResolvableTypeTests.java
+++ b/spring-core/src/test/java/org/springframework/core/ResolvableTypeTests.java
@@ -50,6 +50,8 @@ import org.mockito.Captor;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.core.ResolvableType.VariableResolver;
+import org.springframework.core.annotation.AnnotatedMethod;
+import org.springframework.util.ClassUtils;
 import org.springframework.util.MultiValueMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -499,6 +501,18 @@ class ResolvableTypeTests {
 		type = type.getNested(2);
 		assertThat(type.resolve()).isEqualTo(List.class);
 		assertThat(type.resolveGeneric()).isEqualTo(String.class);
+	}
+
+	@Test
+	void getNested() throws Exception {
+		Method method = MySimpleParameterizedController.class.getMethod("handleDto", List.class);
+		HandlerMethod handlerMethod = new HandlerMethod(new MySimpleParameterizedController(), method);
+		MethodParameter methodParam = handlerMethod.getMethodParameters()[0];
+
+		ResolvableType resolvable = ResolvableType.forMethodParameter(methodParam).getNested(2);
+
+		Class<?> contextClass = methodParam.getContainingClass();
+		assertThat(GenericTypeResolver.resolveType(resolvable.getType(), contextClass)).isEqualTo(SimpleBean.class);
 	}
 
 	@Test
@@ -1980,5 +1994,76 @@ class ResolvableTypeTests {
 			return type.getType() + ":" + type;
 		}
 	}
+
+
+	private static class HandlerMethod extends AnnotatedMethod {
+
+		private final Class<?> beanType;
+
+		/**
+		 * Create an instance from a bean instance and a method.
+		 */
+		public HandlerMethod(Object bean, Method method) {
+			super(method);
+			this.beanType = ClassUtils.getUserClass(bean);
+		}
+
+		@Override
+		protected Class<?> getContainingClass() {
+			return beanType;
+		}
+
+	}
+
+
+	@SuppressWarnings("unused")
+	private abstract static class MyParameterizedController<DTO extends Identifiable> {
+
+		public void handleDto(List<DTO> dto) {
+		}
+	}
+
+
+	@SuppressWarnings("unused")
+	private static class MySimpleParameterizedController extends MyParameterizedController<SimpleBean> {
+	}
+
+
+	private interface Identifiable extends Serializable {
+
+		Long getId();
+
+		void setId(Long id);
+	}
+
+
+	@SuppressWarnings({ "serial" })
+	private static class SimpleBean implements Identifiable {
+
+		private Long id;
+
+		private String name;
+
+		@Override
+		public Long getId() {
+			return id;
+		}
+
+		@Override
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		@SuppressWarnings("unused")
+		public void setName(String name) {
+			this.name = name;
+		}
+	}
+
+
 
 }

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodArgumentResolver.java
@@ -252,10 +252,10 @@ public abstract class AbstractMessageConverterMethodArgumentResolver implements 
 	protected ResolvableType getNestedTypeIfNeeded(ResolvableType type) {
 		ResolvableType genericType = type;
 		if (Optional.class.isAssignableFrom(genericType.toClass())) {
-			genericType = genericType.getNested(2);
+			genericType = ResolvableType.forType(genericType.getNested(2).getType(), type);
 		}
 		if (HttpEntity.class.isAssignableFrom(genericType.toClass())) {
-			genericType = genericType.getNested(2);
+			genericType = ResolvableType.forType(genericType.getNested(2).getType(), type);
 		}
 		return genericType;
 	}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessorTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessorTests.java
@@ -30,7 +30,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.core.MethodParameter;
@@ -152,7 +151,6 @@ public class HttpEntityMethodProcessorTests {
 	}
 
 	@Test
-	@Disabled("Determine why this fails with JacksonJsonHttpMessageConverter but passes with MappingJackson2HttpMessageConverter")
 	void resolveArgumentTypeVariable() throws Exception {
 		Method method = MySimpleParameterizedController.class.getMethod("handleDto", HttpEntity.class);
 		HandlerMethod handlerMethod = new HandlerMethod(new MySimpleParameterizedController(), method);

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessorTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessorTests.java
@@ -30,6 +30,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.core.MethodParameter;
@@ -151,6 +152,7 @@ public class HttpEntityMethodProcessorTests {
 	}
 
 	@Test
+	@Disabled("Determine why this fails with JacksonJsonHttpMessageConverter but passes with MappingJackson2HttpMessageConverter")
 	void resolveArgumentTypeVariable() throws Exception {
 		Method method = MySimpleParameterizedController.class.getMethod("handleDto", HttpEntity.class);
 		HandlerMethod handlerMethod = new HandlerMethod(new MySimpleParameterizedController(), method);


### PR DESCRIPTION
This causes JacksonJsonHttpMessageConverter.read() 's contextClass to resolve to null

> Determine why this fails with JacksonJsonHttpMessageConverter but passes with MappingJackson2HttpMessageConverter

Because the `MappingJackson2HttpMessageConverter` is a `GenericHttpMessageConverter` that explicitly provides the `contextClass` during reading, whereas the `JacksonJsonHttpMessageConverter` obtains it through `(ResolvableType.getSource() as MethodParameter).getContainingClass`.

https://github.com/spring-projects/spring-framework/blob/253eb28458123fd0d0e1959c594c50fd7eed2a70/spring-web/src/main/java/org/springframework/http/converter/GenericHttpMessageConverter.java#L69-L71

but type.getSource() is not instanceof MethodParameter

https://github.com/spring-projects/spring-framework/blob/253eb28458123fd0d0e1959c594c50fd7eed2a70/spring-web/src/main/java/org/springframework/http/converter/AbstractJacksonHttpMessageConverter.java#L311-L320


https://github.com/spring-projects/spring-framework/blob/253eb28458123fd0d0e1959c594c50fd7eed2a70/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessorTests.java#L154-L176

