### PR TITLE
fix: prevent IllegalArgumentException when apiVersion is missing

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/condition/VersionRequestCondition.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/condition/VersionRequestCondition.java
@@ -100,9 +100,12 @@ public final class VersionRequestCondition extends AbstractRequestCondition<Vers
 
 	@Override
 	public @Nullable VersionRequestCondition getMatchingCondition(ServerWebExchange exchange) {
+		if (this.version == null) {
+			return this;
+		}
 		ApiVersionHolder versionHolder = exchange.getRequiredAttribute(HandlerMapping.API_VERSION_ATTRIBUTE);
 
-		if (this.version == null || !versionHolder.hasVersion()) {
+		if (!versionHolder.hasVersion()) {
 			return this;
 		}
 


### PR DESCRIPTION
# Context

When no API versioning is configured, calling
RequestMappingInfo#getMatchingCondition(ServerWebExchange exchange) results throws an exception.

# Problem

The exception is thrown from VersionRequestCondition#getMatchingCondition.

When API versioning is disabled, the following line assumes that a version attribute is always present in the exchange:

```java
ApiVersionHolder versionHolder =
        exchange.getRequiredAttribute(HandlerMapping.API_VERSION_ATTRIBUTE);
```

If no version has been resolved, this attribute is missing, which throws:

```
java.lang.IllegalArgumentException:
Required attribute 'org.springframework.web.reactive.HandlerMapping.apiVersion' is missing
```

VersionRequestCondition does not handle the case where API versioning is not configured.
It unconditionally expects HandlerMapping.API_VERSION_ATTRIBUTE to be present, even when no version is defined.

# Fix

Checking version == null before makes VersionRequestCondition#getMatchingCondition resilient to the absence of API versioning by safely handling a null or missing API version attribute instead of throwing an exception.