### PR TITLE
Handle blank Accept-Language header in AcceptHeaderLocaleResolver

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AcceptHeaderLocaleResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/i18n/AcceptHeaderLocaleResolver.java
@@ -85,7 +85,7 @@ public class AcceptHeaderLocaleResolver extends AbstractLocaleResolver {
 	@Override
 	public Locale resolveLocale(HttpServletRequest request) {
 		Locale defaultLocale = getDefaultLocale();
-		if (defaultLocale != null && request.getHeader("Accept-Language") == null) {
+		if (defaultLocale != null && !StringUtils.hasText(request.getHeader("Accept-Language"))) {
 			return defaultLocale;
 		}
 		Locale requestLocale = request.getLocale();

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/AcceptHeaderLocaleResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/i18n/AcceptHeaderLocaleResolverTests.java
@@ -105,6 +105,14 @@ class AcceptHeaderLocaleResolverTests {
 		assertThat(this.resolver.resolveLocale(request)).isEqualTo(US);
 	}
 
+	@Test
+	void defaultLocaleWithBlankAcceptLanguageHeader() {
+		this.resolver.setDefaultLocale(JAPANESE);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Accept-Language", "");
+		assertThat(this.resolver.resolveLocale(request)).isEqualTo(JAPANESE);
+	}
+
 
 	private HttpServletRequest request(Locale... locales) {
 		MockHttpServletRequest request = new MockHttpServletRequest();


### PR DESCRIPTION
## Problem

`AcceptHeaderLocaleResolver.resolveLocale()` correctly returns `defaultLocale` 
when the `Accept-Language` header is absent (`null`), but ignores it when the 
header is present with a blank value (`""`), falling back to `Locale.getDefault()` 
(JVM system locale) instead.

## Fix

Replace the `null` check with `!StringUtils.hasText()` which handles `null`, 
empty string, and whitespace-only values consistently.

## Root cause
```java
// before
if (defaultLocale != null && request.getHeader("Accept-Language") == null) {

// after  
if (defaultLocale != null && !StringUtils.hasText(request.getHeader("Accept-Language"))) {
```

Closes gh-36512