### PR TITLE
fix TransactionAspectSupport#currentTransactionStatus javadoc

### DIFF
--- a/spring-tx/src/main/java/org/springframework/transaction/interceptor/TransactionAspectSupport.java
+++ b/spring-tx/src/main/java/org/springframework/transaction/interceptor/TransactionAspectSupport.java
@@ -151,7 +151,7 @@ public abstract class TransactionAspectSupport implements BeanFactoryAware, Init
 	 * Mainly intended for code that wants to set the current transaction
 	 * rollback-only but not throw an application exception.
 	 * <p>This exposes the locally declared transaction boundary with its declared name
-	 * and characteristics, as managed by the aspect. Ar runtime, the local boundary may
+	 * and characteristics, as managed by the aspect. At runtime, the local boundary may
 	 * participate in an outer transaction: If you need transaction metadata from such
 	 * an outer transaction (the actual resource transaction) instead, consider using
 	 * {@link org.springframework.transaction.support.TransactionSynchronizationManager}.


### PR DESCRIPTION
The goal of this PR is to fix javadoc documentation for TransactionAspectSupport's currentTransactionStatus method and https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/transaction/interceptor/TransactionAspectSupport.html#currentTransactionStatus() documentation respectively