### PR TITLE
Address nullness warning from upcoming version of NullAway

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotatedElementUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotatedElementUtils.java
@@ -823,7 +823,7 @@ public abstract class AnnotatedElementUtils {
 		return MergedAnnotations.from(element, SearchStrategy.TYPE_HIERARCHY, repeatableContainers);
 	}
 
-	private static @Nullable MultiValueMap<String, Object> nullIfEmpty(MultiValueMap<String, Object> map) {
+	private static @Nullable MultiValueMap<String, @Nullable Object> nullIfEmpty(MultiValueMap<String, @Nullable Object> map) {
 		return (map.isEmpty() ? null : map);
 	}
 


### PR DESCRIPTION
NullAway will emit these warnings once https://github.com/uber/NullAway/pull/1499 lands:

```
spring-core/src/main/java/org/springframework/core/annotation/AnnotatedElementUtils.java:520: error: [NullAway] referenced method returns @Nullable MultiValueMap<String, Object>, but functional interface method returns @Nullable MultiValueMap<String, @Nullable Object>, which has mismatched type parameter nullability
                                .collect(MergedAnnotationCollectors.toMultiValueMap(AnnotatedElementUtils::nullIfEmpty, adaptations));
                                                                                    ^
    (see http://t.uber.com/nullaway )
spring-core/src/main/java/org/springframework/core/annotation/AnnotatedElementUtils.java:520: error: [NullAway] parameter type of referenced method is MultiValueMap<String, Object>, but parameter in functional interface method has type MultiValueMap<String, @Nullable Object>, which has mismatched type parameter nullability
                                .collect(MergedAnnotationCollectors.toMultiValueMap(AnnotatedElementUtils::nullIfEmpty, adaptations));
                                                                                    ^
```

This PR updates the annotations on `nullIfEmpty` to address these warnings.