### PR TITLE
Use Reader.transferTo in FileCopyUtils

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/FileCopyUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/FileCopyUtils.java
@@ -168,13 +168,7 @@ public abstract class FileCopyUtils {
 		Assert.notNull(out, "No Writer specified");
 
 		try {
-			int charCount = 0;
-			char[] buffer = new char[BUFFER_SIZE];
-			int charsRead;
-			while ((charsRead = in.read(buffer)) != -1) {
-				out.write(buffer, 0, charsRead);
-				charCount += charsRead;
-			}
+			int charCount = (int) in.transferTo(out);
 			out.flush();
 			return charCount;
 		}


### PR DESCRIPTION
Use the transferTo method in FileCopyUtils#copy(Reader, Writer); Reader subclasses may have optimized implementations of `transferTo`.