### PR TITLE
Add selector type support for sendAndReceive methods in JmsOperations and JmsTemplate

### DIFF
--- a/spring-jms/src/main/java/org/springframework/jms/core/JmsOperations.java
+++ b/spring-jms/src/main/java/org/springframework/jms/core/JmsOperations.java
@@ -401,6 +401,36 @@ public interface JmsOperations {
 	 */
 	@Nullable Message sendAndReceive(String destinationName, MessageCreator messageCreator) throws JmsException;
 
+	/**
+	 * Send a message and receive the reply from the specified destination. The
+	 * {@link MessageCreator} callback creates the message given a Session. A given
+	 * responseQueue is set in the {@code JMSReplyTO} header of the message.
+	 * @param destination the destination to send this message to
+	 * @param responseQueue the destination to receive the reply from
+	 * @param messageCreator callback to create a message
+	 * @return the reply, possibly {@code null} if the message could not be received,
+	 * for example due to a timeout
+	 * @throws JmsException checked JMSException converted to unchecked
+	 * @since 7.0.4
+	 */
+	@Nullable Message sendAndReceive(Destination destination, Destination responseQueue, MessageCreator messageCreator) throws JmsException;
+
+	/**
+	 * Send a message and receive the reply from the specified destination. The
+	 * {@link MessageCreator} callback creates the message given a Session. A given
+	 * responseQueue is set in the {@code JMSReplyTO} header of the message.
+	 * @param destinationName the name of the destination to send this message to
+	 * (to be resolved to an actual destination by a DestinationResolver)
+	 * @param responseQueueName the name of the destination to receive the reply from
+	 * (to be resolved to an actual destination by a DestinationResolver)
+	 * @param messageCreator callback to create a message
+	 * @return the reply, possibly {@code null} if the message could not be received,
+	 * for example due to a timeout
+	 * @throws JmsException checked JMSException converted to unchecked
+	 * @since 7.0.4
+	 */
+	@Nullable Message sendAndReceive(String destinationName, String responseQueueName, MessageCreator messageCreator) throws JmsException;
+
 
 	//---------------------------------------------------------------------------------------
 	// Convenience methods for browsing messages

--- a/spring-jms/src/main/java/org/springframework/jms/core/JmsTemplate.java
+++ b/spring-jms/src/main/java/org/springframework/jms/core/JmsTemplate.java
@@ -899,6 +899,11 @@ public class JmsTemplate extends JmsDestinationAccessor implements JmsOperations
 	}
 
 	@Override
+	public @Nullable Message sendAndReceive(Destination destination, Destination responseQueue, MessageCreator messageCreator) throws JmsException {
+		return executeLocal(session -> doSendAndReceive(session, destination, responseQueue, messageCreator), true);
+	}
+
+	@Override
 	public @Nullable Message sendAndReceive(String destinationName, MessageCreator messageCreator) throws JmsException {
 		return executeLocal(session -> {
 			Destination destination = resolveDestinationName(session, destinationName);
@@ -906,8 +911,17 @@ public class JmsTemplate extends JmsDestinationAccessor implements JmsOperations
 		}, true);
 	}
 
+	@Override
+	public @Nullable Message sendAndReceive(String destinationName, String responseQueueName, MessageCreator messageCreator) throws JmsException {
+		return executeLocal(session -> {
+			Destination destination = resolveDestinationName(session, destinationName);
+			Destination responseQueue = resolveDestinationName(session, responseQueueName);
+			return doSendAndReceive(session, destination, responseQueue, messageCreator);
+		}, true);
+	}
+
 	/**
-	 * Send a request message to the given {@link Destination} and block until
+	 * Send a request message to the given {@link Destination destination} and block until
 	 * a reply has been received on a temporary queue created on-the-fly.
 	 * <p>Return the response message or {@code null} if no message has
 	 * @throws JMSException if thrown by JMS API methods
@@ -915,13 +929,32 @@ public class JmsTemplate extends JmsDestinationAccessor implements JmsOperations
 	protected @Nullable Message doSendAndReceive(Session session, Destination destination, MessageCreator messageCreator)
 			throws JMSException {
 
-		Assert.notNull(messageCreator, "MessageCreator must not be null");
 		TemporaryQueue responseQueue = null;
+		try {
+			responseQueue = session.createTemporaryQueue();
+			return doSendAndReceive(session, destination, responseQueue, messageCreator);
+		}
+		finally {
+			if (responseQueue != null) {
+				responseQueue.delete();
+			}
+		}
+	}
+
+	/**
+	 * Send a request message to the given {@link Destination destination} and block until
+	 * a reply has been received on a {@link Destination responseQueue} queue.
+	 * <p>Return the response message or {@code null} if no message has
+	 * @throws JMSException if thrown by JMS API methods
+	 */
+	protected @Nullable Message doSendAndReceive(Session session, Destination destination, Destination responseQueue, MessageCreator messageCreator)
+			throws JMSException {
+
+		Assert.notNull(messageCreator, "MessageCreator must not be null");
 		MessageProducer producer = null;
 		MessageConsumer consumer = null;
 		try {
 			Message requestMessage = messageCreator.createMessage(session);
-			responseQueue = session.createTemporaryQueue();
 			producer = session.createProducer(destination);
 			consumer = session.createConsumer(responseQueue);
 			requestMessage.setJMSReplyTo(responseQueue);
@@ -934,9 +967,6 @@ public class JmsTemplate extends JmsDestinationAccessor implements JmsOperations
 		finally {
 			JmsUtils.closeMessageConsumer(consumer);
 			JmsUtils.closeMessageProducer(producer);
-			if (responseQueue != null) {
-				responseQueue.delete();
-			}
 		}
 	}
 


### PR DESCRIPTION
For explicit response queue we need correlationId to be used.
There are 2 main approaches depending on JMS provider:
- random correlationId - and (random) ID set on request that JMS provider copies to response message
- messageId - after sending request, JMS probider assigns messageId to request message and this value is also being copied to correlationId on response message