### PR TITLE
`MergedAnnotation` does not use `ClassLoader` for method or field

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/annotation/TypeMappedAnnotation.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/TypeMappedAnnotation.java
@@ -604,7 +604,7 @@ final class TypeMappedAnnotation<A extends Annotation> extends AbstractMergedAnn
 				return clazz.getClassLoader();
 			}
 			if (this.source instanceof Member member) {
-				member.getDeclaringClass().getClassLoader();
+				return member.getDeclaringClass().getClassLoader();
 			}
 		}
 		return null;


### PR DESCRIPTION
I checked carefully, something goes wrong without `return`.