### PR TITLE
Fix nullability annotation in JdbcTemplate

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -1578,7 +1578,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 		ResultSet keys = ps.getGeneratedKeys();
 		if (keys != null) {
 			try {
-				RowMapperResultSetExtractor<Map<String, Object>> rse =
+				RowMapperResultSetExtractor<Map<String, @Nullable Object>> rse =
 						new RowMapperResultSetExtractor<>(getColumnMapRowMapper(), rowsExpected);
 				generatedKeys.addAll(result(rse.extractData(keys)));
 			}


### PR DESCRIPTION
An issue was reported by a local build of NullAway with https://github.com/uber/NullAway/pull/1464 applied.  The fix is correct since `org.springframework.jdbc.core.JdbcTemplate#getColumnMapRowMapper` returns `RowMapper<Map<String, @Nullable Object>>`.  The NullAway fix will be in its next release.