### PR TITLE
Fix typo in HttpRange error message

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpRange.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpRange.java
@@ -249,7 +249,7 @@ public abstract class HttpRange {
 			}
 			if (lastBytePos != null && lastBytePos < firstBytePos) {
 				throw new IllegalArgumentException("firstBytePosition=" + firstBytePos +
-						" should be less then or equal to lastBytePosition=" + lastBytePos);
+						" should be less than or equal to lastBytePosition=" + lastBytePos);
 			}
 		}
 


### PR DESCRIPTION
`then` → `than` in error message for invalid byte range positions.