### PR TITLE
Add support for vendor-suffixed x-ndjson media types in Jackson JSON …

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2CodecSupport.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/json/Jackson2CodecSupport.java
@@ -81,7 +81,9 @@ public abstract class Jackson2CodecSupport {
 	private static final List<MimeType> defaultMimeTypes = List.of(
 			MediaType.APPLICATION_JSON,
 			new MediaType("application", "*+json"),
-			MediaType.APPLICATION_NDJSON);
+			MediaType.APPLICATION_NDJSON,
+			new MediaType("application", "*+x-ndjson")
+	);
 
 
 	protected final Log logger = HttpLogging.forLogName(getClass());

--- a/spring-web/src/main/java/org/springframework/http/codec/json/JacksonJsonDecoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/json/JacksonJsonDecoder.java
@@ -55,7 +55,8 @@ public class JacksonJsonDecoder extends AbstractJacksonDecoder<JsonMapper> {
 	private static final MimeType[] DEFAULT_JSON_MIME_TYPES = new MimeType[] {
 			MediaType.APPLICATION_JSON,
 			new MediaType("application", "*+json"),
-			MediaType.APPLICATION_NDJSON
+			MediaType.APPLICATION_NDJSON,
+			new MediaType("application", "*+x-ndjson")
 	};
 
 

--- a/spring-web/src/main/java/org/springframework/http/codec/json/JacksonJsonEncoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/json/JacksonJsonEncoder.java
@@ -55,7 +55,8 @@ public class JacksonJsonEncoder extends AbstractJacksonEncoder<JsonMapper> {
 	private static final MimeType[] DEFAULT_JSON_MIME_TYPES = new MimeType[] {
 			MediaType.APPLICATION_JSON,
 			new MediaType("application", "*+json"),
-			MediaType.APPLICATION_NDJSON
+			MediaType.APPLICATION_NDJSON,
+			new MediaType("application", "*+x-ndjson")
 	};
 
 

--- a/spring-web/src/main/java/org/springframework/http/converter/json/JacksonJsonHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/JacksonJsonHttpMessageConverter.java
@@ -58,7 +58,8 @@ public class JacksonJsonHttpMessageConverter extends AbstractJacksonHttpMessageC
 			Collections.singletonList(MediaType.APPLICATION_PROBLEM_JSON);
 
 	private static final MediaType[] DEFAULT_JSON_MIME_TYPES = new MediaType[] {
-			MediaType.APPLICATION_JSON, new MediaType("application", "*+json") };
+			MediaType.APPLICATION_JSON, new MediaType("application", "*+json"),
+			MediaType.APPLICATION_NDJSON, new MediaType("application", "*+x-ndjson") };
 
 
 	private @Nullable String jsonPrefix;

--- a/spring-web/src/test/java/org/springframework/http/codec/json/Jackson2JsonDecoderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/json/Jackson2JsonDecoderTests.java
@@ -113,6 +113,12 @@ class Jackson2JsonDecoderTests extends AbstractDecoderTests<Jackson2JsonDecoder>
 
 	}
 
+	@Test
+	void canDecodeVendorSuffixedNdjson() {
+		MediaType vendorNdjson = MediaType.parseMediaType("application/vnd.example.v1+x-ndjson");
+		assertThat(decoder.canDecode(ResolvableType.forClass(Pojo.class), vendorNdjson)).isTrue();
+	}
+
 	@Test  // SPR-15866
 	void canDecodeWithProvidedMimeType() {
 		MimeType textJavascript = new MimeType("text", "javascript", StandardCharsets.UTF_8);

--- a/spring-web/src/test/java/org/springframework/http/codec/json/JacksonJsonDecoderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/json/JacksonJsonDecoderTests.java
@@ -111,6 +111,12 @@ class JacksonJsonDecoderTests extends AbstractDecoderTests<JacksonJsonDecoder> {
 		assertThat(decoder.canDecode(ResolvableType.forClass(Map.class), MediaType.APPLICATION_JSON)).isTrue();
 	}
 
+	@Test
+	void canDecodeVendorSuffixedNdjson() {
+		MediaType vendorNdjson = MediaType.parseMediaType("application/vnd.example.v1+x-ndjson");
+		assertThat(decoder.canDecode(ResolvableType.forClass(Pojo.class), vendorNdjson)).isTrue();
+	}
+
 	@Test  // SPR-15866
 	void canDecodeWithProvidedMimeType() {
 		MimeType textJavascript = new MimeType("text", "javascript", StandardCharsets.UTF_8);


### PR DESCRIPTION
This PR addresses issue https://github.com/spring-projects/spring-framework/issues/36121

## Summary
* Improved `JacksonJsonDecoder` to natively support the `application/*+x-ndjson` media type.
* Added tests to verify that vendor-suffixed NDJSON types (e.g., `application/vnd.example.v1+x-ndjson`) are correctly decoded out-of-the-box.
* Confirmed that custom components are no longer required to handle various NDJSON media types.

## Resolved Issue
* Ensured that `JacksonJsonDecoder` and related codecs can handle all `application/*+x-ndjson` types, including vendor-specific variants, without additional configuration.
* Prevents regressions by covering these cases in the test suite.

## Integration Test
I’ve added an integration test for this behavior. If needed, I can include it in the PR as well.
<img width="1249" height="744" alt="스크린샷 2026-01-18 오후 2 23 56" src="https://github.com/user-attachments/assets/9fe818eb-b7b4-43c2-8a54-ed25020c2187" />
