### PR TITLE
Fix typo in FormTag Javadoc and TLD

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/FormTag.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/tags/form/FormTag.java
@@ -126,7 +126,7 @@ import org.springframework.web.util.UriUtils;
  * <td><p>methodParam</p></td>
  * <td><p>false</p></td>
  * <td><p>true</p></td>
- * <td><p>The parameter name used for HTTP methods other then GET and POST.
+ * <td><p>The parameter name used for HTTP methods other than GET and POST.
  * Default is '_method'.</p></td>
  * </tr>
  * <tr class="odd-row-color">

--- a/spring-webmvc/src/main/resources/META-INF/spring-form.tld
+++ b/spring-webmvc/src/main/resources/META-INF/spring-form.tld
@@ -188,7 +188,7 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
-			<description>The parameter name used for HTTP methods other then GET and POST.
+			<description>The parameter name used for HTTP methods other than GET and POST.
 			Default is '_method'.</description>
 			<name>methodParam</name>
 			<required>false</required>


### PR DESCRIPTION
`then` → `than` in methodParam attribute description.