### PR TITLE
Add TooManyHttpMediaTypesException and TooManyMimeTypesException

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
@@ -351,7 +351,7 @@ public abstract class MimeTypeUtils {
 	public static <T extends MimeType> void sortBySpecificity(List<T> mimeTypes) {
 		Assert.notNull(mimeTypes, "'mimeTypes' must not be null");
 		if (mimeTypes.size() > 50) {
-			throw new InvalidMimeTypeException(mimeTypes.toString(), "Too many elements");
+			throw new TooManyMimeTypesException(mimeTypes);
 		}
 
 		bubbleSort(mimeTypes, MimeType::isLessSpecific);

--- a/spring-core/src/main/java/org/springframework/util/TooManyMimeTypesException.java
+++ b/spring-core/src/main/java/org/springframework/util/TooManyMimeTypesException.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.util;
+
+import java.util.List;
+
+/**
+ * Exception thrown from {@link MimeTypeUtils#sortBySpecificity(List)} in case of
+ * the {@code mimeTypes} contains more than 50 elements.
+ */
+public class TooManyMimeTypesException extends IllegalArgumentException {
+
+	private final List<? extends MimeType> mimeTypes;
+
+	/**
+	 * Create a new TooManyMimeTypesException for the given content type.
+	 * @param mimeTypes the offending media types
+	 */
+	public TooManyMimeTypesException(List<? extends MimeType> mimeTypes) {
+		super("Too many mimeTypes \"" + mimeTypes + "\"");
+		this.mimeTypes = mimeTypes;
+	}
+
+	/**
+	 * Return the offending content types.
+	 */
+	public List<? extends MimeType> getMimeTypes() {
+		return this.mimeTypes;
+	}
+
+}

--- a/spring-web/src/main/java/org/springframework/web/TooManyHttpMediaTypesException.java
+++ b/spring-web/src/main/java/org/springframework/web/TooManyHttpMediaTypesException.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.util.CollectionUtils;
+
+import java.util.Collections;
+
+/**
+ * Exception thrown when the request handler cannot resolve {@link MediaType}
+ * due to the {@code mimeTypes} contains too many elements.
+ */
+public class TooManyHttpMediaTypesException extends HttpMediaTypeException {
+
+	private static final String PARSE_ERROR_DETAIL_CODE =
+			ErrorResponse.getDefaultDetailMessageCode(TooManyHttpMediaTypesException.class, "parseError");
+
+
+	/**
+	 * Constructor for when the {@code Accept} header cannot be parsed.
+	 * @param message the parse error message
+	 */
+	public TooManyHttpMediaTypesException(String message) {
+		super(message, Collections.emptyList(), PARSE_ERROR_DETAIL_CODE, null);
+		getBody().setDetail("Too many elements in Accept header.");
+	}
+
+	@Override
+	public HttpStatusCode getStatusCode() {
+		return HttpStatus.NOT_ACCEPTABLE;
+	}
+
+	@Override
+	public HttpHeaders getHeaders() {
+		if (CollectionUtils.isEmpty(getSupportedMediaTypes())) {
+			return HttpHeaders.EMPTY;
+		}
+		HttpHeaders headers = new HttpHeaders();
+		headers.setAccept(getSupportedMediaTypes());
+		return headers;
+	}
+
+}

--- a/spring-web/src/main/java/org/springframework/web/accept/ContentNegotiationManager.java
+++ b/spring-web/src/main/java/org/springframework/web/accept/ContentNegotiationManager.java
@@ -33,6 +33,7 @@ import org.springframework.http.MediaType;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.TooManyHttpMediaTypesException;
 import org.springframework.web.context.request.NativeWebRequest;
 
 /**
@@ -123,7 +124,8 @@ public class ContentNegotiationManager implements ContentNegotiationStrategy, Me
 	}
 
 	@Override
-	public List<MediaType> resolveMediaTypes(NativeWebRequest request) throws HttpMediaTypeNotAcceptableException {
+	public List<MediaType> resolveMediaTypes(NativeWebRequest request)
+			throws HttpMediaTypeNotAcceptableException, TooManyHttpMediaTypesException {
 		for (ContentNegotiationStrategy strategy : this.strategies) {
 			List<MediaType> mediaTypes = strategy.resolveMediaTypes(request);
 			if (mediaTypes.equals(MEDIA_TYPE_ALL_LIST)) {

--- a/spring-web/src/main/java/org/springframework/web/accept/ContentNegotiationStrategy.java
+++ b/spring-web/src/main/java/org/springframework/web/accept/ContentNegotiationStrategy.java
@@ -21,6 +21,7 @@ import java.util.List;
 
 import org.springframework.http.MediaType;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.TooManyHttpMediaTypesException;
 import org.springframework.web.context.request.NativeWebRequest;
 
 /**
@@ -48,8 +49,10 @@ public interface ContentNegotiationStrategy {
 	 * were requested.
 	 * @throws HttpMediaTypeNotAcceptableException if the requested media
 	 * types cannot be parsed
+	 * @throws TooManyHttpMediaTypesException if the requested media
+	 * types is too many
 	 */
 	List<MediaType> resolveMediaTypes(NativeWebRequest webRequest)
-			throws HttpMediaTypeNotAcceptableException;
+			throws HttpMediaTypeNotAcceptableException, TooManyHttpMediaTypesException;
 
 }

--- a/spring-web/src/main/java/org/springframework/web/accept/HeaderContentNegotiationStrategy.java
+++ b/spring-web/src/main/java/org/springframework/web/accept/HeaderContentNegotiationStrategy.java
@@ -25,7 +25,9 @@ import org.springframework.http.MediaType;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.InvalidMimeTypeException;
 import org.springframework.util.MimeTypeUtils;
+import org.springframework.util.TooManyMimeTypesException;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.TooManyHttpMediaTypesException;
 import org.springframework.web.context.request.NativeWebRequest;
 
 /**
@@ -43,7 +45,7 @@ public class HeaderContentNegotiationStrategy implements ContentNegotiationStrat
 	 */
 	@Override
 	public List<MediaType> resolveMediaTypes(NativeWebRequest request)
-			throws HttpMediaTypeNotAcceptableException {
+			throws HttpMediaTypeNotAcceptableException, TooManyHttpMediaTypesException {
 
 		String[] headerValueArray = request.getHeaderValues(HttpHeaders.ACCEPT);
 		if (headerValueArray == null) {
@@ -55,6 +57,10 @@ public class HeaderContentNegotiationStrategy implements ContentNegotiationStrat
 			List<MediaType> mediaTypes = MediaType.parseMediaTypes(headerValues);
 			MimeTypeUtils.sortBySpecificity(mediaTypes);
 			return !CollectionUtils.isEmpty(mediaTypes) ? mediaTypes : MEDIA_TYPE_ALL_LIST;
+		}
+		catch (TooManyMimeTypesException ex) {
+			throw new TooManyHttpMediaTypesException(
+					"Could not parse 'Accept' header " + headerValues + ": " + ex.getMessage());
 		}
 		catch (InvalidMediaTypeException | InvalidMimeTypeException ex) {
 			throw new HttpMediaTypeNotAcceptableException(

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/ProducesRequestCondition.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/condition/ProducesRequestCondition.java
@@ -31,6 +31,7 @@ import org.springframework.util.MimeType;
 import org.springframework.util.ObjectUtils;
 import org.springframework.web.HttpMediaTypeException;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.TooManyHttpMediaTypesException;
 import org.springframework.web.accept.ContentNegotiationManager;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.context.request.ServletWebRequest;
@@ -273,7 +274,7 @@ public final class ProducesRequestCondition extends AbstractRequestCondition<Pro
 			}
 			return 0;
 		}
-		catch (HttpMediaTypeNotAcceptableException ex) {
+		catch (HttpMediaTypeNotAcceptableException | TooManyHttpMediaTypesException ex) {
 			// should never happen
 			throw new IllegalStateException("Cannot compare without having any requested media types", ex);
 		}
@@ -281,7 +282,7 @@ public final class ProducesRequestCondition extends AbstractRequestCondition<Pro
 
 	@SuppressWarnings("unchecked")
 	private List<MediaType> getAcceptedMediaTypes(HttpServletRequest request)
-			throws HttpMediaTypeNotAcceptableException {
+			throws HttpMediaTypeNotAcceptableException, TooManyHttpMediaTypesException {
 
 		List<MediaType> result = (List<MediaType>) request.getAttribute(MEDIA_TYPES_ATTRIBUTE);
 		if (result == null) {

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ExceptionHandlerExceptionResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ExceptionHandlerExceptionResolver.java
@@ -42,6 +42,7 @@ import org.springframework.http.converter.support.AllEncompassingFormHttpMessage
 import org.springframework.ui.ModelMap;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.TooManyHttpMediaTypesException;
 import org.springframework.web.accept.ContentNegotiationManager;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.context.request.RequestAttributes;
@@ -509,7 +510,7 @@ public class ExceptionHandlerExceptionResolver extends AbstractHandlerMethodExce
 		try {
 			acceptedMediaTypes = this.contentNegotiationManager.resolveMediaTypes(webRequest);
 		}
-		catch (HttpMediaTypeNotAcceptableException mediaTypeExc) {
+		catch (HttpMediaTypeNotAcceptableException | TooManyHttpMediaTypesException mediaTypeExc) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("Could not resolve accepted media types for @ExceptionHandler [" + webRequest.getHeader(HttpHeaders.ACCEPT) + "]", mediaTypeExc);
 			}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyMethodProcessor.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/RequestResponseBodyMethodProcessor.java
@@ -40,6 +40,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.ErrorResponse;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.TooManyHttpMediaTypesException;
 import org.springframework.web.accept.ContentNegotiationManager;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.WebDataBinder;
@@ -194,7 +195,8 @@ public class RequestResponseBodyMethodProcessor extends AbstractMessageConverter
 	@Override
 	public void handleReturnValue(@Nullable Object returnValue, MethodParameter returnType,
 			ModelAndViewContainer mavContainer, NativeWebRequest webRequest)
-			throws IOException, HttpMediaTypeNotAcceptableException, HttpMessageNotWritableException {
+			throws IOException, HttpMediaTypeNotAcceptableException,
+			HttpMessageNotWritableException, TooManyHttpMediaTypesException {
 
 		mavContainer.setRequestHandled(true);
 		ServletServerHttpRequest inputMessage = createInputMessage(webRequest);

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/support/DefaultHandlerExceptionResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/support/DefaultHandlerExceptionResolver.java
@@ -32,10 +32,7 @@ import org.springframework.http.ProblemDetail;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.validation.method.MethodValidationException;
-import org.springframework.web.ErrorResponse;
-import org.springframework.web.HttpMediaTypeNotAcceptableException;
-import org.springframework.web.HttpMediaTypeNotSupportedException;
-import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.*;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingPathVariableException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
@@ -193,6 +190,9 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 				else if (ex instanceof HttpMediaTypeNotAcceptableException theEx) {
 					mav = handleHttpMediaTypeNotAcceptable(theEx, request, response, handler);
 				}
+				else if (ex instanceof TooManyHttpMediaTypesException theEx) {
+					mav = handleTooManyHttpMediaTypesException(theEx, request, response, handler);
+				}
 				else if (ex instanceof MissingPathVariableException theEx) {
 					mav = handleMissingPathVariable(theEx, request, response, handler);
 				}
@@ -256,6 +256,22 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 			}
 		}
 
+		return null;
+	}
+
+	/**
+	 * Handle the case where the mimeTypes in Accept header contains too many elements.
+	 * <p>The default implementation returns {@code null} in which case the
+	 * exception is handled in {@link #handleErrorResponse}.
+	 * @param ex the TooManyHttpMediaTypesException to be handled
+	 * @param request current HTTP request
+	 * @param response current HTTP response
+	 * @param handler the executed handler
+	 * @return an empty {@code ModelAndView} indicating the exception was handled, or
+	 * {@code null} indicating the exception should be handled in {@link #handleErrorResponse}
+	 * @throws IOException potentially thrown from {@link HttpServletResponse#sendError}
+	 */
+	private ModelAndView handleTooManyHttpMediaTypesException(TooManyHttpMediaTypesException ex, HttpServletRequest request, HttpServletResponse response, Object handler) {
 		return null;
 	}
 


### PR DESCRIPTION
#36300
Reason I make this PR
1. We have a "secret" constraint of 50 mime types
```
	public static <T extends MimeType> void sortBySpecificity(List<T> mimeTypes) {
		Assert.notNull(mimeTypes, "'mimeTypes' must not be null");
		if (mimeTypes.size() > 50) {
			throw new InvalidMimeTypeException(mimeTypes.toString(), "Too many elements");
		}

		bubbleSort(mimeTypes, MimeType::isLessSpecific);
	}
```
and we just throw a generic `InvalidMimeTypeException`, then `HttpMediaTypeNotAcceptableException`. It is unclear for the developers and end-users why my `MediaType` are `NotAcceptable`. Their fault? Or framework limitation? Or configuration error? Not easy to know!
2. The framework default to return 406 http status without any infomation, making the end-users/client can not know what is happenning behind
3. Adding new Exception will help the developers to write their exception handler to provide useful infomation to the end-users. E.g let them know they must not provide more than 50 mime types.