### PR TITLE
Remove deprecated `methodIdentification()` method in `CacheAspectSupport`

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/interceptor/CacheAspectSupport.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/CacheAspectSupport.java
@@ -291,21 +291,6 @@ public abstract class CacheAspectSupport extends AbstractCacheInvoker
 		this.initialized = true;
 	}
 
-
-	/**
-	 * Convenience method to return a String representation of this Method
-	 * for use in logging. Can be overridden in subclasses to provide a
-	 * different identifier for the given method.
-	 * @param method the method we're interested in
-	 * @param targetClass class the method is on
-	 * @return log message identifying this method
-	 * @see org.springframework.util.ClassUtils#getQualifiedMethodName
-	 */
-	protected String methodIdentification(Method method, Class<?> targetClass) {
-		Method specificMethod = ClassUtils.getMostSpecificMethod(method, targetClass);
-		return ClassUtils.getQualifiedMethodName(specificMethod);
-	}
-
 	protected Collection<? extends Cache> getCaches(
 			CacheOperationInvocationContext<CacheOperation> context, CacheResolver cacheResolver) {
 


### PR DESCRIPTION
The Javadoc said it's used for logging, but it's not used anywhere.