### PR TITLE
Optimize NamedParameterUtils#buildValueArray by lazily fetching SqlParameter

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterUtils.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterUtils.java
@@ -363,12 +363,12 @@ public abstract class NamedParameterUtils {
 		for (int i = 0; i < paramNames.size(); i++) {
 			String paramName = paramNames.get(i);
 			try {
-				SqlParameter param = findParameter(declaredParams, paramName, i);
 				Object paramValue = paramSource.getValue(paramName);
 				if (paramValue instanceof SqlParameterValue) {
 					paramArray[i] = paramValue;
 				}
 				else {
+					SqlParameter param = findParameter(declaredParams, paramName, i);
 					paramArray[i] = (param != null ? new SqlParameterValue(param, paramValue) :
 							SqlParameterSourceUtils.getTypedValue(paramSource, paramName));
 				}


### PR DESCRIPTION
This PR optimizes the performance of NamedParameterUtils#buildValueArray by deferring the call to findParameter(declaredParams, paramName, i).

Changes: In the original implementation, findParameter was called for every parameter in the loop, regardless of whether the paramValue retrieved from paramSource was already an instance of SqlParameterValue.

Since findParameter involves iterating through the declaredParams list (or performing lookups), skipping this call when paramValue instanceof SqlParameterValue is true reduces unnecessary CPU cycles and memory access, especially for queries with a large number of parameters or long declaredParams lists.