### PR TITLE
Update Spring MVC functional endpoints to use Servlet response header adapters

### DIFF
--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/function/DefaultServerResponseBuilderTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/function/DefaultServerResponseBuilderTests.java
@@ -236,6 +236,22 @@ class DefaultServerResponseBuilderTests {
 	}
 
 	@Test
+	void buildReplacesExistingResponseHeaders() throws Exception {
+		ServerResponse response = ServerResponse.ok()
+				.header("MyKey", "MyValue")
+				.build();
+
+		MockHttpServletRequest mockRequest = new MockHttpServletRequest("GET", "https://example.com");
+		MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+		mockResponse.addHeader("MyKey", "OldValue");
+
+		ModelAndView mav = response.writeTo(mockRequest, mockResponse, EMPTY_CONTEXT);
+		assertThat(mav).isNull();
+
+		assertThat(mockResponse.getHeaders("MyKey")).containsExactly("MyValue");
+	}
+
+	@Test
 	void notModifiedEtag() throws Exception {
 		String etag = "\"foo\"";
 		ServerResponse response = ServerResponse.ok()


### PR DESCRIPTION
After #36334, Spring MVC controllers use optimized Servlet response header handling via `ServletServerHttpResponse` and `ServletResponseHeadersAdapter`.

This updates functional endpoints by switching `AbstractServerResponse` header writing to `ServletServerHttpResponse` as well.

A test is also added to verify existing response headers are replaced when writing a `ServerResponse`.

Closes gh-36358