### PR TITLE
Fix typo in WebMvcConfigurationSupport Javadoc

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/config/annotation/WebMvcConfigurationSupport.java
@@ -884,7 +884,7 @@ public class WebMvcConfigurationSupport implements ApplicationContextAware, Serv
 	}
 
 	/**
-	 * Override this method to add custom {@link HttpMessageConverter messsage converters}
+	 * Override this method to add custom {@link HttpMessageConverter message converters}
 	 * to use with the {@link RequestMappingHandlerAdapter} and the
 	 * {@link ExceptionHandlerExceptionResolver}.
 	 * <p>Adding converters to the list turns off the default converters that would


### PR DESCRIPTION
Fix a typo in the Javadoc of `configureMessageConverters`: `messsage` → `message`.