### PR TITLE
Use defensive `Date` copies for `SimpleMailMessage` `sentDate`

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/mail/SimpleMailMessage.java
+++ b/spring-context-support/src/main/java/org/springframework/mail/SimpleMailMessage.java
@@ -79,7 +79,7 @@ public class SimpleMailMessage implements MailMessage, Serializable {
 		this.to = copyOrNull(original.getTo());
 		this.cc = copyOrNull(original.getCc());
 		this.bcc = copyOrNull(original.getBcc());
-		this.sentDate = original.getSentDate();
+		this.sentDate = copyOrNull(original.sentDate);
 		this.subject = original.getSubject();
 		this.text = original.getText();
 	}
@@ -147,11 +147,11 @@ public class SimpleMailMessage implements MailMessage, Serializable {
 
 	@Override
 	public void setSentDate(@Nullable Date sentDate) {
-		this.sentDate = sentDate;
+		this.sentDate = copyOrNull(sentDate);
 	}
 
 	public @Nullable Date getSentDate() {
-		return this.sentDate;
+		return copyOrNull(this.sentDate);
 	}
 
 	@Override
@@ -194,8 +194,9 @@ public class SimpleMailMessage implements MailMessage, Serializable {
 		if (getBcc() != null) {
 			target.setBcc(copy(getBcc()));
 		}
-		if (getSentDate() != null) {
-			target.setSentDate(getSentDate());
+		if (this.sentDate != null) {
+			Date sentDate = this.sentDate;
+			target.setSentDate((Date) sentDate.clone());
 		}
 		if (getSubject() != null) {
 			target.setSubject(getSubject());
@@ -245,6 +246,10 @@ public class SimpleMailMessage implements MailMessage, Serializable {
 			return null;
 		}
 		return copy(state);
+	}
+
+	private static @Nullable Date copyOrNull(@Nullable Date date) {
+		return (date != null ? (Date) date.clone() : null);
 	}
 
 	private static String[] copy(String[] state) {

--- a/spring-context-support/src/test/java/org/springframework/mail/SimpleMailMessageTests.java
+++ b/spring-context-support/src/test/java/org/springframework/mail/SimpleMailMessageTests.java
@@ -98,6 +98,60 @@ class SimpleMailMessageTests {
 		assertThat(copy.getBcc()[0]).isEqualTo("us@mail.org");
 	}
 
+	@Test
+	void setSentDateStoresACopy() {
+		SimpleMailMessage message = new SimpleMailMessage();
+		Date sentDate = new Date(1234L);
+
+		message.setSentDate(sentDate);
+		sentDate.setTime(0L);
+
+		assertThat(message.getSentDate()).isEqualTo(new Date(1234L));
+	}
+
+	@Test
+	void getSentDateReturnsACopy() {
+		SimpleMailMessage message = new SimpleMailMessage();
+		Date sentDate = new Date(1234L);
+		message.setSentDate(sentDate);
+
+		Date exportedDate = message.getSentDate();
+		exportedDate.setTime(0L);
+
+		assertThat(message.getSentDate()).isEqualTo(new Date(1234L));
+	}
+
+	@Test
+	void copyConstructorCopiesSentDate() {
+		Date sentDate = new Date(1234L);
+		SimpleMailMessage original = new SimpleMailMessage();
+		original.setSentDate(sentDate);
+
+		SimpleMailMessage copy = new SimpleMailMessage(original);
+		sentDate.setTime(0L);
+
+		Date copiedDate = copy.getSentDate();
+		assertThat(copiedDate).isNotNull();
+		copiedDate.setTime(1L);
+
+		assertThat(original.getSentDate()).isEqualTo(new Date(1234L));
+		assertThat(copy.getSentDate()).isEqualTo(new Date(1234L));
+	}
+
+	@Test
+	void copyToCopiesSentDate() {
+		SimpleMailMessage source = new SimpleMailMessage();
+		source.setSentDate(new Date(1234L));
+
+		TestMailMessage target = new TestMailMessage();
+		source.copyTo(target);
+
+		assertThat(target.getSentDate()).isNotNull();
+		target.getSentDate().setTime(0L);
+
+		assertThat(source.getSentDate()).isEqualTo(new Date(1234L));
+	}
+
 	/**
 	 * Tests that two equal SimpleMailMessages have equal hash codes.
 	 */
@@ -164,6 +218,60 @@ class SimpleMailMessageTests {
 	@Test
 	void copyToChokesOnNullTargetMessage() {
 		assertThatIllegalArgumentException().isThrownBy(() -> new SimpleMailMessage().copyTo(null));
+	}
+
+	private static class TestMailMessage implements MailMessage {
+
+		private Date sentDate;
+
+		Date getSentDate() {
+			return this.sentDate;
+		}
+
+		@Override
+		public void setFrom(String from) {
+		}
+
+		@Override
+		public void setReplyTo(String replyTo) {
+		}
+
+		@Override
+		public void setTo(String to) {
+		}
+
+		@Override
+		public void setTo(String... to) {
+		}
+
+		@Override
+		public void setCc(String cc) {
+		}
+
+		@Override
+		public void setCc(String... cc) {
+		}
+
+		@Override
+		public void setBcc(String bcc) {
+		}
+
+		@Override
+		public void setBcc(String... bcc) {
+		}
+
+		@Override
+		public void setSentDate(Date sentDate) {
+			this.sentDate = sentDate;
+		}
+
+		@Override
+		public void setSubject(String subject) {
+		}
+
+		@Override
+		public void setText(String text) {
+		}
 	}
 
 }


### PR DESCRIPTION
## Summary

This PR updates `SimpleMailMessage` to use defensive `Date` copies for `sentDate`.

Currently, `SimpleMailMessage` already copies its recipient arrays in copy paths, but `sentDate` can still be shared across instances if it is not copied consistently. As a result, external mutation of a shared `Date` reference can affect message state unexpectedly.

## Changes

This change makes `sentDate` handling consistent by using defensive `Date` copies in the relevant paths.

Specifically:
- `setSentDate(Date)` stores a defensive copy
- `getSentDate()` returns a defensive copy
- the copy constructor copies `sentDate` independently
- `copyTo(MailMessage)` passes an independent `Date` instance

## Rationale

This is a narrow change intended to preserve the existing behavior of `SimpleMailMessage` while avoiding accidental state mutation through shared mutable `Date` references.

## Tests

I also added regression tests covering:
- mutation of the input `Date` after calling `setSentDate`
- mutation of the `Date` returned by `getSentDate`
- copy constructor isolation for `sentDate`
- `copyTo(MailMessage)` isolation for `sentDate`