### PR TITLE
Fix deprecated Groovy syntax in spring-aspects

### DIFF
--- a/spring-aspects/spring-aspects.gradle
+++ b/spring-aspects/spring-aspects.gradle
@@ -3,15 +3,15 @@ description = "Spring Aspects"
 apply plugin: "io.freefair.aspectj"
 
 compileAspectj {
-	sourceCompatibility "17"
-	targetCompatibility "17"
+	sourceCompatibility = "17"
+	targetCompatibility = "17"
 	ajcOptions {
 		compilerArgs += "-parameters"
 	}
 }
 compileTestAspectj {
-	sourceCompatibility "17"
-	targetCompatibility "17"
+	sourceCompatibility = "17"
+	targetCompatibility = "17"
 	ajcOptions {
 		compilerArgs += "-parameters"
 	}


### PR DESCRIPTION
## Related Issues
Closes #36131 

## Description
This PR addresses the Gradle deprecation warnings reported in the linked issue.

the legacy Groovy DSL syntax for property assignment (space-separated values) is deprecated in Gradle 9.x and will be removed in Gradle 10. This change updates `spring-aspects.gradle` to use the standard assignment operator (`=`).

## Changes
* Updated `spring-aspects/spring-aspects.gradle`: Replaced space-separated property assignments with explicit assignment operators.

## Verification
I have verified that the build completes successfully and the specific deprecation warnings regarding property assignment are resolved.

```bash
./gradlew :spring-aspects:clean :spring-aspects:assemble --warning-mode=all