### PR TITLE
Propagate max frame length to WebSocket session

### DIFF
--- a/spring-webflux/src/test/java/org/springframework/web/reactive/socket/AbstractReactiveWebSocketIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/socket/AbstractReactiveWebSocketIntegrationTests.java
@@ -148,7 +148,9 @@ abstract class AbstractReactiveWebSocketIntegrationTests {
 		if (this.client instanceof Lifecycle lifecycle) {
 			lifecycle.stop();
 		}
-		this.server.stop();
+		if (this.server != null) {
+			this.server.stop();
+		}
 	}
 
 


### PR DESCRIPTION
This PR ensures that `maxFramePayloadLength` from `WebsocketClientSpec` is passed to `ReactorNettyWebSocketSession`.

Previously, the session used the default 64KB limit regardless of client configuration, causing `io.netty.handler.codec.TooLongFrameException` when receiving larger frames from servers like Tomcat or Jetty.

Closes gh-36369

| Before| After |
|------------|-----------|
|<img width="1610" height="468" alt="largePayload_before_fix" src="https://github.com/user-attachments/assets/c4794afe-112d-402c-a3c9-2c9955ba00f8" />|<img width="1558" height="527" alt="largePayload_after_fix" src="https://github.com/user-attachments/assets/976ab970-26ae-44f7-9e7d-f7c93a5513af" />|

I have updated the PR to include a fix for `JettyWebSocketClient` as well.

The issue was consistent across both clients: session-level limits were not being synchronized with the client-level configuration. For Jetty, I've implemented this by configuring the native session during initialization within the `JettyWebSocketHandlerAdapter`. For Reactor Netty, the `maxFramePayloadLength` is now correctly propagated through the session constructor.

I've also expanded the integration tests to verify the fix for both Reactor Netty and Jetty. All tests are passing.

| Before| After |
|------------|-----------|
|<img width="1767" height="559" alt="largePayload_jetty_before_fix" src="https://github.com/user-attachments/assets/6245ddd1-d68c-4210-b3a6-274aa70393c7" />|<img width="1811" height="444" alt="largePayload_fixed" src="https://github.com/user-attachments/assets/8aa5928d-e51e-43c8-becb-aeb2a8a20018" />|
