### PR TITLE
Remove unnecessary space in contributing guide title

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing  to the Spring Framework
+# Contributing to the Spring Framework
 
 First off, thank you for taking the time to contribute! :+1: :tada: 
 


### PR DESCRIPTION
## Summary
Fix a typo in the contributing guide title by removing the duplicated space.

## Changes
- [x] Remove the duplicated space in the `CONTRIBUTING.md` title
- [x] Keep the change limited to a docs-only typo fix

## Related Issue
N/A

## How to Test
No functional changes. Verified the diff and confirmed the heading now renders with a single space.

## Checklist
- [x] I have read the CONTRIBUTING guide
- [x] My changes follow the code style of this project
- [x] I have added/updated tests if needed