### PR TITLE
Reject unbalanced parentheses in profile expressions

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/env/ProfilesParser.java
+++ b/spring-core/src/main/java/org/springframework/core/env/ProfilesParser.java
@@ -88,13 +88,10 @@ final class ProfilesParser {
 				}
 				case "!" -> elements.add(not(parseTokens(expression, tokens, Context.NEGATE)));
 				case ")" -> {
-					Profiles merged = merge(expression, elements, operator);
 					if (context == Context.PARENTHESIS) {
-						return merged;
+						return merge(expression, elements, operator);
 					}
-					elements.clear();
-					elements.add(merged);
-					operator = null;
+					assertWellFormed(expression, false);
 				}
 				default -> {
 					Profiles value = equals(token);
@@ -105,6 +102,7 @@ final class ProfilesParser {
 				}
 			}
 		}
+		assertWellFormed(expression, context != Context.PARENTHESIS);
 		return merge(expression, elements, operator);
 	}
 

--- a/spring-core/src/test/java/org/springframework/core/env/ProfilesTests.java
+++ b/spring-core/src/test/java/org/springframework/core/env/ProfilesTests.java
@@ -155,7 +155,7 @@ class ProfilesTests {
 
 	@Test
 	void ofAndExpressionWithoutSpaces() {
-		Profiles profiles = Profiles.of("spring&framework)");
+		Profiles profiles = Profiles.of("(spring&framework)");
 		assertAndExpression(profiles);
 	}
 
@@ -290,6 +290,15 @@ class ProfilesTests {
 		assertMalformed(() -> Profiles.of("("));
 		assertMalformed(() -> Profiles.of(")"));
 		assertMalformed(() -> Profiles.of("a & b | c"));
+	}
+
+	@Test
+	void malformedExpressionsWithUnbalancedParentheses() {
+		assertMalformed(() -> Profiles.of("dev)"));
+		assertMalformed(() -> Profiles.of("(dev"));
+		assertMalformed(() -> Profiles.of("spring&framework)"));
+		assertMalformed(() -> Profiles.of("((dev)"));
+		assertMalformed(() -> Profiles.of("(dev))"));
 	}
 
 	@Test


### PR DESCRIPTION
## Problem

`ProfilesParser` silently accepts unbalanced parentheses in profile expressions. For example, `Profiles.of("dev)")` or `@Profile("dev)")` is accepted without error and treated as `"dev"`. This can lead to unexpected behavior where malformed profile annotations are silently interpreted instead of being rejected.

## Root Cause

In `ProfilesParser.parseTokens()`, when a closing `)` is encountered outside of a `Context.PARENTHESIS` context (i.e., without a matching opening `(`), the parser merges the current elements, clears state, and continues parsing instead of raising a validation error. Similarly, when all tokens are consumed while still inside a `PARENTHESIS` context (unmatched opening `(`), the method returns normally without detecting the imbalance.

## Fix

- In the `")"` case of `parseTokens()`, reject unmatched closing parentheses by calling `assertWellFormed(expression, false)` when not in `PARENTHESIS` context, instead of silently continuing
- After the token loop, add `assertWellFormed(expression, context != Context.PARENTHESIS)` to reject unmatched opening parentheses when tokens are exhausted
- Fix an existing test (`ofAndExpressionWithoutSpaces`) that inadvertently relied on this lenient behavior by using `"spring&framework)"` instead of `"(spring&framework)"`

## Tests Added

| Change Point | Test |
|-------------|------|
| Reject unmatched `)` at top level | `malformedExpressionsWithUnbalancedParentheses()` — verifies `"dev)"`, `"spring&framework)"`, `"(dev))"` all throw `IllegalArgumentException` |
| Reject unmatched `(` when tokens exhaust | `malformedExpressionsWithUnbalancedParentheses()` — verifies `"(dev"`, `"((dev)"` throw `IllegalArgumentException` |
| Fix existing test input | `ofAndExpressionWithoutSpaces()` — now uses `"(spring&framework)"` and still passes `assertAndExpression` checks |

All 37 tests in `ProfilesTests` pass, including all pre-existing tests (no regressions).

## Impact

Expressions with unbalanced parentheses that were previously silently accepted will now throw `IllegalArgumentException` with a "Malformed profile expression" message. This is consistent with the existing behavior for standalone `"("` and `")"` which already throw. Well-formed expressions are not affected.

Fixes #36540