### PR TITLE
Fix Spring-ORM SpringBeanContainer::getBeanClass returns proxy-class instead of target-class

### DIFF
--- a/spring-orm/src/main/java/org/springframework/orm/jpa/hibernate/SpringBeanContainer.java
+++ b/spring-orm/src/main/java/org/springframework/orm/jpa/hibernate/SpringBeanContainer.java
@@ -27,6 +27,7 @@ import org.hibernate.resource.beans.spi.BeanInstanceProducer;
 import org.hibernate.type.spi.TypeBootstrapContext;
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.aop.framework.AopProxyUtils;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
@@ -262,7 +263,7 @@ public final class SpringBeanContainer implements BeanContainer {
 		@Override
 		@SuppressWarnings("unchecked")
 		public Class<B> getBeanClass() {
-			return (Class<B>) this.beanInstance.getClass();
+			return (Class<B>) AopProxyUtils.ultimateTargetClass(this.beanInstance);
 		}
 
 		public void destroyIfNecessary() {


### PR DESCRIPTION
**Problem**
Since Hibernate ORM `7.2.x`, `ManagedBeanRegistryImpl` enforces that the class returned by `ContainedBean::getBeanClass` must be identical to the requested bean type.
Spring’s `SpringContainedBean` currently returns `bean.getClass()`, which for AOP-proxied beans is a synthetic CGLIB subclass rather than the user-defined type. This mismatch causes Hibernate to throw:

```
IllegalArgumentException: Bean is not of requested type
```

**Root cause**
`SpringContainedBean` misinterprets the contract of `ContainedBean::getBeanClass()`: it must return the original target class, not the runtime proxy class.

**Solution**
Use `AopUtils.getTargetClass(bean)` instead of `bean.getClass()` to defer the actual user-defined type of CGLIB/Java-proxy wrapper. 
