### PR TITLE
Use computeIfAbsent in CommandLineArgs.addOptionArg

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/env/CommandLineArgs.java
+++ b/spring-core/src/main/java/org/springframework/core/env/CommandLineArgs.java
@@ -46,11 +46,9 @@ class CommandLineArgs {
 	 * without an associated value &mdash; for example, "--foo" vs. "--foo=bar".
 	 */
 	public void addOptionArg(String optionName, @Nullable String optionValue) {
-		if (!this.optionArgs.containsKey(optionName)) {
-			this.optionArgs.put(optionName, new ArrayList<>());
-		}
+		List<String> values = this.optionArgs.computeIfAbsent(optionName, key -> new ArrayList<>());
 		if (optionValue != null) {
-			this.optionArgs.get(optionName).add(optionValue);
+			values.add(optionValue);
 		}
 	}
 


### PR DESCRIPTION
Replace the manual `containsKey`/`put`/`get` three-step pattern in
`CommandLineArgs.addOptionArg` with `Map.computeIfAbsent`, which expresses
the same intent more concisely and avoids the redundant second map lookup.

Before:
```java
if (!this.optionArgs.containsKey(optionName)) {
    this.optionArgs.put(optionName, new ArrayList<>());
}
if (optionValue != null) {
    this.optionArgs.get(optionName).add(optionValue);
}
```

After:
```java
List<String> values = this.optionArgs.computeIfAbsent(optionName, key -> new ArrayList<>());
if (optionValue != null) {
    values.add(optionValue);
}
```

Behavior is identical: the option name is always registered in the map (even
without a value), and the value is added only when non-null.