### PR TITLE
Log which HandlerInterceptor threw the exception

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/HandlerExecutionChain.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/HandlerExecutionChain.java
@@ -175,7 +175,7 @@ public class HandlerExecutionChain {
 				interceptor.afterCompletion(request, response, this.handler, ex);
 			}
 			catch (Throwable ex2) {
-				logger.error("HandlerInterceptor.afterCompletion threw exception", ex2);
+				logger.error("HandlerInterceptor.afterCompletion threw exception in interceptor [" + interceptor + "]", ex2);
 			}
 		}
 	}


### PR DESCRIPTION
Add information about which interceptor actually threw the exception as it may not be clear from the exception itself.
For example we had an issue where the exception was just `java.lang.NullPointerException: null` - where was it coming from was everyones guess.