### PR TITLE
Refine YamlProcessor to allow different empty values

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlProcessor.java
@@ -304,7 +304,7 @@ public abstract class YamlProcessor {
 	 * @since 4.1.3
 	 */
 	protected final Map<String, Object> getFlattenedMap(Map<String, Object> source) {
-		return getFlattenedMap(source, false);
+		return getFlattenedMap(source, false, null);
 	}
 
 	/**
@@ -313,21 +313,25 @@ public abstract class YamlProcessor {
 	 * source. When called with the Map from a {@link MatchCallback} the result will
 	 * contain the same values as the {@link MatchCallback} Properties.
 	 * @param source the source map
-	 * @param includeNulls if {@code null} entries can be included in the result
+	 * @param includeEmpty if empty entries should be included in the result
+	 * @param emptyValue the value used to represent empty entries (e.g. {@code null} or an empty {@code String}
 	 * @return a flattened map
 	 * @since 7.0.4
 	 */
-	protected final Map<String, Object> getFlattenedMap(Map<String, Object> source, boolean includeNulls) {
+	protected final Map<String, Object> getFlattenedMap(Map<String, Object> source, boolean includeEmpty,
+			@Nullable Object emptyValue) {
+
 		Map<String, Object> result = new LinkedHashMap<>();
-		buildFlattenedMap(result, source, null, includeNulls);
+		buildFlattenedMap(result, source, null, includeEmpty, emptyValue);
 		return result;
 	}
 
 	@SuppressWarnings({"rawtypes", "unchecked"})
 	private void buildFlattenedMap(Map<String, Object> result, Map<String, Object> source, @Nullable String path,
-			boolean includeNulls) {
-		if (includeNulls && source.isEmpty()) {
-			result.put(path, null);
+			boolean includeEmpty, @Nullable Object emptyValue) {
+
+		if (includeEmpty && source.isEmpty()) {
+			result.put(path, emptyValue);
 			return;
 		}
 		source.forEach((key, value) -> {
@@ -344,7 +348,7 @@ public abstract class YamlProcessor {
 			}
 			else if (value instanceof Map map) {
 				// Need a compound key
-				buildFlattenedMap(result, map, key, includeNulls);
+				buildFlattenedMap(result, map, key, includeEmpty, emptyValue);
 			}
 			else if (value instanceof Collection collection) {
 				// Need a compound key
@@ -355,12 +359,12 @@ public abstract class YamlProcessor {
 					int count = 0;
 					for (Object object : collection) {
 						buildFlattenedMap(result, Collections.singletonMap(
-								"[" + (count++) + "]", object), key, includeNulls);
+								"[" + (count++) + "]", object), key, includeEmpty, emptyValue);
 					}
 				}
 			}
 			else {
-				result.put(key, (value != null ? value : ""));
+				result.put(key, (value != null ? value : (includeEmpty ? emptyValue : "")));
 			}
 		});
 	}


### PR DESCRIPTION
Update `YamlProcessor` to allow any value to be inserted for empty entries. This update will allow blank strings to be used instead of `null` which better aligns with the way that `.properties` files are loaded.

This update also allows allows the specified `emptyValue` to be inserted instead of a blank String when the YAML contains `null` or `~` values.

See gh-36197
See gh-19986