### PR TITLE
Revise nullability in HttpEntity and ResponseEntity

### DIFF
--- a/framework-docs/src/main/kotlin/org/springframework/docs/web/webmvc/mvccontroller/mvcannexceptionhandlerexc/ExceptionController.kt
+++ b/framework-docs/src/main/kotlin/org/springframework/docs/web/webmvc/mvccontroller/mvcannexceptionhandlerexc/ExceptionController.kt
@@ -27,7 +27,7 @@ class ExceptionController {
 
 	// tag::narrow[]
 	@ExceptionHandler(FileSystemException::class, RemoteException::class)
-	fun handleIOException(ex: IOException): ResponseEntity<String> {
+	fun handleIoException(ex: IOException): ResponseEntity<String?> {
 		return ResponseEntity.internalServerError().body(ex.message)
 	}
 	// end::narrow[]
@@ -35,7 +35,7 @@ class ExceptionController {
 
 	// tag::general[]
 	@ExceptionHandler(FileSystemException::class, RemoteException::class)
-	fun handleExceptions(ex: Exception): ResponseEntity<String> {
+	fun handleExceptions(ex: Exception): ResponseEntity<String?> {
 		return ResponseEntity.internalServerError().body(ex.message)
 	}
 	// end::general[]

--- a/framework-docs/src/main/kotlin/org/springframework/docs/web/webmvc/mvccontroller/mvcannexceptionhandlerexc/ExceptionController.kt
+++ b/framework-docs/src/main/kotlin/org/springframework/docs/web/webmvc/mvccontroller/mvcannexceptionhandlerexc/ExceptionController.kt
@@ -27,7 +27,7 @@ class ExceptionController {
 
 	// tag::narrow[]
 	@ExceptionHandler(FileSystemException::class, RemoteException::class)
-	fun handleIoException(ex: IOException): ResponseEntity<String?> {
+	fun handleIOException(ex: IOException): ResponseEntity<String?> {
 		return ResponseEntity.internalServerError().body(ex.message)
 	}
 	// end::narrow[]

--- a/spring-web/src/main/java/org/springframework/http/HttpEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpEntity.java
@@ -56,7 +56,7 @@ import org.springframework.util.ObjectUtils;
  * @see #getBody()
  * @see #getHeaders()
  */
-public class HttpEntity<T> {
+public class HttpEntity<T extends @Nullable Object> {
 
 	/**
 	 * An {@code HttpEntity} instance with a {@code null} body and

--- a/spring-web/src/main/java/org/springframework/http/HttpEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpEntity.java
@@ -112,7 +112,7 @@ public class HttpEntity<T extends @Nullable Object> {
 	 * @param headers the entity headers
 	 * @deprecated in favor of {@link #HttpEntity(HttpHeaders)}
 	 */
-	@SuppressWarnings("NullAway")
+	@SuppressWarnings({"removal", "NullAway"})
 	@Deprecated(since = "7.0", forRemoval = true)
 	public HttpEntity(MultiValueMap<String, String> headers) {
 		this(null, headers);

--- a/spring-web/src/main/java/org/springframework/http/HttpEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpEntity.java
@@ -67,12 +67,13 @@ public class HttpEntity<T extends @Nullable Object> {
 
 	private final HttpHeaders headers;
 
-	private final @Nullable T body;
+	private final T body;
 
 
 	/**
 	 * Create a new, empty {@code HttpEntity}.
 	 */
+	@SuppressWarnings("NullAway")
 	protected HttpEntity() {
 		this(null, (HttpHeaders) null);
 	}
@@ -90,6 +91,7 @@ public class HttpEntity<T extends @Nullable Object> {
 	 * @param headers the entity headers
 	 * @since 7.0
 	 */
+	@SuppressWarnings("NullAway")
 	public HttpEntity(HttpHeaders headers) {
 		this(null, headers);
 	}
@@ -100,7 +102,7 @@ public class HttpEntity<T extends @Nullable Object> {
 	 * @param headers the entity headers
 	 * @since 7.0
 	 */
-	public HttpEntity(@Nullable T body, @Nullable HttpHeaders headers) {
+	public HttpEntity(T body, @Nullable HttpHeaders headers) {
 		this.body = body;
 		this.headers = (headers != null) ? headers : new HttpHeaders();
 	}
@@ -110,7 +112,7 @@ public class HttpEntity<T extends @Nullable Object> {
 	 * @param headers the entity headers
 	 * @deprecated in favor of {@link #HttpEntity(HttpHeaders)}
 	 */
-	@SuppressWarnings("removal")
+	@SuppressWarnings("NullAway")
 	@Deprecated(since = "7.0", forRemoval = true)
 	public HttpEntity(MultiValueMap<String, String> headers) {
 		this(null, headers);
@@ -123,7 +125,7 @@ public class HttpEntity<T extends @Nullable Object> {
 	 * @deprecated in favor of {@link #HttpEntity(Object, HttpHeaders)}
 	 */
 	@Deprecated(since = "7.0", forRemoval = true)
-	public HttpEntity(@Nullable T body, @Nullable MultiValueMap<String, String> headers) {
+	public HttpEntity(T body, @Nullable MultiValueMap<String, String> headers) {
 		this(body, (headers != null) ? new HttpHeaders(headers) : new HttpHeaders());
 	}
 
@@ -138,7 +140,7 @@ public class HttpEntity<T extends @Nullable Object> {
 	/**
 	 * Returns the body of this entity.
 	 */
-	public @Nullable T getBody() {
+	public T getBody() {
 		return this.body;
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/RequestEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/RequestEntity.java
@@ -156,7 +156,7 @@ public class RequestEntity<T extends @Nullable Object> extends HttpEntity<T> {
 	 * @param url the URL
 	 * @deprecated in favor of {@link #RequestEntity(HttpHeaders, HttpMethod, URI)}
 	 */
-	@SuppressWarnings("NullAway")
+	@SuppressWarnings({"removal", "NullAway"})
 	@Deprecated(since = "7.0", forRemoval = true)
 	public RequestEntity(MultiValueMap<String, String> headers, HttpMethod method, URI url) {
 		this(null, headers, method, url, null);
@@ -170,6 +170,7 @@ public class RequestEntity<T extends @Nullable Object> extends HttpEntity<T> {
 	 * @param url the URL
 	 * @deprecated in favor of {@link #RequestEntity(Object, HttpHeaders, HttpMethod, URI)}
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "7.0", forRemoval = true)
 	public RequestEntity(
 			T body, @Nullable MultiValueMap<String, String> headers,

--- a/spring-web/src/main/java/org/springframework/http/RequestEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/RequestEntity.java
@@ -65,7 +65,7 @@ import org.springframework.util.ObjectUtils;
  * @see org.springframework.web.client.RestOperations#exchange(RequestEntity, Class)
  * @see ResponseEntity
  */
-public class RequestEntity<T> extends HttpEntity<T> {
+public class RequestEntity<T extends @Nullable Object> extends HttpEntity<T> {
 
 	private final @Nullable HttpMethod method;
 
@@ -78,6 +78,7 @@ public class RequestEntity<T> extends HttpEntity<T> {
 	 * @param method the method
 	 * @param url the URL
 	 */
+	@SuppressWarnings("NullAway")
 	public RequestEntity(HttpMethod method, URI url) {
 		this(null, (HttpHeaders) null, method, url, null);
 	}
@@ -88,7 +89,7 @@ public class RequestEntity<T> extends HttpEntity<T> {
 	 * @param method the method
 	 * @param url the URL
 	 */
-	public RequestEntity(@Nullable T body, HttpMethod method, URI url) {
+	public RequestEntity(T body, HttpMethod method, URI url) {
 		this(body, (HttpHeaders) null, method, url, null);
 	}
 
@@ -100,7 +101,7 @@ public class RequestEntity<T> extends HttpEntity<T> {
 	 * @param type the type used for generic type resolution
 	 * @since 4.3
 	 */
-	public RequestEntity(@Nullable T body, HttpMethod method, URI url, Type type) {
+	public RequestEntity(T body, HttpMethod method, URI url, Type type) {
 		this(body, (HttpHeaders) null, method, url, type);
 	}
 
@@ -111,6 +112,7 @@ public class RequestEntity<T> extends HttpEntity<T> {
 	 * @param url the URL
 	 * @since 7.0
 	 */
+	@SuppressWarnings("NullAway")
 	public RequestEntity(HttpHeaders headers, HttpMethod method, URI url) {
 		this(null, headers, method, url, null);
 	}
@@ -123,7 +125,7 @@ public class RequestEntity<T> extends HttpEntity<T> {
 	 * @param url the URL
 	 * @since 7.0
 	 */
-	public RequestEntity(@Nullable T body, @Nullable HttpHeaders headers,
+	public RequestEntity(T body, @Nullable HttpHeaders headers,
 			@Nullable HttpMethod method, URI url) {
 
 		this(body, headers, method, url, null);
@@ -138,7 +140,7 @@ public class RequestEntity<T> extends HttpEntity<T> {
 	 * @param type the type used for generic type resolution
 	 * @since 7.0
 	 */
-	public RequestEntity(@Nullable T body, @Nullable HttpHeaders headers,
+	public RequestEntity(T body, @Nullable HttpHeaders headers,
 			@Nullable HttpMethod method, @Nullable URI url, @Nullable Type type) {
 
 		super(body, headers);
@@ -154,7 +156,7 @@ public class RequestEntity<T> extends HttpEntity<T> {
 	 * @param url the URL
 	 * @deprecated in favor of {@link #RequestEntity(HttpHeaders, HttpMethod, URI)}
 	 */
-	@SuppressWarnings("removal")
+	@SuppressWarnings("NullAway")
 	@Deprecated(since = "7.0", forRemoval = true)
 	public RequestEntity(MultiValueMap<String, String> headers, HttpMethod method, URI url) {
 		this(null, headers, method, url, null);
@@ -168,10 +170,9 @@ public class RequestEntity<T> extends HttpEntity<T> {
 	 * @param url the URL
 	 * @deprecated in favor of {@link #RequestEntity(Object, HttpHeaders, HttpMethod, URI)}
 	 */
-	@SuppressWarnings("removal")
 	@Deprecated(since = "7.0", forRemoval = true)
 	public RequestEntity(
-			@Nullable T body, @Nullable MultiValueMap<String, String> headers,
+			T body, @Nullable MultiValueMap<String, String> headers,
 			@Nullable HttpMethod method, URI url) {
 
 		this(body, headers, method, url, null);
@@ -189,7 +190,7 @@ public class RequestEntity<T> extends HttpEntity<T> {
 	 */
 	@SuppressWarnings("removal")
 	@Deprecated(since = "7.0", forRemoval = true)
-	public RequestEntity(@Nullable T body, @Nullable MultiValueMap<String, String> headers,
+	public RequestEntity(T body, @Nullable MultiValueMap<String, String> headers,
 			@Nullable HttpMethod method, @Nullable URI url, @Nullable Type type) {
 
 		super(body, headers);
@@ -548,7 +549,7 @@ public class RequestEntity<T> extends HttpEntity<T> {
 		 * @return the request entity
 		 * @see BodyBuilder#body(Object)
 		 */
-		RequestEntity<Void> build();
+		RequestEntity<@Nullable Void> build();
 	}
 
 
@@ -704,7 +705,7 @@ public class RequestEntity<T> extends HttpEntity<T> {
 		}
 
 		@Override
-		public RequestEntity<Void> build() {
+		public RequestEntity<@Nullable Void> build() {
 			return buildInternal(null, null);
 		}
 
@@ -718,7 +719,7 @@ public class RequestEntity<T> extends HttpEntity<T> {
 			return buildInternal(body, type);
 		}
 
-		private <T> RequestEntity<T> buildInternal(@Nullable T body, @Nullable Type type) {
+		private <T extends @Nullable Object> RequestEntity<T> buildInternal(T body, @Nullable Type type) {
 			if (this.uri != null) {
 				return new RequestEntity<>(body, this.headers, this.method, this.uri, type);
 			}
@@ -738,7 +739,7 @@ public class RequestEntity<T> extends HttpEntity<T> {
 	 * @since 5.3
 	 * @param <T> the body type
 	 */
-	public static class UriTemplateRequestEntity<T> extends RequestEntity<T> {
+	public static class UriTemplateRequestEntity<T extends @Nullable Object> extends RequestEntity<T> {
 
 		private final String uriTemplate;
 
@@ -747,7 +748,7 @@ public class RequestEntity<T> extends HttpEntity<T> {
 		private final @Nullable Map<String, ? extends @Nullable Object> uriVarsMap;
 
 		UriTemplateRequestEntity(
-				@Nullable T body, @Nullable HttpHeaders headers,
+				T body, @Nullable HttpHeaders headers,
 				@Nullable HttpMethod method, @Nullable Type type, String uriTemplate,
 				@Nullable Object @Nullable [] uriVarsArray, @Nullable Map<String, ?> uriVarsMap) {
 

--- a/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
@@ -311,7 +311,7 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 	 * @return the created {@code ResponseEntity}
 	 * @since 6.0.5
 	 */
-	public static <T extends @Nullable Object> ResponseEntity<T> ofNullable(@Nullable T body) {
+	public static <T extends @Nullable Object> ResponseEntity<T> ofNullable(T body) {
 		if (body == null) {
 			return notFound().build();
 		}

--- a/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
@@ -264,7 +264,7 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 	 * @return the created {@code ResponseEntity}
 	 * @since 4.1
 	 */
-	public static <T extends @Nullable Object> ResponseEntity<@Nullable T> ok(@Nullable T body) {
+	public static <T extends @Nullable Object> ResponseEntity<T> ok(T body) {
 		return ok().body(body);
 	}
 
@@ -297,8 +297,8 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 
 			@SuppressWarnings("unchecked")
 			@Override
-			public <T> ResponseEntity<@Nullable T> build() {
-				return (ResponseEntity<@Nullable T>) body(body);
+			public <T extends @Nullable Object> ResponseEntity<T> build() {
+				return (ResponseEntity<T>) body(body);
 			}
 		};
 	}
@@ -311,7 +311,7 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 	 * @return the created {@code ResponseEntity}
 	 * @since 6.0.5
 	 */
-	public static <T extends @Nullable Object> ResponseEntity<@Nullable T> ofNullable(@Nullable T body) {
+	public static <T extends @Nullable Object> ResponseEntity<T> ofNullable(@Nullable T body) {
 		if (body == null) {
 			return notFound().build();
 		}
@@ -519,7 +519,7 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 		 * @return the response entity
 		 * @see BodyBuilder#body(Object)
 		 */
-		<T> ResponseEntity<@Nullable T> build();
+		<T extends @Nullable Object> ResponseEntity<T> build();
 	}
 
 
@@ -655,8 +655,9 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 			return this;
 		}
 
+		@SuppressWarnings("NullAway")
 		@Override
-		public <T> ResponseEntity<@Nullable T> build() {
+		public <T extends @Nullable Object> ResponseEntity<T> build() {
 			return body(null);
 		}
 

--- a/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
@@ -87,6 +87,7 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 	 * Create a {@code ResponseEntity} with a status code only.
 	 * @param status the status code
 	 */
+	@SuppressWarnings("NullAway")
 	public ResponseEntity(HttpStatusCode status) {
 		this(null, (HttpHeaders) null, status);
 	}
@@ -96,7 +97,7 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 	 * @param body the entity body
 	 * @param status the status code
 	 */
-	public ResponseEntity(@Nullable T body, HttpStatusCode status) {
+	public ResponseEntity(T body, HttpStatusCode status) {
 		this(body, (HttpHeaders) null, status);
 	}
 
@@ -106,6 +107,7 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 	 * @param status the status code
 	 * @since 7.0
 	 */
+	@SuppressWarnings("NullAway")
 	public ResponseEntity(HttpHeaders headers, HttpStatusCode status) {
 		this(null, headers, status);
 	}
@@ -117,7 +119,7 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 	 * @param rawStatus the status code value
 	 * @since 7.0
 	 */
-	public ResponseEntity(@Nullable T body, @Nullable HttpHeaders headers, int rawStatus) {
+	public ResponseEntity(T body, @Nullable HttpHeaders headers, int rawStatus) {
 		this(body, headers, HttpStatusCode.valueOf(rawStatus));
 	}
 
@@ -128,7 +130,7 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 	 * @param statusCode the status code
 	 * @since 7.0
 	 */
-	public ResponseEntity(@Nullable T body, @Nullable HttpHeaders headers, HttpStatusCode statusCode) {
+	public ResponseEntity(T body, @Nullable HttpHeaders headers, HttpStatusCode statusCode) {
 		super(body, headers);
 		Assert.notNull(statusCode, "HttpStatusCode must not be null");
 
@@ -141,7 +143,7 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 	 * @param status the status code
 	 * @deprecated in favor of {@link #ResponseEntity(HttpHeaders, HttpStatusCode)}
 	 */
-	@SuppressWarnings("removal")
+	@SuppressWarnings("NullAway")
 	@Deprecated(since = "7.0", forRemoval = true)
 	public ResponseEntity(MultiValueMap<String, String> headers, HttpStatusCode status) {
 		this(null, headers, status);
@@ -155,9 +157,8 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 	 * @since 5.3.2
 	 * @deprecated in favor of {@link #ResponseEntity(Object, HttpHeaders, int)}
 	 */
-	@SuppressWarnings("removal")
 	@Deprecated(since = "7.0", forRemoval = true)
-	public ResponseEntity(@Nullable T body, @Nullable MultiValueMap<String, String> headers, int rawStatus) {
+	public ResponseEntity(T body, @Nullable MultiValueMap<String, String> headers, int rawStatus) {
 		this(body, headers, HttpStatusCode.valueOf(rawStatus));
 	}
 
@@ -170,7 +171,7 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 	 */
 	@SuppressWarnings("removal")
 	@Deprecated(since = "7.0", forRemoval = true)
-	public ResponseEntity(@Nullable T body, @Nullable MultiValueMap<String, String> headers, HttpStatusCode statusCode) {
+	public ResponseEntity(T body, @Nullable MultiValueMap<String, String> headers, HttpStatusCode statusCode) {
 		super(body, headers);
 		Assert.notNull(statusCode, "HttpStatusCode must not be null");
 
@@ -263,7 +264,7 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 	 * @return the created {@code ResponseEntity}
 	 * @since 4.1
 	 */
-	public static <T extends @Nullable Object> ResponseEntity<T> ok(@Nullable T body) {
+	public static <T extends @Nullable Object> ResponseEntity<@Nullable T> ok(@Nullable T body) {
 		return ok().body(body);
 	}
 
@@ -296,8 +297,8 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 
 			@SuppressWarnings("unchecked")
 			@Override
-			public <T> ResponseEntity<T> build() {
-				return (ResponseEntity<T>) body(body);
+			public <T> ResponseEntity<@Nullable T> build() {
+				return (ResponseEntity<@Nullable T>) body(body);
 			}
 		};
 	}
@@ -310,7 +311,7 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 	 * @return the created {@code ResponseEntity}
 	 * @since 6.0.5
 	 */
-	public static <T extends @Nullable Object> ResponseEntity<T> ofNullable(@Nullable T body) {
+	public static <T extends @Nullable Object> ResponseEntity<@Nullable T> ofNullable(@Nullable T body) {
 		if (body == null) {
 			return notFound().build();
 		}
@@ -518,7 +519,7 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 		 * @return the response entity
 		 * @see BodyBuilder#body(Object)
 		 */
-		<T> ResponseEntity<T> build();
+		<T> ResponseEntity<@Nullable T> build();
 	}
 
 
@@ -552,7 +553,7 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 		 * @param body the body of the response entity
 		 * @return the built response entity
 		 */
-		<T> ResponseEntity<T> body(@Nullable T body);
+		<T extends @Nullable Object> ResponseEntity<T> body(T body);
 	}
 
 
@@ -655,12 +656,12 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 		}
 
 		@Override
-		public <T> ResponseEntity<T> build() {
+		public <T> ResponseEntity<@Nullable T> build() {
 			return body(null);
 		}
 
 		@Override
-		public <T extends @Nullable Object> ResponseEntity<T> body(@Nullable T body) {
+		public <T extends @Nullable Object> ResponseEntity<T> body(T body) {
 			return new ResponseEntity<>(body, this.headers, this.statusCode);
 		}
 	}

--- a/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
@@ -78,7 +78,7 @@ import org.springframework.util.ObjectUtils;
  * @see org.springframework.web.client.RestOperations#getForEntity(URI, Class)
  * @see RequestEntity
  */
-public class ResponseEntity<T> extends HttpEntity<T> {
+public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 
 	private final HttpStatusCode status;
 
@@ -263,7 +263,7 @@ public class ResponseEntity<T> extends HttpEntity<T> {
 	 * @return the created {@code ResponseEntity}
 	 * @since 4.1
 	 */
-	public static <T> ResponseEntity<T> ok(@Nullable T body) {
+	public static <T extends @Nullable Object> ResponseEntity<T> ok(@Nullable T body) {
 		return ok().body(body);
 	}
 
@@ -310,7 +310,7 @@ public class ResponseEntity<T> extends HttpEntity<T> {
 	 * @return the created {@code ResponseEntity}
 	 * @since 6.0.5
 	 */
-	public static <T> ResponseEntity<T> ofNullable(@Nullable T body) {
+	public static <T extends @Nullable Object> ResponseEntity<T> ofNullable(@Nullable T body) {
 		if (body == null) {
 			return notFound().build();
 		}
@@ -660,7 +660,7 @@ public class ResponseEntity<T> extends HttpEntity<T> {
 		}
 
 		@Override
-		public <T> ResponseEntity<T> body(@Nullable T body) {
+		public <T extends @Nullable Object> ResponseEntity<T> body(@Nullable T body) {
 			return new ResponseEntity<>(body, this.headers, this.statusCode);
 		}
 	}

--- a/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
@@ -143,7 +143,7 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 	 * @param status the status code
 	 * @deprecated in favor of {@link #ResponseEntity(HttpHeaders, HttpStatusCode)}
 	 */
-	@SuppressWarnings("NullAway")
+	@SuppressWarnings({"removal", "NullAway"})
 	@Deprecated(since = "7.0", forRemoval = true)
 	public ResponseEntity(MultiValueMap<String, String> headers, HttpStatusCode status) {
 		this(null, headers, status);
@@ -157,6 +157,7 @@ public class ResponseEntity<T extends @Nullable Object> extends HttpEntity<T> {
 	 * @since 5.3.2
 	 * @deprecated in favor of {@link #ResponseEntity(Object, HttpHeaders, int)}
 	 */
+	@SuppressWarnings("removal")
 	@Deprecated(since = "7.0", forRemoval = true)
 	public ResponseEntity(T body, @Nullable MultiValueMap<String, String> headers, int rawStatus) {
 		this(body, headers, HttpStatusCode.valueOf(rawStatus));

--- a/spring-web/src/main/java/org/springframework/http/client/MultipartBodyBuilder.java
+++ b/spring-web/src/main/java/org/springframework/http/client/MultipartBodyBuilder.java
@@ -317,7 +317,7 @@ public final class MultipartBodyBuilder {
 		}
 
 		public HttpEntity<?> build() {
-			return new HttpEntity<>(this.body, this.headers);
+			return new HttpEntity<@Nullable Object>(this.body, this.headers);
 		}
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestTemplate.java
@@ -1019,7 +1019,7 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 	/**
 	 * Response extractor for {@link HttpEntity}.
 	 */
-	private class ResponseEntityResponseExtractor<T> implements ResponseExtractor<ResponseEntity<T>> {
+	private class ResponseEntityResponseExtractor<T> implements ResponseExtractor<ResponseEntity<@Nullable T>> {
 
 		private final @Nullable HttpMessageConverterExtractor<T> delegate;
 
@@ -1033,7 +1033,7 @@ public class RestTemplate extends InterceptingHttpAccessor implements RestOperat
 		}
 
 		@Override
-		public ResponseEntity<T> extractData(ClientHttpResponse response) throws IOException {
+		public ResponseEntity<@Nullable T> extractData(ClientHttpResponse response) throws IOException {
 			if (this.delegate != null) {
 				T body = this.delegate.extractData(response);
 				return ResponseEntity.status(response.getStatusCode()).headers(response.getHeaders()).body(body);

--- a/spring-web/src/test/kotlin/org/springframework/http/ResponseEntityKotlinTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/http/ResponseEntityKotlinTests.kt
@@ -61,8 +61,8 @@ class ResponseEntityKotlinTests {
 	}
 
 	@Test
-	fun okNullUnitType() {
-		val responseEntity = ResponseEntity.ok<Unit>(null)
+	fun okUnitType() {
+		val responseEntity: ResponseEntity<Unit> = ResponseEntity.ok().build()
 		assertThat(responseEntity).isNotNull()
 		assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.OK)
 		assertThat(responseEntity.body).isNull()

--- a/spring-web/src/test/kotlin/org/springframework/http/ResponseEntityKotlinTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/http/ResponseEntityKotlinTests.kt
@@ -36,15 +36,6 @@ class ResponseEntityKotlinTests {
 	}
 
 	@Test
-	fun ofNullNullable() {
-		val responseEntity = ResponseEntity.ofNullable<Int>(null)
-		assertThat(responseEntity).isNotNull()
-		assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
-		assertThat(responseEntity.body).isNull()
-	}
-
-
-	@Test
 	fun ofNullNullableType() {
 		val responseEntity = ResponseEntity.ofNullable<Int?>(null)
 		assertThat(responseEntity).isNotNull()
@@ -65,7 +56,7 @@ class ResponseEntityKotlinTests {
 		val responseEntity: ResponseEntity<Unit> = ResponseEntity.ok().build()
 		assertThat(responseEntity).isNotNull()
 		assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.OK)
-		assertThat(responseEntity.body).isNull()
+		assertThat(responseEntity.body).isEqualTo(Unit)
 	}
 
 	@Test
@@ -81,7 +72,7 @@ class ResponseEntityKotlinTests {
 		val responseEntity = ResponseEntity.noContent().build<Unit>()
 		assertThat(responseEntity).isNotNull()
 		assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.NO_CONTENT)
-		assertThat(responseEntity.body).isNull()
+		assertThat(responseEntity.body).isEqualTo(Unit)
 	}
 
 	@Test

--- a/spring-web/src/test/kotlin/org/springframework/http/ResponseEntityKotlinTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/http/ResponseEntityKotlinTests.kt
@@ -43,4 +43,21 @@ class ResponseEntityKotlinTests {
 		assertThat(responseEntity.body).isNull()
 	}
 
+
+	@Test
+	fun ofNullNullableType() {
+		val responseEntity = ResponseEntity.ofNullable<Int?>(null)
+		assertThat(responseEntity).isNotNull()
+		assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.NOT_FOUND)
+		assertThat(responseEntity.body).isNull()
+	}
+
+	@Test
+	fun okNullNullableType() {
+		val responseEntity = ResponseEntity.ok<String?>(null)
+		assertThat(responseEntity).isNotNull()
+		assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.OK)
+		assertThat(responseEntity.body).isNull()
+	}
+
 }

--- a/spring-web/src/test/kotlin/org/springframework/http/ResponseEntityKotlinTests.kt
+++ b/spring-web/src/test/kotlin/org/springframework/http/ResponseEntityKotlinTests.kt
@@ -60,4 +60,35 @@ class ResponseEntityKotlinTests {
 		assertThat(responseEntity.body).isNull()
 	}
 
+	@Test
+	fun okNullUnitType() {
+		val responseEntity = ResponseEntity.ok<Unit>(null)
+		assertThat(responseEntity).isNotNull()
+		assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.OK)
+		assertThat(responseEntity.body).isNull()
+	}
+
+	@Test
+	fun okNullNullableUnitType() {
+		val responseEntity = ResponseEntity.ok<Unit?>(null)
+		assertThat(responseEntity).isNotNull()
+		assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.OK)
+		assertThat(responseEntity.body).isNull()
+	}
+
+	@Test
+	fun noContentUnitType() {
+		val responseEntity = ResponseEntity.noContent().build<Unit>()
+		assertThat(responseEntity).isNotNull()
+		assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.NO_CONTENT)
+		assertThat(responseEntity.body).isNull()
+	}
+
+	@Test
+	fun noContentNullableUnitType() {
+		val responseEntity: ResponseEntity<Unit?> = ResponseEntity.noContent().build()
+		assertThat(responseEntity).isNotNull()
+		assertThat(responseEntity.statusCode).isEqualTo(HttpStatus.NO_CONTENT)
+		assertThat(responseEntity.body).isNull()
+	}
 }

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClientUtils.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClientUtils.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.function.Predicate;
 
+import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -52,7 +53,7 @@ abstract class WebClientUtils {
 	@SuppressWarnings("unchecked")
 	public static <T> Mono<ResponseEntity<T>> mapToEntity(ClientResponse response, Mono<T> bodyMono) {
 		return ((Mono<Object>) bodyMono).defaultIfEmpty(VALUE_NONE).map(body ->
-				new ResponseEntity<>(
+				new ResponseEntity<@Nullable T>(
 						body != VALUE_NONE ? (T) body : null,
 						response.headers().asHttpHeaders(),
 						response.statusCode()));

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/HttpEntityMethodArgumentResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/HttpEntityMethodArgumentResolver.java
@@ -63,8 +63,8 @@ public class HttpEntityMethodArgumentResolver extends AbstractMessageReaderArgum
 
 	private Object createEntity(@Nullable Object body, Class<?> entityType, ServerHttpRequest request) {
 		return (RequestEntity.class.equals(entityType) ?
-				new RequestEntity<>(body, request.getHeaders(), request.getMethod(), request.getURI()) :
-				new HttpEntity<>(body, request.getHeaders()));
+				new RequestEntity<@Nullable Object>(body, request.getHeaders(), request.getMethod(), request.getURI()) :
+				new HttpEntity<@Nullable Object>(body, request.getHeaders()));
 	}
 
 }

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseEntityExceptionHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/ResponseEntityExceptionHandler.java
@@ -105,7 +105,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 			ErrorResponseException.class,
 			MethodValidationException.class
 	})
-	public final Mono<ResponseEntity<Object>> handleException(Exception ex, ServerWebExchange exchange) {
+	public final Mono<ResponseEntity<@Nullable Object>> handleException(Exception ex, ServerWebExchange exchange) {
 		if (ex instanceof MethodNotAllowedException theEx) {
 			return handleMethodNotAllowedException(theEx, theEx.getHeaders(), theEx.getStatusCode(), exchange);
 		}
@@ -159,7 +159,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @param exchange the current request and response
 	 * @return a {@code Mono} with the {@code ResponseEntity} for the response
 	 */
-	protected Mono<ResponseEntity<Object>> handleMethodNotAllowedException(
+	protected Mono<ResponseEntity<@Nullable Object>> handleMethodNotAllowedException(
 			MethodNotAllowedException ex, HttpHeaders headers, HttpStatusCode status,
 			ServerWebExchange exchange) {
 
@@ -175,7 +175,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @param exchange the current request and response
 	 * @return a {@code Mono} with the {@code ResponseEntity} for the response
 	 */
-	protected Mono<ResponseEntity<Object>> handleNotAcceptableStatusException(
+	protected Mono<ResponseEntity<@Nullable Object>> handleNotAcceptableStatusException(
 			NotAcceptableStatusException ex, HttpHeaders headers, HttpStatusCode status,
 			ServerWebExchange exchange) {
 
@@ -191,7 +191,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @param exchange the current request and response
 	 * @return a {@code Mono} with the {@code ResponseEntity} for the response
 	 */
-	protected Mono<ResponseEntity<Object>> handleUnsupportedMediaTypeStatusException(
+	protected Mono<ResponseEntity<@Nullable Object>> handleUnsupportedMediaTypeStatusException(
 			UnsupportedMediaTypeStatusException ex, HttpHeaders headers, HttpStatusCode status,
 			ServerWebExchange exchange) {
 
@@ -207,7 +207,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @param exchange the current request and response
 	 * @return a {@code Mono} with the {@code ResponseEntity} for the response
 	 */
-	protected Mono<ResponseEntity<Object>> handleMissingRequestValueException(
+	protected Mono<ResponseEntity<@Nullable Object>> handleMissingRequestValueException(
 			MissingRequestValueException ex, HttpHeaders headers, HttpStatusCode status,
 			ServerWebExchange exchange) {
 
@@ -223,7 +223,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @param exchange the current request and response
 	 * @return a {@code Mono} with the {@code ResponseEntity} for the response
 	 */
-	protected Mono<ResponseEntity<Object>> handleUnsatisfiedRequestParameterException(
+	protected Mono<ResponseEntity<@Nullable Object>> handleUnsatisfiedRequestParameterException(
 			UnsatisfiedRequestParameterException ex, HttpHeaders headers, HttpStatusCode status,
 			ServerWebExchange exchange) {
 
@@ -239,7 +239,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @param exchange the current request and response
 	 * @return a {@code Mono} with the {@code ResponseEntity} for the response
 	 */
-	protected Mono<ResponseEntity<Object>> handleWebExchangeBindException(
+	protected Mono<ResponseEntity<@Nullable Object>> handleWebExchangeBindException(
 			WebExchangeBindException ex, HttpHeaders headers, HttpStatusCode status,
 			ServerWebExchange exchange) {
 
@@ -256,7 +256,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @return a {@code Mono} with the {@code ResponseEntity} for the response
 	 * @since 6.1
 	 */
-	protected Mono<ResponseEntity<Object>> handleHandlerMethodValidationException(
+	protected Mono<ResponseEntity<@Nullable Object>> handleHandlerMethodValidationException(
 			HandlerMethodValidationException ex, HttpHeaders headers, HttpStatusCode status,
 			ServerWebExchange exchange) {
 
@@ -272,7 +272,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @param exchange the current request and response
 	 * @return a {@code Mono} with the {@code ResponseEntity} for the response
 	 */
-	protected Mono<ResponseEntity<Object>> handleServerWebInputException(
+	protected Mono<ResponseEntity<@Nullable Object>> handleServerWebInputException(
 			ServerWebInputException ex, HttpHeaders headers, HttpStatusCode status,
 			ServerWebExchange exchange) {
 
@@ -288,7 +288,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @param exchange the current request and response
 	 * @return a {@code Mono} with the {@code ResponseEntity} for the response
 	 */
-	protected Mono<ResponseEntity<Object>> handleResponseStatusException(
+	protected Mono<ResponseEntity<@Nullable Object>> handleResponseStatusException(
 			ResponseStatusException ex, HttpHeaders headers, HttpStatusCode status,
 			ServerWebExchange exchange) {
 
@@ -304,7 +304,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @param exchange the current request and response
 	 * @return a {@code Mono} with the {@code ResponseEntity} for the response
 	 */
-	protected Mono<ResponseEntity<Object>> handleServerErrorException(
+	protected Mono<ResponseEntity<@Nullable Object>> handleServerErrorException(
 			ServerErrorException ex, HttpHeaders headers, HttpStatusCode status,
 			ServerWebExchange exchange) {
 
@@ -320,7 +320,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @param exchange the current request and response
 	 * @return a {@code Mono} with the {@code ResponseEntity} for the response
 	 */
-	protected Mono<ResponseEntity<Object>> handleErrorResponseException(
+	protected Mono<ResponseEntity<@Nullable Object>> handleErrorResponseException(
 			ErrorResponseException ex, HttpHeaders headers, HttpStatusCode status,
 			ServerWebExchange exchange) {
 
@@ -336,7 +336,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @return a {@code Mono} with the {@code ResponseEntity} for the response
 	 * @since 6.1
 	 */
-	protected Mono<ResponseEntity<Object>> handleMethodValidationException(
+	protected Mono<ResponseEntity<@Nullable Object>> handleMethodValidationException(
 			MethodValidationException ex, HttpStatus status, ServerWebExchange exchange) {
 
 		ProblemDetail body = createProblemDetail(ex, status, "Validation failed", null, null, exchange);
@@ -394,7 +394,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @param exchange the current request and response
 	 * @return a {@code Mono} with the {@code ResponseEntity} for the response
 	 */
-	protected Mono<ResponseEntity<Object>> handleExceptionInternal(
+	protected Mono<ResponseEntity<@Nullable Object>> handleExceptionInternal(
 			Exception ex, @Nullable Object body, @Nullable HttpHeaders headers, HttpStatusCode status,
 			ServerWebExchange exchange) {
 
@@ -421,11 +421,11 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @return a {@code Mono} with the created {@code ResponseEntity}
 	 * @since 6.0
 	 */
-	protected Mono<ResponseEntity<Object>> createResponseEntity(
+	protected Mono<ResponseEntity<@Nullable Object>> createResponseEntity(
 			@Nullable Object body, @Nullable HttpHeaders headers, HttpStatusCode status,
 			ServerWebExchange exchange) {
 
-		return Mono.just(new ResponseEntity<>(body, headers, status));
+		return Mono.just(new ResponseEntity<@Nullable Object>(body, headers, status));
 	}
 
 }

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/HttpEntityMethodProcessor.java
@@ -156,11 +156,11 @@ public class HttpEntityMethodProcessor extends AbstractMessageConverterMethodPro
 
 		Object body = readWithMessageConverters(inputMessage, parameter, paramType);
 		if (RequestEntity.class == parameter.getParameterType()) {
-			return new RequestEntity<>(body, inputMessage.getHeaders(),
+			return new RequestEntity<@Nullable Object>(body, inputMessage.getHeaders(),
 					inputMessage.getMethod(), inputMessage.getURI());
 		}
 		else {
-			return new HttpEntity<>(body, inputMessage.getHeaders());
+			return new HttpEntity<@Nullable Object>(body, inputMessage.getHeaders());
 		}
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ResponseEntityExceptionHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ResponseEntityExceptionHandler.java
@@ -135,7 +135,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 			MethodValidationException.class,
 			AsyncRequestNotUsableException.class
 		})
-	public final @Nullable ResponseEntity<Object> handleException(Exception ex, WebRequest request) throws Exception {
+	public final @Nullable ResponseEntity<@Nullable Object> handleException(Exception ex, WebRequest request) throws Exception {
 		if (ex instanceof HttpRequestMethodNotSupportedException subEx) {
 			return handleHttpRequestMethodNotSupported(subEx, subEx.getHeaders(), subEx.getStatusCode(), request);
 		}
@@ -219,7 +219,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @return a {@code ResponseEntity} for the response to use, possibly
 	 * {@code null} when the response is already committed
 	 */
-	protected @Nullable ResponseEntity<Object> handleHttpRequestMethodNotSupported(
+	protected @Nullable ResponseEntity<@Nullable Object> handleHttpRequestMethodNotSupported(
 			HttpRequestMethodNotSupportedException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
 		pageNotFoundLogger.warn(ex.getMessage());
@@ -236,7 +236,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @return a {@code ResponseEntity} for the response to use, possibly
 	 * {@code null} when the response is already committed
 	 */
-	protected @Nullable ResponseEntity<Object> handleHttpMediaTypeNotSupported(
+	protected @Nullable ResponseEntity<@Nullable Object> handleHttpMediaTypeNotSupported(
 			HttpMediaTypeNotSupportedException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
 		return handleExceptionInternal(ex, null, headers, status, request);
@@ -252,7 +252,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @return a {@code ResponseEntity} for the response to use, possibly
 	 * {@code null} when the response is already committed
 	 */
-	protected @Nullable ResponseEntity<Object> handleHttpMediaTypeNotAcceptable(
+	protected @Nullable ResponseEntity<@Nullable Object> handleHttpMediaTypeNotAcceptable(
 			HttpMediaTypeNotAcceptableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
 		return handleExceptionInternal(ex, null, headers, status, request);
@@ -269,7 +269,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * {@code null} when the response is already committed
 	 * @since 4.2
 	 */
-	protected @Nullable ResponseEntity<Object> handleMissingPathVariable(
+	protected @Nullable ResponseEntity<@Nullable Object> handleMissingPathVariable(
 			MissingPathVariableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
 		return handleExceptionInternal(ex, null, headers, status, request);
@@ -285,7 +285,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @return a {@code ResponseEntity} for the response to use, possibly
 	 * {@code null} when the response is already committed
 	 */
-	protected @Nullable ResponseEntity<Object> handleMissingServletRequestParameter(
+	protected @Nullable ResponseEntity<@Nullable Object> handleMissingServletRequestParameter(
 			MissingServletRequestParameterException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
 		return handleExceptionInternal(ex, null, headers, status, request);
@@ -301,7 +301,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @return a {@code ResponseEntity} for the response to use, possibly
 	 * {@code null} when the response is already committed
 	 */
-	protected @Nullable ResponseEntity<Object> handleMissingServletRequestPart(
+	protected @Nullable ResponseEntity<@Nullable Object> handleMissingServletRequestPart(
 			MissingServletRequestPartException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
 		return handleExceptionInternal(ex, null, headers, status, request);
@@ -317,7 +317,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @return a {@code ResponseEntity} for the response to use, possibly
 	 * {@code null} when the response is already committed
 	 */
-	protected @Nullable ResponseEntity<Object> handleServletRequestBindingException(
+	protected @Nullable ResponseEntity<@Nullable Object> handleServletRequestBindingException(
 			ServletRequestBindingException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
 		return handleExceptionInternal(ex, null, headers, status, request);
@@ -333,7 +333,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @return a {@code ResponseEntity} for the response to use, possibly
 	 * {@code null} when the response is already committed
 	 */
-	protected @Nullable ResponseEntity<Object> handleMethodArgumentNotValid(
+	protected @Nullable ResponseEntity<@Nullable Object> handleMethodArgumentNotValid(
 			MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
 		return handleExceptionInternal(ex, null, headers, status, request);
@@ -350,7 +350,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * {@code null} when the response is already committed
 	 * @since 6.1
 	 */
-	protected @Nullable ResponseEntity<Object> handleHandlerMethodValidationException(
+	protected @Nullable ResponseEntity<@Nullable Object> handleHandlerMethodValidationException(
 			HandlerMethodValidationException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
 		return handleExceptionInternal(ex, null, headers, status, request);
@@ -367,7 +367,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * {@code null} when the response is already committed
 	 * @since 4.0
 	 */
-	protected @Nullable ResponseEntity<Object> handleNoHandlerFoundException(
+	protected @Nullable ResponseEntity<@Nullable Object> handleNoHandlerFoundException(
 			NoHandlerFoundException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
 		return handleExceptionInternal(ex, null, headers, status, request);
@@ -384,7 +384,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * {@code null} when the response is already committed
 	 * @since 6.1
 	 */
-	protected @Nullable ResponseEntity<Object> handleNoResourceFoundException(
+	protected @Nullable ResponseEntity<@Nullable Object> handleNoResourceFoundException(
 			NoResourceFoundException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
 		return handleExceptionInternal(ex, null, headers, status, request);
@@ -401,7 +401,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * {@code null} when the response is already committed
 	 * @since 4.2.8
 	 */
-	protected @Nullable ResponseEntity<Object> handleAsyncRequestTimeoutException(
+	protected @Nullable ResponseEntity<@Nullable Object> handleAsyncRequestTimeoutException(
 			AsyncRequestTimeoutException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
 		return handleExceptionInternal(ex, null, headers, status, request);
@@ -418,7 +418,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * {@code null} when the response is already committed
 	 * @since 6.0
 	 */
-	protected @Nullable ResponseEntity<Object> handleErrorResponseException(
+	protected @Nullable ResponseEntity<@Nullable Object> handleErrorResponseException(
 			ErrorResponseException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
 		return handleExceptionInternal(ex, null, headers, status, request);
@@ -435,7 +435,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * {@code null} when the response is already committed
 	 * @since 6.1
 	 */
-	protected @Nullable ResponseEntity<Object> handleMaxUploadSizeExceededException(
+	protected @Nullable ResponseEntity<@Nullable Object> handleMaxUploadSizeExceededException(
 			MaxUploadSizeExceededException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
 		return handleExceptionInternal(ex, null, headers, status, request);
@@ -454,7 +454,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @return a {@code ResponseEntity} for the response to use, possibly
 	 * {@code null} when the response is already committed
 	 */
-	protected @Nullable ResponseEntity<Object> handleConversionNotSupported(
+	protected @Nullable ResponseEntity<@Nullable Object> handleConversionNotSupported(
 			ConversionNotSupportedException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
 		Object[] args = {ex.getPropertyName(), ex.getValue()};
@@ -477,7 +477,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @return a {@code ResponseEntity} for the response to use, possibly
 	 * {@code null} when the response is already committed
 	 */
-	protected @Nullable ResponseEntity<Object> handleTypeMismatch(
+	protected @Nullable ResponseEntity<@Nullable Object> handleTypeMismatch(
 			TypeMismatchException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
 		Object[] args = {ex.getPropertyName(), ex.getValue(),
@@ -502,7 +502,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @return a {@code ResponseEntity} for the response to use, possibly
 	 * {@code null} when the response is already committed
 	 */
-	protected @Nullable ResponseEntity<Object> handleHttpMessageNotReadable(
+	protected @Nullable ResponseEntity<@Nullable Object> handleHttpMessageNotReadable(
 			HttpMessageNotReadableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
 		ProblemDetail body = createProblemDetail(ex, status, "Failed to read request", null, null, request);
@@ -522,7 +522,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @return a {@code ResponseEntity} for the response to use, possibly
 	 * {@code null} when the response is already committed
 	 */
-	protected @Nullable ResponseEntity<Object> handleHttpMessageNotWritable(
+	protected @Nullable ResponseEntity<@Nullable Object> handleHttpMessageNotWritable(
 			HttpMessageNotWritableException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
 
 		ProblemDetail body = createProblemDetail(ex, status, "Failed to write request", null, null, request);
@@ -543,7 +543,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * {@code null} when the response is already committed
 	 * @since 6.1
 	 */
-	protected @Nullable ResponseEntity<Object> handleMethodValidationException(
+	protected @Nullable ResponseEntity<@Nullable Object> handleMethodValidationException(
 			MethodValidationException ex, HttpHeaders headers, HttpStatus status, WebRequest request) {
 
 		ProblemDetail body = createProblemDetail(ex, status, "Validation failed", null, null, request);
@@ -559,7 +559,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * {@code null} when the response is already committed
 	 * @since 6.2
 	 */
-	protected @Nullable ResponseEntity<Object> handleAsyncRequestNotUsableException(
+	protected @Nullable ResponseEntity<@Nullable Object> handleAsyncRequestNotUsableException(
 			AsyncRequestNotUsableException ex, WebRequest request) {
 
 		return null;
@@ -614,7 +614,7 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @return a {@code ResponseEntity} for the response to use, possibly
 	 * {@code null} when the response is already committed
 	 */
-	protected @Nullable ResponseEntity<Object> handleExceptionInternal(
+	protected @Nullable ResponseEntity<@Nullable Object> handleExceptionInternal(
 			Exception ex, @Nullable Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
 
 		if (request instanceof ServletWebRequest servletWebRequest) {
@@ -650,10 +650,10 @@ public abstract class ResponseEntityExceptionHandler implements MessageSourceAwa
 	 * @return the {@code ResponseEntity} instance to use
 	 * @since 6.0
 	 */
-	protected ResponseEntity<Object> createResponseEntity(
+	protected ResponseEntity<@Nullable Object> createResponseEntity(
 			@Nullable Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
 
-		return new ResponseEntity<>(body, headers, statusCode);
+		return new ResponseEntity<@Nullable Object>(body, headers, statusCode);
 	}
 
 }


### PR DESCRIPTION
Based on the IDE warning shown in the screenshot

<img width="1081" height="156" alt="image" src="https://github.com/user-attachments/assets/6d50b188-7686-46e2-93b1-d7e4c8e3ae49" />

This change adds `@Nullable` to the generic bound of ResponseEntity to make the nullability contract.

Related to gh-36236