### PR TITLE
Update GitHub `upload-artifact` action to version 6

### DIFF
--- a/.github/workflows/build-pull-request.yml
+++ b/.github/workflows/build-pull-request.yml
@@ -19,7 +19,7 @@ jobs:
         uses: ./.github/actions/print-jvm-thread-dumps
       - name: Upload Build Reports
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: build-reports
           path: '**/build/reports/'

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -64,7 +64,7 @@ jobs:
         run: ./gradlew spring-framework-release-verification-tests:test
       - name: Upload Build Reports on Failure
         if: failure()
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: build-reports
           path: '**/build/reports/'


### PR DESCRIPTION
This PR updates outdated GitHub Action versions.

- Updated `actions/upload-artifact` from `v5` to `v6` in `.github/workflows/verify.yml`
- Updated `actions/upload-artifact` from `v5` to `v6` in `.github/workflows/build-pull-request.yml`
