### PR TITLE
Remove obsolete doc for spring.context.annotated-bean-reader.create

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/appendix/application-startup-steps.adoc
+++ b/framework-docs/modules/ROOT/pages/core/appendix/application-startup-steps.adoc
@@ -19,10 +19,6 @@ its behavior changes.
 | Initialization of `SmartInitializingSingleton` beans.
 | `beanName` the name of the bean.
 
-| `spring.context.annotated-bean-reader.create`
-| Creation of the `AnnotatedBeanDefinitionReader`.
-|
-
 | `spring.context.base-packages.scan`
 | Scanning of base packages.
 | `packages` array of base packages for scanning.


### PR DESCRIPTION
This PR removes obsolete doc for `spring.context.annotated-bean-reader.create` that has been removed in #35570.