### PR TITLE
Refactor SendTo and Subscription Method Return Value Handlers to use …

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SendToMethodReturnValueHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SendToMethodReturnValueHandler.java
@@ -263,9 +263,10 @@ public class SendToMethodReturnValueHandler implements HandlerMethodReturnValueH
 			getHeaderInitializer().initHeaders(headerAccessor);
 		}
 		if (inputMessage != null && this.headerFilter != null) {
-			inputMessage.getHeaders().forEach((name, value) -> {
+			SimpMessageHeaderAccessor inputAccessor = SimpMessageHeaderAccessor.wrap(inputMessage);
+			inputAccessor.toNativeHeaderMap().forEach((name, values) -> {
 				if (this.headerFilter.test(name)) {
-					headerAccessor.setHeader(name, value);
+					headerAccessor.setNativeHeaderValues(name, values);
 				}
 			});
 		}

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SubscriptionMethodReturnValueHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/annotation/support/SubscriptionMethodReturnValueHandler.java
@@ -160,9 +160,10 @@ public class SubscriptionMethodReturnValueHandler implements HandlerMethodReturn
 			getHeaderInitializer().initHeaders(accessor);
 		}
 		if (inputMessage != null && this.headerFilter != null) {
-			inputMessage.getHeaders().forEach((name, value) -> {
+			SimpMessageHeaderAccessor inputAccessor = SimpMessageHeaderAccessor.wrap(inputMessage);
+			inputAccessor.toNativeHeaderMap().forEach((name, values) -> {
 				if (this.headerFilter.test(name)) {
-					accessor.setHeader(name, value);
+					accessor.setNativeHeaderValues(name, values);
 				}
 			});
 		}


### PR DESCRIPTION
### **PR Title**

**Propagate native STOMP headers to broker via HeaderFilter**

---

### **Summary**

This PR implements the propagation of native STOMP headers based on a predicate, as discussed in previous feedback. The core focus is ensuring that specific native headers (e.g., those with an `x-` prefix) are correctly carried over to the broker-bound messages.

**Key Implementation Details:**

* **Native Header Filtering:** Configured `addHeaderFilter` to propagate native headers starting with the `x-` prefix to response messages.
* Updated **`SendToMethodReturnValueHandler`**: Supports header propagation for `@SendTo` responses.
* Updated **`SubscriptionMethodReturnValueHandler`**: Supports header propagation for `@SubscribeMapping` responses.
* Updated unit tests to verify native header propagation via SimpMessageHeaderAccessor

---

### **Local Test (not included in this PR)**
<img width="560" height="61" alt="스크린샷 2026-02-10 오전 4 11 40" src="https://github.com/user-attachments/assets/c82e0207-af74-47be-be07-38b3ce38bdcd" />

---

### **Related Issues**

* Supersedes #36179
* Fixes #36168

---