### PR TITLE
Simplify programmatic scheduling of cron tasks with time zone

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/config/ScheduledTaskRegistrar.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/config/ScheduledTaskRegistrar.java
@@ -18,6 +18,7 @@ package org.springframework.scheduling.config;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -56,6 +57,7 @@ import org.springframework.util.CollectionUtils;
  * @author Sam Brannen
  * @author Arjen Poutsma
  * @author Brian Clozel
+ * @author Vedran Pavic
  * @since 3.0
  * @see org.springframework.scheduling.annotation.EnableAsync
  * @see org.springframework.scheduling.annotation.SchedulingConfigurer
@@ -284,13 +286,28 @@ public class ScheduledTaskRegistrar implements ScheduledTaskHolder, Initializing
 	}
 
 	/**
-	 * Add a {@link Runnable} task to be triggered per the given cron {@code expression}.
+	 * Add a {@link Runnable} task to be triggered per the given cron {@code expression}
+	 * in the default time zone.
 	 * <p>This method will not register the task if the {@code expression} is
 	 * equal to {@link #CRON_DISABLED}.
+	 * @see CronTask
 	 */
 	public void addCronTask(Runnable task, String expression) {
 		if (!CRON_DISABLED.equals(expression)) {
 			addCronTask(new CronTask(task, expression));
+		}
+	}
+
+	/**
+	 * Add a {@link Runnable} task to be triggered per the given cron {@code expression}
+	 * and time zone.
+	 * <p>This method will not register the task if the {@code expression} is
+	 * equal to {@link #CRON_DISABLED}.
+	 * @see CronTask
+	 */
+	public void addCronTask(Runnable task, String expression, ZoneId zoneId) {
+		if (!CRON_DISABLED.equals(expression)) {
+			addCronTask(new CronTask(task, new CronTrigger(expression, zoneId)));
 		}
 	}
 

--- a/spring-context/src/test/java/org/springframework/scheduling/config/ScheduledTaskRegistrarTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/config/ScheduledTaskRegistrarTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.scheduling.config;
 
+import java.time.ZoneId;
 import java.util.Collections;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +32,7 @@ import static org.mockito.Mockito.mock;
  * @author Tobias Montagna-Hay
  * @author Juergen Hoeller
  * @author Sam Brannen
+ * @author Vedran Pavic
  * @since 4.2
  */
 class ScheduledTaskRegistrarTests {
@@ -79,6 +81,12 @@ class ScheduledTaskRegistrarTests {
 	@Test
 	void addCronTaskWithValidExpression() {
 		this.taskRegistrar.addCronTask(no_op, "* * * * * ?");
+		assertThat(this.taskRegistrar.getCronTaskList()).hasSize(1);
+	}
+
+	@Test
+	void addCronTaskWithValidExpressionAndZoneId() {
+		this.taskRegistrar.addCronTask(no_op, "* * * * * ?", ZoneId.of("Europe/London"));
 		assertThat(this.taskRegistrar.getCronTaskList()).hasSize(1);
 	}
 


### PR DESCRIPTION
This commit adds overloaded `addCronTask` to `ScheduledTaskRegistrar` that allows simpler scheduling of cron tasks with non-default time zone.

---

In practical terms, currently we have to do this:

```java
@Override
public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
    taskRegistrar.addCronTask(new CronTask(() -> {}, new CronTrigger("* * * * * ?", ZoneId.of("Europe/London"))));
}
```

While the changes from this PR allow us to reduce it to:


```java
@Override
public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
    taskRegistrar.addCronTask(() -> {}, "* * * * * ?", ZoneId.of("Europe/London"));
}
```