### PR TITLE
Improve XJC configuration for `spring-oxm` in the Gradle build

### DIFF
--- a/spring-oxm/spring-oxm.gradle
+++ b/spring-oxm/spring-oxm.gradle
@@ -1,3 +1,5 @@
+import com.github.bjornvester.xjc.XjcTask
+
 plugins {
 	id "com.github.bjornvester.xjc"
 }
@@ -26,14 +28,8 @@ dependencies {
 	testRuntimeOnly("com.sun.xml.bind:jaxb-impl")
 }
 
-tasks.named("xjc").configure { xjc ->
-	// XJC plugin only works against main sources, so we have to "move" them to test sources.
-	sourceSets.main.java.exclude {
-		it.file.absolutePath.startsWith(outputJavaDir.get().asFile.absolutePath)
-	}
-	sourceSets.main.resources.exclude {
-		it.file.absolutePath.startsWith(outputResourcesDir.get().asFile.absolutePath)
-	}
-	sourceSets.test.java.srcDir(xjc.outputJavaDir)
-	sourceSets.test.resources.srcDir(xjc.outputResourcesDir)
-}
+// XJC plugin adds generated code to main source set, but we need it only for tests
+sourceSets.main.java.setSrcDirs(["src/main/java"])
+sourceSets.main.resources.setSrcDirs(["src/main/resources"])
+sourceSets.test.java.srcDir(tasks.named("xjc", XjcTask).flatMap { it.outputJavaDir })
+sourceSets.test.resources.srcDir(tasks.named("xjc", XjcTask).flatMap { it.outputResourcesDir })


### PR DESCRIPTION
Existing solution used a filter to remove the generated sources from the main source set, but we shouldn't have xjc sources on main at all. This also still leaves the sources associated with main, just excluded. Additionally, this code relies on the `xjc` task already being a dependency of `compileJava`, configuring sources when the `xjc` task is realized.

We can work around this by resetting the main and resources source sets to their standard dirs.

Once we've done that, we can hook up the output (here `flatMap`ed out from the generation task) so that the output directories are properly associated with the task that generates them.

This simplifies the overall configuration and enables the use of configuration-cache for test compile and debug tasks.