### PR TITLE
new method usePathSegment(int index, Predicate<RequestPath> excludePa…

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/config/ApiVersionConfigurer.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/config/ApiVersionConfigurer.java
@@ -27,6 +27,7 @@ import java.util.function.Predicate;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.http.MediaType;
+import org.springframework.http.server.RequestPath;
 import org.springframework.util.Assert;
 import org.springframework.web.accept.ApiVersionParser;
 import org.springframework.web.accept.InvalidApiVersionException;
@@ -105,6 +106,20 @@ public class ApiVersionConfigurer {
 	 */
 	public ApiVersionConfigurer usePathSegment(int index) {
 		this.versionResolvers.add(new PathApiVersionResolver(index));
+		return this;
+	}
+
+	/**
+	 * Add a resolver that extracts the API version from a path segment
+	 * and that allows to exclude certain paths based on the provided {@link Predicate}.
+	 * <p>Note that this resolver never returns {@code null}, and therefore
+	 * cannot yield to other resolvers, see {@link org.springframework.web.accept.PathApiVersionResolver}.
+	 * @param index the index of the path segment to check; e.g. for URL's like
+	 * {@code "/{version}/..."} use index 0, for {@code "/api/{version}/..."} index 1.
+	 * @param excludePath a {@link Predicate} that allows to exclude certain paths
+	 */
+	public ApiVersionConfigurer usePathSegment(int index, Predicate<RequestPath> excludePath) {
+		this.versionResolvers.add(new PathApiVersionResolver(index, excludePath));
 		return this;
 	}
 

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/accept/PathApiVersionResolverTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/accept/PathApiVersionResolverTests.java
@@ -18,10 +18,13 @@ package org.springframework.web.reactive.accept;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.http.server.PathContainer;
 import org.springframework.web.accept.InvalidApiVersionException;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.testfixture.http.server.reactive.MockServerHttpRequest;
 import org.springframework.web.testfixture.server.MockServerWebExchange;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -29,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /**
  * Unit tests for {@link org.springframework.web.accept.PathApiVersionResolver}.
  * @author Rossen Stoyanchev
+ * @author Martin Mois
  */
 public class PathApiVersionResolverTests {
 
@@ -41,6 +45,39 @@ public class PathApiVersionResolverTests {
 	@Test
 	void insufficientPathSegments() {
 		assertThatThrownBy(() -> testResolve(0, "/", "1.0")).isInstanceOf(InvalidApiVersionException.class);
+	}
+
+	@Test
+	void excludePathTrue() {
+		String requestUri = "/v3/api-docs";
+		testResolveWithExcludePath(requestUri, null);
+	}
+
+	@Test
+	void excludePathFalse() {
+		String requestUri = "/app/1.0/path";
+		testResolveWithExcludePath(requestUri, "1.0");
+	}
+
+	@Test
+	void excludePathFalseShortPath() {
+		String requestUri = "/app";
+		assertThatThrownBy(() -> testResolveWithExcludePath(requestUri, null)).isInstanceOf(InvalidApiVersionException.class);
+	}
+
+	private static void testResolveWithExcludePath(String requestUri, String expected) {
+		ServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get(requestUri));
+		String actual = new PathApiVersionResolver(1, requestPath -> {
+			List<PathContainer.Element> elements = requestPath.elements();
+			if (elements.size() < 4) {
+				return false;
+			}
+			return elements.get(0).value().equals("/") &&
+					elements.get(1).value().equals("v3") &&
+					elements.get(2).value().equals("/") &&
+					elements.get(3).value().equals("api-docs");
+		}).resolveVersion(exchange);
+		assertThat(actual).isEqualTo(expected);
 	}
 
 	private static void testResolve(int index, String requestUri, String expected) {


### PR DESCRIPTION
As discussed in issue #36395 this pull requests provides the new method usePathSegment(int index, Predicate<RequestPath> excludePath) in ApiVersionConfigurer to exclude certain paths.