### PR TITLE
Clarify unversioned handler matching precedence

### DIFF
--- a/framework-docs/modules/ROOT/pages/web/webflux/controller/ann-requestmapping.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webflux/controller/ann-requestmapping.adoc
@@ -393,7 +393,7 @@ is used to map requests.
 Once API versioning is enabled, you can begin to map requests with versions.
 The `@RequestMapping` `version` attribute supports the following:
 
-- No value -- matches any version
+- No value -- matches any version, unless the request is superseded by a more specific version match.
 - Fixed version ("1.2") -- matches the given version only
 - Baseline version ("1.2+") -- matches the given version and above
 

--- a/framework-docs/modules/ROOT/pages/web/webmvc/mvc-controller/ann-requestmapping.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc/mvc-controller/ann-requestmapping.adoc
@@ -424,7 +424,7 @@ is used to map requests.
 Once API versioning is enabled, you can begin to map requests with versions.
 The `@RequestMapping` `version` attribute supports the following:
 
-- No value -- matches any version
+- No value -- matches any version, unless the request is superseded by a more specific version match.
 - Fixed version ("1.2") -- matches the given version only
 - Baseline version ("1.2+") -- matches the given version and above
 


### PR DESCRIPTION
The documentation is updated to clarify that a handler with no version attribute matches any version only when it is not superseded by a more specific version match.

Closes https://github.com/spring-projects/spring-framework/issues/36082