### PR TITLE
Fix incorrect Javadoc in HandlerMethodReturnValueHandlerComposite regarding caching

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/method/support/HandlerMethodReturnValueHandlerComposite.java
+++ b/spring-web/src/main/java/org/springframework/web/method/support/HandlerMethodReturnValueHandlerComposite.java
@@ -28,7 +28,6 @@ import org.springframework.web.context.request.NativeWebRequest;
 /**
  * Handles method return values by delegating to a list of registered
  * {@link HandlerMethodReturnValueHandler HandlerMethodReturnValueHandlers}.
- * Previously resolved return types are cached for faster lookups.
  *
  * @author Rossen Stoyanchev
  * @since 3.1


### PR DESCRIPTION
<!--

Have you considered asking for help on stackoverflow.com?

** Bug Reports **
Please submit issues against OSS supported versions, see https://spring.io/projects/spring-framework#support
Please provide a minimal sample application that reproduces the problem for faster issue triage.

** Enhancements requests **
Before explaining how you would like things to work,
please describe a concrete use case for this feature and how you have tried to solve this so far.

-->

# Description
The Javadoc for `HandlerMethodReturnValueHandlerComposite` claims that return types are cached for faster lookups.

```java
/**
 * Handles method return values by delegating to a list of registered
 * {@link HandlerMethodReturnValueHandler HandlerMethodReturnValueHandlers}.
 * Previously resolved return types are cached for faster lookups.  << This part!!
 *
 * @author Rossen Stoyanchev
 * @since 3.1
 */
public class HandlerMethodReturnValueHandlerComposite implements HandlerMethodReturnValueHandler {

	private final List<HandlerMethodReturnValueHandler> returnValueHandlers = new ArrayList<>();

	public List<HandlerMethodReturnValueHandler> getHandlers() {
		return Collections.unmodifiableList(this.returnValueHandlers);
	}

	@Override
	public boolean supportsReturnType(MethodParameter returnType) {
		return getReturnValueHandler(returnType) != null;
	}

	@Nullable
	private HandlerMethodReturnValueHandler getReturnValueHandler(MethodParameter returnType) {
		for (HandlerMethodReturnValueHandler handler : this.returnValueHandlers) {
			if (handler.supportsReturnType(returnType)) {
				return handler;
			}
		}
		return null;
	}
    // ....
```

**"Previously resolved return types are cached for faster lookups."**

However, the current implementation does not contain any caching logic (such as a Map). It performs a linear search through the returnValueHandlers list every time.

## Background
As noted in commit cfe2af7 (Apr 2012), the caching of handlers was intentionally removed to ensure selection based on the actual return value type (SPR-9218). It appears the Javadoc was not updated at that time and has remained inconsistent with the implementation for over a decade.

# Changes
Remove the outdated sentence about caching from the class-level Javadoc to match the actual implementation and avoid developer confusion.