### PR TITLE
Corrected the definition of coroutines

### DIFF
--- a/framework-docs/modules/ROOT/pages/languages/kotlin/coroutines.adoc
+++ b/framework-docs/modules/ROOT/pages/languages/kotlin/coroutines.adoc
@@ -1,8 +1,8 @@
 [[coroutines]]
 = Coroutines
 
-Kotlin {kotlin-docs}/coroutines-overview.html[Coroutines] are Kotlin
-lightweight threads allowing to write non-blocking code in an imperative way. On language side,
+Kotlin {kotlin-docs}/coroutines-overview.html[Coroutines] are instances of
+suspendable computations allowing to write non-blocking code in an imperative way. On language side,
 suspending functions provides an abstraction for asynchronous operations while on library side
 {kotlin-github-org}/kotlinx.coroutines[kotlinx.coroutines] provides functions like
 {kotlin-coroutines-api}/kotlinx-coroutines-core/kotlinx.coroutines/async.html[`async { }`]


### PR DESCRIPTION
Corrected the definition of coroutines.

Coroutines are often compared to threads, as some of their characterists are similar. As result, coroutines are well described as lightweight threads in various references. This does not mean that coroutines are lightweight threads.
A single coroutine may work on more than a single thread throughout its lifecycle, being suspended and resumed. A single thread may run numerous coroutines sequentially.

[The official document of Kotlin Coroutines](https://kotlinlang.org/docs/coroutines-basics.html) also mentions this point. It describes as:

> A coroutine is an instance of a suspendable computation. It is conceptually similar to a thread, in the sense that it takes a block of code to run that works concurrently with the rest of the code. However, a coroutine is not bound to any particular thread. It may suspend its execution in one thread and resume in another one.
Coroutines can be thought of as light-weight threads, but there is a number of important differences that make their real-life usage very different from threads.

I peviously proposed the same at Spring Data Commons ([PR](https://github.com/spring-projects/spring-data-commons/pull/3136)), and thankfully the maintainer accepted my request as it makes sense to keep align with Kotlin's perspective.