### PR TITLE
`AbstractMockHttpServletRequestBuilder#param` does not allow `null` in Kotlin

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/request/AbstractMockHttpServletRequestBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/request/AbstractMockHttpServletRequestBuilder.java
@@ -447,7 +447,7 @@ public abstract class AbstractMockHttpServletRequestBuilder<B extends AbstractMo
 	 * @param name the parameter name
 	 * @param values one or more values
 	 */
-	public B param(String name, String... values) {
+	public B param(String name, @Nullable String... values) {
 		this.parameters.addAll(name, Arrays.asList(values));
 		return self();
 	}

--- a/spring-test/src/main/kotlin/org/springframework/test/web/servlet/MockHttpServletRequestDsl.kt
+++ b/spring-test/src/main/kotlin/org/springframework/test/web/servlet/MockHttpServletRequestDsl.kt
@@ -107,7 +107,7 @@ open class MockHttpServletRequestDsl(private val builder: AbstractMockHttpServle
 	/**
 	 * @see [MockHttpServletRequestBuilder.param]
 	 */
-	fun param(name: String, vararg values: String) {
+	fun param(name: String, vararg values: String?) {
 		builder.param(name, *values)
 	}
 


### PR DESCRIPTION
## Problem statement
Since Spring Framework 7.0 it's not possible to use `null` value as an argument for MockMvc query parameters.
E.g. for such snippet of Kotlin code
```kotlin
mockMvc
    .perform(
        get("/url")
            .param("limit", "1"),
            .param("cursor", null) // <- compilation fails now
    ).andExpect(status().isOk)
```

While `null` value is a legal value for query parameters (it's serialized as "?paramName" in the query string without following `=` (and is expected in our test on the server side)

Original change: https://github.com/spring-projects/spring-framework/commit/bc5d771a0639c6e47eda2b610c221a4515384abb by @sdeleuze

## Proposed solution
Mark argument `@Nullable` for Java callers and Kotlin extension.
