### PR TITLE
Add DataAccessResourceFailureException to CLIENT_EXCEPTION_TYPES 

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/DisconnectedClientHelper.java
+++ b/spring-web/src/main/java/org/springframework/web/util/DisconnectedClientHelper.java
@@ -56,6 +56,8 @@ public class DisconnectedClientHelper {
 					"org.springframework.web.client.RestClientException", classLoader));
 			CLIENT_EXCEPTION_TYPES.add(ClassUtils.forName(
 					"org.springframework.web.reactive.function.client.WebClientException", classLoader));
+			CLIENT_EXCEPTION_TYPES.add(ClassUtils.forName(
+				"org.springframework.dao.DataAccessResourceFailureException",classLoader));
 		}
 		catch (ClassNotFoundException ex) {
 			// ignore


### PR DESCRIPTION
Include DataAccessResourceFailureException in CLIENT_EXCEPTION_TYPES

Closes gh-36135

Signed-off-by: Siva <164894350+SivaPA08@users.noreply.github.com>
