### PR TITLE
Add programmatic configuration tabs in the transactional refdoc

### DIFF
--- a/framework-docs/modules/ROOT/pages/data-access/transaction/declarative/annotations.adoc
+++ b/framework-docs/modules/ROOT/pages/data-access/transaction/declarative/annotations.adoc
@@ -89,47 +89,38 @@ annotation in a `@Configuration` class. See the
 {spring-framework-api}/transaction/annotation/EnableTransactionManagement.html[javadoc]
 for full details.
 
-In XML configuration, the `<tx:annotation-driven/>` tag provides similar convenience:
+The following examples show the configuration needed to enable annotation-driven transaction management:
 
-[source,xml,indent=0,subs="verbatim,quotes"]
+[tabs]
+======
+Java::
++
+[source,java,indent=0,subs="verbatim,quotes",role="primary"]
 ----
-	<!-- from the file 'context.xml' -->
-	<?xml version="1.0" encoding="UTF-8"?>
-	<beans xmlns="http://www.springframework.org/schema/beans"
-		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xmlns:aop="http://www.springframework.org/schema/aop"
-		xmlns:tx="http://www.springframework.org/schema/tx"
-		xsi:schemaLocation="
-			http://www.springframework.org/schema/beans
-			https://www.springframework.org/schema/beans/spring-beans.xsd
-			http://www.springframework.org/schema/tx
-			https://www.springframework.org/schema/tx/spring-tx.xsd
-			http://www.springframework.org/schema/aop
-			https://www.springframework.org/schema/aop/spring-aop.xsd">
-
-		<!-- this is the service object that we want to make transactional -->
-		<bean id="fooService" class="x.y.service.DefaultFooService"/>
-
-		<!-- enable the configuration of transactional behavior based on annotations -->
-		<!-- a TransactionManager is still required -->
-		<tx:annotation-driven transaction-manager="txManager"/> <1>
-
-		<bean id="txManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
-			<!-- (this dependency is defined somewhere else) -->
-			<property name="dataSource" ref="dataSource"/>
-		</bean>
-
-		<!-- other <bean/> definitions here -->
-
-	</beans>
+include-code::AppConfig[]
 ----
-<1> The line that makes the bean instance transactional.
 
-TIP: You can omit the `transaction-manager` attribute in the `<tx:annotation-driven/>`
-tag if the bean name of the `TransactionManager` that you want to wire in has the name
-`transactionManager`. If the `TransactionManager` bean that you want to dependency-inject
-has any other name, you have to use the `transaction-manager` attribute, as in the
-preceding example.
+Kotlin::
++
+[source,kotlin,indent=0,subs="verbatim,quotes",role="secondary"]
+----
+include-code::AppConfig[]
+----
+
+XML::
++
+[source,xml,indent=0,subs="verbatim,quotes",role="secondary"]
+----
+include-code::annotations-tx[tags=snippet]
+----
+======
+
+TIP: In programmatic configuration, the `@EnableTransactionManagement` annotation uses any
+`PlatformTransactionManager` bean in the context. In XML configuration, you can omit
+the `transaction-manager` attribute in the `<tx:annotation-driven/>` tag if the bean
+name of the `TransactionManager` that you want to wire in has the name `transactionManager`.
+If the `TransactionManager` bean has any other name, you have to use the
+`transaction-manager` attribute explicitly, as in the preceding example.
 
 Reactive transactional methods use reactive return types in contrast to imperative
 programming arrangements as the following listing shows:

--- a/framework-docs/src/main/java/org/springframework/docs/dataaccess/transaction/declarative/annotations/AppConfig.java
+++ b/framework-docs/src/main/java/org/springframework/docs/dataaccess/transaction/declarative/annotations/AppConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.docs.dataaccess.transaction.declarative.annotations;
+
+import javax.sql.DataSource;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+// tag::snippet[]
+@Configuration
+@EnableTransactionManagement
+public class AppConfig {
+
+	@Bean
+	public FooService fooService() {
+		return new DefaultFooService();
+	}
+
+	@Bean
+	public PlatformTransactionManager txManager(DataSource dataSource) {
+		return new DataSourceTransactionManager(dataSource);
+	}
+}
+// end::snippet[]

--- a/framework-docs/src/main/kotlin/org/springframework/docs/dataaccess/transaction/declarative/annotations/AppConfig.kt
+++ b/framework-docs/src/main/kotlin/org/springframework/docs/dataaccess/transaction/declarative/annotations/AppConfig.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.docs.dataaccess.transaction.declarative.annotations
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.jdbc.datasource.DataSourceTransactionManager
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.annotation.EnableTransactionManagement
+import javax.sql.DataSource
+
+// tag::snippet[]
+@Configuration
+@EnableTransactionManagement
+class AppConfig {
+
+	@Bean
+	fun fooService(): FooService {
+		return DefaultFooService()
+	}
+
+	@Bean
+	fun txManager(dataSource: DataSource): PlatformTransactionManager {
+		return DataSourceTransactionManager(dataSource)
+	}
+}
+// end::snippet[]

--- a/framework-docs/src/main/resources/org/springframework/docs/dataaccess/transaction/declarative/annotations/annotations-tx.xml
+++ b/framework-docs/src/main/resources/org/springframework/docs/dataaccess/transaction/declarative/annotations/annotations-tx.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- tag::snippet[] -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:aop="http://www.springframework.org/schema/aop"
+	xmlns:tx="http://www.springframework.org/schema/tx"
+	xsi:schemaLocation="
+		http://www.springframework.org/schema/beans
+		https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/tx
+		https://www.springframework.org/schema/tx/spring-tx.xsd
+		http://www.springframework.org/schema/aop
+		https://www.springframework.org/schema/aop/spring-aop.xsd">
+
+	<!-- this is the service object that we want to make transactional -->
+	<bean id="fooService" class="x.y.service.DefaultFooService"/>
+
+	<!-- enable the configuration of transactional behavior based on annotations -->
+	<!-- a TransactionManager is still required -->
+	<tx:annotation-driven transaction-manager="txManager"/> <!--1-->
+
+	<bean id="txManager" class="org.springframework.jdbc.datasource.DataSourceTransactionManager">
+		<!-- (this dependency is defined somewhere else) -->
+		<property name="dataSource" ref="dataSource"/>
+	</bean>
+
+	<!-- other <bean/> definitions here -->
+
+</beans>
+<!-- end::snippet[] -->


### PR DESCRIPTION
## Description

  Adds Java Config example alongside existing XML configuration in the `@Transactional`
  annotations section.

  **Changes:**
  - Added Java Config tab showing `@EnableTransactionManagement` setup
  - Kept existing XML configuration in a separate tab
  - Updated TIP section to explain both approaches

  This allows users to choose between modern Java Config and traditional XML
  configuration.

  Closes #34093