### PR TITLE
Replace `getErrors()` with `getBindingResult()` in examples

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/bind/ServletRequestDataBinder.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/ServletRequestDataBinder.java
@@ -69,7 +69,7 @@ import org.springframework.web.util.WebUtils;
  * // trigger actual binding of request parameters
  * binder.bind(request);
  * // optionally evaluate binding errors
- * Errors errors = binder.getErrors();
+ * Errors errors = binder.getBindingResult();
  * ...</pre>
  *
  * @author Rod Johnson

--- a/spring-web/src/main/java/org/springframework/web/bind/support/WebRequestDataBinder.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/support/WebRequestDataBinder.java
@@ -53,7 +53,7 @@ import org.springframework.web.multipart.support.StandardServletPartUtils;
  * which include specifying allowed/required fields, and registering custom
  * property editors.
  *
- * <p>Can also used for manual data binding in custom web controllers or interceptors
+ * <p>Can also be used for manual data binding in custom web controllers or interceptors
  * that build on Spring's {@link org.springframework.web.context.request.WebRequest}
  * abstraction: for example, in a {@link org.springframework.web.context.request.WebRequestInterceptor}
  * implementation. Simply instantiate a WebRequestDataBinder for each binding
@@ -68,7 +68,7 @@ import org.springframework.web.multipart.support.StandardServletPartUtils;
  * // trigger actual binding of request parameters
  * binder.bind(request);
  * // optionally evaluate binding errors
- * Errors errors = binder.getErrors();
+ * Errors errors = binder.getBindingResult();
  * ...</pre>
  *
  * @author Juergen Hoeller


### PR DESCRIPTION
`DataBinder#getErrors`  was removed in `v4.0.0.M1`.

https://github.com/spring-projects/spring-framework/commit/0a8f5b2919ef7193d17b045b3a757800160d64e9#diff-1f22c41307a3ddcec8f1bc7a237d3b77ac7564883f4c663402993affac8a5756