### PR TITLE
Use Java Files utilities in FileCopyUtils

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/FileCopyUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/FileCopyUtils.java
@@ -16,7 +16,6 @@
 
 package org.springframework.util;
 
-import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
@@ -76,7 +75,7 @@ public abstract class FileCopyUtils {
 	public static void copy(byte[] in, File out) throws IOException {
 		Assert.notNull(in, "No input byte array specified");
 		Assert.notNull(out, "No output File specified");
-		copy(new ByteArrayInputStream(in), Files.newOutputStream(out.toPath()));
+		Files.write(out.toPath(), in);
 	}
 
 	/**
@@ -87,7 +86,7 @@ public abstract class FileCopyUtils {
 	 */
 	public static byte[] copyToByteArray(File in) throws IOException {
 		Assert.notNull(in, "No input File specified");
-		return copyToByteArray(Files.newInputStream(in.toPath()));
+		return Files.readAllBytes(in.toPath());
 	}
 
 

--- a/spring-core/src/test/java/org/springframework/util/FileCopyUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/FileCopyUtilsTests.java
@@ -21,9 +21,12 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -87,4 +90,29 @@ class FileCopyUtilsTests {
 		assertThat(result).isEqualTo(content);
 	}
 
+	@Test
+	void copyFile(@TempDir Path tempDir) throws IOException {
+		Path source = tempDir.resolve("src");
+		Path target = tempDir.resolve("target");
+		Files.write(source, "content".getBytes());
+		int bytesWritten = FileCopyUtils.copy(source.toFile(), target.toFile());
+		assertThat(bytesWritten).isEqualTo(7);
+		assertThat(target).exists();
+		assertThat(target).content().isEqualTo("content");
+	}
+
+	@Test
+	void copyFileToByteArray(@TempDir Path tempDir) throws IOException {
+		Path source = tempDir.resolve("src");
+		Files.write(source, "content".getBytes());
+		assertThat(FileCopyUtils.copyToByteArray(source.toFile())).asString().isEqualTo("content");
+	}
+
+	@Test
+	void copyByteArrayToFile(@TempDir Path tempDir) throws IOException {
+		Path target = tempDir.resolve("target");
+		FileCopyUtils.copy("content".getBytes(), target.toFile());
+		assertThat(target).exists();
+		assertThat(target).content().isEqualTo("content");
+	}
 }


### PR DESCRIPTION
Use helpers from java.nio.file.Files for some methods in FileCopyUtils.

Additionally, add unit tests for the various file-related methods.