### PR TITLE
fix(web): handle HttpMessageNotWritableException in DisconnectedClien…

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/DisconnectedClientHelper.java
+++ b/spring-web/src/main/java/org/springframework/web/util/DisconnectedClientHelper.java
@@ -42,7 +42,8 @@ import org.springframework.util.ClassUtils;
 public class DisconnectedClientHelper {
 
 	private static final Set<String> EXCEPTION_PHRASES =
-			Set.of("broken pipe", "connection reset by peer");
+			Set.of("broken pipe", "connection reset by peer",
+					"response may not be written");
 
 	private static final Set<String> EXCEPTION_TYPE_NAMES =
 			Set.of("AbortedException", "ClientAbortException",

--- a/spring-web/src/test/java/org/springframework/web/util/DisconnectedClientHelperTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/DisconnectedClientHelperTests.java
@@ -34,6 +34,7 @@ import org.springframework.messaging.MessagingException;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.context.request.async.AsyncRequestNotUsableException;
 import org.springframework.web.testfixture.http.MockHttpInputMessage;
+import org.springframework.http.converter.HttpMessageNotWritableException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -97,6 +98,13 @@ class DisconnectedClientHelperTests {
 	@Test // gh-34533
 	void nullException() {
 		assertThat(DisconnectedClientHelper.isClientDisconnectedException(null)).isFalse();
+	}
+
+	@Test // gh-36421
+	void httpMessageNotWritableFromClosedConnection() {
+		IOException cause = new IOException("The response may not be written to once it has been closed");
+		Exception ex = new HttpMessageNotWritableException("Could not write JSON", cause);
+		assertThat(DisconnectedClientHelper.isClientDisconnectedException(ex)).isTrue();
 	}
 
 }


### PR DESCRIPTION
## Problem
When a client disconnects, `@ExceptionHandler` attempts to write a response, resulting in `HttpMessageNotWritableException` wrapping an `IOException: The response may not be written to once it has been closed`. This exception is not recognized by `DisconnectedClientHelper` and propagates to the Servlet container unnecessarily.

## Solution
Add `"response may not be written"` to the `EXCEPTION_PHRASES` set in `DisconnectedClientHelper` so that this scenario is silently logged at DEBUG level instead of propagating.

Closes #36421