### PR TITLE
Replace System.err/printStackTrace with logger

### DIFF
--- a/spring-core-test/src/main/java/org/springframework/aot/agent/InvocationsRecorderClassTransformer.java
+++ b/spring-core-test/src/main/java/org/springframework/aot/agent/InvocationsRecorderClassTransformer.java
@@ -21,6 +21,8 @@ import java.lang.instrument.IllegalClassFormatException;
 import java.security.ProtectionDomain;
 import java.util.Arrays;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.asm.ClassReader;
@@ -35,6 +37,8 @@ import org.springframework.util.Assert;
  * @see InvocationsRecorderClassVisitor
  */
 class InvocationsRecorderClassTransformer implements ClassFileTransformer {
+
+	private static final Log logger = LogFactory.getLog(InvocationsRecorderClassTransformer.class);
 
 	private static final String AGENT_PACKAGE = InvocationsRecorderClassTransformer.class.getPackageName().replace('.', '/');
 
@@ -102,7 +106,9 @@ class InvocationsRecorderClassTransformer implements ClassFileTransformer {
 			fileReader.accept(classVisitor, 0);
 		}
 		catch (Exception ex) {
-			ex.printStackTrace();
+			if (logger.isDebugEnabled()) {
+				logger.debug("Failed to transform class", ex);
+			}
 			return classfileBuffer;
 		}
 		if (classVisitor.isTransformed()) {

--- a/spring-test/src/main/java/org/springframework/test/json/JsonConverterDelegate.java
+++ b/spring-test/src/main/java/org/springframework/test/json/JsonConverterDelegate.java
@@ -43,7 +43,7 @@ public interface JsonConverterDelegate {
 	 * serialization and deserialization to and from JSON. This is useful for
 	 * mapping generic maps and lists to higher level Objects.
 	 * @param value the value to map
-	 * @param targetType the target tyep
+	 * @param targetType the target type
 	 * @return the decoded object
 	 * @param <T> the target type
 	 */

--- a/spring-web/src/main/java/org/springframework/web/util/ServletContextPropertyUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/util/ServletContextPropertyUtils.java
@@ -17,6 +17,8 @@
 package org.springframework.web.util;
 
 import jakarta.servlet.ServletContext;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.util.PropertyPlaceholderHelper;
@@ -89,6 +91,8 @@ public abstract class ServletContextPropertyUtils {
 
 	private static class ServletContextPlaceholderResolver implements PropertyPlaceholderHelper.PlaceholderResolver {
 
+		private static final Log logger = LogFactory.getLog(ServletContextPlaceholderResolver.class);
+
 		private final String text;
 
 		private final ServletContext servletContext;
@@ -113,8 +117,10 @@ public abstract class ServletContextPropertyUtils {
 				return propVal;
 			}
 			catch (Throwable ex) {
-				System.err.println("Could not resolve placeholder '" + placeholderName + "' in [" +
-						this.text + "] as ServletContext init-parameter or system property: " + ex);
+				if (logger.isDebugEnabled()) {
+					logger.debug("Could not resolve placeholder '" + placeholderName + "' in [" +
+							this.text + "] as ServletContext init-parameter or system property", ex);
+				}
 				return null;
 			}
 		}


### PR DESCRIPTION
Replace System.err.println() in ServletContextPropertyUtils and printStackTrace() in InvocationsRecorderClassTransformer with proper logging using Apache Commons Logging. This improves error handling and follows Spring Framework logging conventions.

Also fix typo in JsonConverterDelegate javadoc: 'tyep' -> 'type'.