### PR TITLE
Add missing @Deprecated.forRemoval for removed in 7.0

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/ResponseEntity.java
@@ -148,7 +148,7 @@ public class ResponseEntity<T> extends HttpEntity<T> {
 	 * @deprecated as of 6.0, in favor of {@link #getStatusCode()}; scheduled
 	 * for removal in 7.0
 	 */
-	@Deprecated(since = "6.0")
+	@Deprecated(since = "6.0", forRemoval = true)
 	public int getStatusCodeValue() {
 		return getStatusCode().value();
 	}

--- a/spring-web/src/main/java/org/springframework/http/converter/HttpMessageNotReadableException.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/HttpMessageNotReadableException.java
@@ -38,9 +38,10 @@ public class HttpMessageNotReadableException extends HttpMessageConversionExcept
 	/**
 	 * Create a new HttpMessageNotReadableException.
 	 * @param msg the detail message
-	 * @deprecated as of 5.1, in favor of {@link #HttpMessageNotReadableException(String, HttpInputMessage)}
+	 * @deprecated as of 5.1, in favor of {@link #HttpMessageNotReadableException(String, HttpInputMessage)},
+	 * for removal in 7.0
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true)
 	public HttpMessageNotReadableException(String msg) {
 		super(msg);
 		this.httpInputMessage = null;
@@ -50,9 +51,10 @@ public class HttpMessageNotReadableException extends HttpMessageConversionExcept
 	 * Create a new HttpMessageNotReadableException.
 	 * @param msg the detail message
 	 * @param cause the root cause (if any)
-	 * @deprecated as of 5.1, in favor of {@link #HttpMessageNotReadableException(String, Throwable, HttpInputMessage)}
+	 * @deprecated as of 5.1, in favor of {@link #HttpMessageNotReadableException(String, Throwable, HttpInputMessage)},
+	 * for removal in 7.0
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true)
 	public HttpMessageNotReadableException(String msg, @Nullable Throwable cause) {
 		super(msg, cause);
 		this.httpInputMessage = null;

--- a/spring-web/src/main/java/org/springframework/web/client/RestClientResponseException.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestClientResponseException.java
@@ -127,7 +127,7 @@ public class RestClientResponseException extends RestClientException {
 	 * Return the raw HTTP status code value.
 	 * @deprecated in favor of {@link #getStatusCode()}, for removal in 7.0
 	 */
-	@Deprecated(since = "6.0")
+	@Deprecated(since = "6.0", forRemoval = true)
 	public int getRawStatusCode() {
 		return this.statusCode.value();
 	}

--- a/spring-web/src/main/java/org/springframework/web/client/UnknownContentTypeException.java
+++ b/spring-web/src/main/java/org/springframework/web/client/UnknownContentTypeException.java
@@ -115,7 +115,7 @@ public class UnknownContentTypeException extends RestClientException {
 	 * Return the raw HTTP status code value.
 	 * @deprecated in favor of {@link #getStatusCode()}, for removal in 7.0
 	 */
-	@Deprecated(since = "6.0")
+	@Deprecated(since = "6.0", forRemoval = true)
 	public int getRawStatusCode() {
 		return this.statusCode.value();
 	}

--- a/spring-web/src/main/java/org/springframework/web/util/ContentCachingRequestWrapper.java
+++ b/spring-web/src/main/java/org/springframework/web/util/ContentCachingRequestWrapper.java
@@ -71,7 +71,10 @@ public class ContentCachingRequestWrapper extends HttpServletRequestWrapper {
 	/**
 	 * Create a new ContentCachingRequestWrapper for the given servlet request.
 	 * @param request the original servlet request
+	 * @deprecated as of 6.2, in favor of {@link #ContentCachingRequestWrapper(HttpServletRequest, int)},
+	 * for removal in 7.0
 	 */
+	@Deprecated(forRemoval = true)
 	public ContentCachingRequestWrapper(HttpServletRequest request) {
 		super(request);
 		int contentLength = request.getContentLength();

--- a/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponentsBuilder.java
@@ -238,7 +238,7 @@ public class UriComponentsBuilder implements UriBuilder, Cloneable {
 	 * @deprecated as of 6.2, in favor of {@link #fromUriString(String)};
 	 * scheduled for removal in 7.0.
 	 */
-	@Deprecated(since = "6.2")
+	@Deprecated(since = "6.2", forRemoval = true)
 	public static UriComponentsBuilder fromHttpUrl(String httpUrl) throws InvalidUrlException {
 		return fromUriString(httpUrl);
 	}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClientResponseException.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClientResponseException.java
@@ -174,7 +174,7 @@ public class WebClientResponseException extends WebClientException {
 	 * Return the raw HTTP status code value.
 	 * @deprecated in favor of {@link #getStatusCode()}, for removal in 7.0
 	 */
-	@Deprecated(since = "6.0")
+	@Deprecated(since = "6.0", forRemoval = true)
 	public int getRawStatusCode() {
 		return this.statusCode.value();
 	}


### PR DESCRIPTION
We should distinguish just `@Deprecated` and these which are removed already in the spring-framework 7.0 to prioritize addressing these cases.
Also, for our specific scenario, we have arch-unit test that checks all `@Deprecated` annotated classes/constructors/methods and prohibits its usage in the project and library code if `forRemoval=true` (otherwise it's more lenient).