### PR TITLE
Perserve default API version in RestClientAdapter

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/support/RestClientAdapter.java
+++ b/spring-web/src/main/java/org/springframework/web/client/support/RestClientAdapter.java
@@ -99,7 +99,9 @@ public final class RestClientAdapter implements HttpExchangeAdapter {
 		RestClient.RequestBodySpec spec = setUri(uriSpec, values);
 		spec.headers(headers -> headers.putAll(values.getHeaders()));
 		setCookieHeader(spec, values);
-		spec.apiVersion(values.getApiVersion());
+		if (values.getApiVersion() != null) {
+			spec.apiVersion(values.getApiVersion());
+		}
 		spec.attributes(attributes -> attributes.putAll(values.getAttributes()));
 		setBody(spec, values);
 		return spec;

--- a/spring-web/src/test/java/org/springframework/web/client/support/RestClientAdapterTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/support/RestClientAdapterTests.java
@@ -200,6 +200,27 @@ class RestClientAdapterTests {
 		assertThat(actualResponse).isEqualTo("Hello Spring 2!");
 	}
 
+	@Test
+	void greetingWithDefaultApiVersion() throws Exception {
+		prepareResponse(builder ->
+				builder.setHeader("Content-Type", "text/plain").body("Hello Spring 2!"));
+
+		RestClient restClient = RestClient.builder()
+				.baseUrl(anotherServer.url("/").toString())
+				.defaultApiVersion("1.0")
+				.apiVersionInserter(ApiVersionInserter.useHeader("X-Version"))
+				.build();
+
+		RestClientAdapter adapter = RestClientAdapter.create(restClient);
+		Service service = HttpServiceProxyFactory.builderFor(adapter).build().createClient(Service.class);
+
+		String actualResponse = service.getGreeting();
+
+		RecordedRequest request = anotherServer.takeRequest();
+		assertThat(request.getHeaders().get("X-Version")).isEqualTo("1.0");
+		assertThat(actualResponse).isEqualTo("Hello Spring 2!");
+	}
+
 	@Test // see gh-36326
 	void getBodyWithGenericReturnType() {
 		prepareResponse(r -> r.setHeader("Content-Type", "application/json").body("{\"name\":\"Karl\"}"));

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/support/WebClientAdapter.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/support/WebClientAdapter.java
@@ -111,7 +111,9 @@ public final class WebClientAdapter extends AbstractReactorHttpExchangeAdapter {
 		WebClient.RequestBodySpec bodySpec = setUri(uriSpec, values);
 		bodySpec.headers(headers -> headers.putAll(values.getHeaders()));
 		bodySpec.cookies(cookies -> cookies.putAll(values.getCookies()));
-		bodySpec.apiVersion(values.getApiVersion());
+		if (values.getApiVersion() != null) {
+			bodySpec.apiVersion(values.getApiVersion());
+		}
 		bodySpec.attributes(attributes -> attributes.putAll(values.getAttributes()));
 		setBody(bodySpec, values);
 		return bodySpec;

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/support/WebClientAdapterTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/support/WebClientAdapterTests.java
@@ -48,6 +48,7 @@ import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.client.ApiVersionInserter;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.service.annotation.GetExchange;
@@ -127,6 +128,25 @@ class WebClientAdapterTests {
 				.verify(Duration.ofSeconds(5));
 
 		assertThat(attributes).containsEntry("myAttribute", "myAttributeValue");
+	}
+
+	@Test
+	void greetingWithDefaultApiVersion() throws InterruptedException {
+		prepareResponse(builder -> builder.setHeader("Content-Type", "text/plain").body("Hello Spring 2!"));
+
+		WebClient webClient = WebClient.builder()
+				.baseUrl(this.server.url("/").toString())
+				.defaultApiVersion("1.0")
+				.apiVersionInserter(ApiVersionInserter.useHeader("X-Version"))
+				.build();
+
+		StepVerifier.create(initService(webClient, Service.class).getGreeting())
+				.expectNext("Hello Spring 2!")
+				.expectComplete()
+				.verify(Duration.ofSeconds(5));
+
+		RecordedRequest request = this.server.takeRequest();
+		assertThat(request.getHeaders().get("X-Version")).isEqualTo("1.0");
 	}
 
 	@Test // see gh-36326


### PR DESCRIPTION
This PR fixes the regression reported in spring-boot - https://github.com/spring-projects/spring-boot/issues/49701.