### PR TITLE
Fix typo in HttpExchangeAdapterDecorator Javadoc

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/service/invoker/HttpExchangeAdapterDecorator.java
+++ b/spring-web/src/main/java/org/springframework/web/service/invoker/HttpExchangeAdapterDecorator.java
@@ -39,7 +39,7 @@ public class HttpExchangeAdapterDecorator implements HttpExchangeAdapter {
 
 
 	/**
-	 * Return the wrapped delgate {@code HttpExchangeAdapter}.
+	 * Return the wrapped delegate {@code HttpExchangeAdapter}.
 	 */
 	public HttpExchangeAdapter getHttpExchangeAdapter() {
 		return this.delegate;


### PR DESCRIPTION
Fix a typo in the Javadoc of `getHttpExchangeAdapter`: `delgate` → `delegate`.