### PR TITLE
Fix flaky reactorNettyAttributes test by using doFinally for synchronous cleanup

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpConnector.java
@@ -162,22 +162,33 @@ public class ReactorClientHttpConnector implements ClientHttpConnector, SmartLif
 
 		requestSender = setUri(requestSender, uri);
 		AtomicReference<ReactorClientHttpResponse> responseRef = new AtomicReference<>();
+		AtomicReference<Connection> connectionRef = new AtomicReference<>();
 
-		return requestSender
+			return requestSender
 				.send((request, outbound) -> requestCallback.apply(adaptRequest(method, uri, request, outbound)))
 				.responseConnection((response, connection) -> {
 					ReactorClientHttpResponse clientResponse = new ReactorClientHttpResponse(response, connection);
 					responseRef.set(clientResponse);
-					registerAttributeCallback(connection);
+					connectionRef.set(connection); 
 					return Mono.just((ClientHttpResponse) clientResponse);
 				})
 				.next()
+				.doFinally(signal -> { 
+					ReactorClientHttpResponse response = responseRef.get();
+					if (response != null) {
+						clearChannelAttribute(response.connection);
+					}
+				})
 				.doOnCancel(() -> {
 					ReactorClientHttpResponse response = responseRef.get();
 					if (response != null) {
 						response.releaseAfterCancel(method);
 					}
 				});
+	}
+
+	private static void clearChannelAttribute(Connection connection) {
+		connection.channel().attr(ATTRIBUTES_KEY).set(null);
 	}
 
 	private static HttpClient.RequestSender setUri(HttpClient.RequestSender requestSender, URI uri) {

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientIntegrationTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/WebClientIntegrationTests.java
@@ -1323,7 +1323,6 @@ class WebClientIntegrationTests {
 				.verify(Duration.ofSeconds(3));
 	}
 
-	@Disabled("Disabled because it's flaky (gh-36589)")
 	@Test  // gh-36158
 	void reactorNettyAttributes() throws IOException {
 		startServer(new ReactorClientHttpConnector());
@@ -1334,14 +1333,17 @@ class WebClientIntegrationTests {
 		AtomicReference<Channel> channelRef = new AtomicReference<>();
 
 		Mono<String> result = this.webClient.get().uri("/greeting")
-				.httpRequest(request -> {
-					HttpClientRequest reactorRequest = request.getNativeRequest();
-					channelRef.set(((ChannelOperations<?, ?>) reactorRequest).channel());
-				})
-				.retrieve()
-				.bodyToMono(String.class);
+            .httpRequest(request -> {
+                HttpClientRequest reactorRequest = request.getNativeRequest();
+                channelRef.set(((ChannelOperations<?, ?>) reactorRequest).channel());
+            })
+            .retrieve()
+            .bodyToMono(String.class);
 
-		StepVerifier.create(result).expectNext("Hello Spring!").expectComplete().verify(Duration.ofSeconds(3));
+    StepVerifier.create(result)
+            .expectNext("Hello Spring!")
+            .expectComplete()
+            .verify(Duration.ofSeconds(3));
 
 		assertThat(channelRef.get().attr(ReactorClientHttpConnector.ATTRIBUTES_KEY).get()).isNull();
 	}


### PR DESCRIPTION
Use `doFinally` operator in the reactive chain for guaranteed synchronous cleanup:
- Store `Connection` in `AtomicReference`
- Use `doFinally(signal -> clearChannelAttribute(conn))` instead of async callback
- Ensures cleanup is part of reactive chain
- Remove `@Disabled` annotation from test

## Changes
- **ReactorClientHttpConnector.java**: Add `connectionRef`, `doFinally` operator, `clearChannelAttribute()` method
- **WebClientIntegrationTests.java**: Remove `@Disabled` annotation

Fixes #36589
Relates to #36158

Signed-off-by: Pratap Chandra Deo <pratapchandradeo@users.noreply.github.com>