### PR TITLE
Fix the SingleConnectionDataSource constructor to allow null url, username, password

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/DriverManagerDataSource.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/DriverManagerDataSource.java
@@ -21,6 +21,8 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
 
+import org.jspecify.annotations.Nullable;
+
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 
@@ -90,7 +92,7 @@ public class DriverManagerDataSource extends AbstractDriverBasedDataSource {
 	 * @param password the JDBC password to use for accessing the DriverManager
 	 * @see java.sql.DriverManager#getConnection(String, String, String)
 	 */
-	public DriverManagerDataSource(String url, String username, String password) {
+	public DriverManagerDataSource(@Nullable String url, @Nullable String username, @Nullable String password) {
 		setUrl(url);
 		setUsername(username);
 		setPassword(password);

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/SingleConnectionDataSource.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/SingleConnectionDataSource.java
@@ -93,7 +93,7 @@ public class SingleConnectionDataSource extends DriverManagerDataSource
 	 * close-suppressing proxy or the physical Connection
 	 * @see java.sql.DriverManager#getConnection(String, String, String)
 	 */
-	public SingleConnectionDataSource(String url, String username, String password, boolean suppressClose) {
+	public SingleConnectionDataSource(@Nullable String url, @Nullable String username, @Nullable String password, boolean suppressClose) {
 		super(url, username, password);
 		this.suppressClose = suppressClose;
 	}

--- a/spring-jdbc/src/test/kotlin/org/springframework/jdbc/datasource/SingleConnectionDataSourceTest.kt
+++ b/spring-jdbc/src/test/kotlin/org/springframework/jdbc/datasource/SingleConnectionDataSourceTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.jdbc.datasource
+
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+
+class SingleConnectionDataSourceTest {
+
+        // The underlying AbstractDriverBasedDataSource.setUrl, setUsername and setPassword
+        // methods allow null, so ensure the SingleConnectionDataSource constructor does too.
+	@Test
+	fun `construct SingleConnectionDataSource with null properties`() {
+		val url: String? = null
+		val username: String? = null
+		val password: String? = null
+		val singleConnectionDataSource = SingleConnectionDataSource(url, username, password, false /* arbitrary */)
+		assertNotNull(singleConnectionDataSource)
+	}
+}


### PR DESCRIPTION
since the underlying AbstractDriverBasedDataSource.setUrl, setUsername and setPassword methods allow null.

The @NonNullFields annotation in
[spring-jdbc/src/main/java/org/springframework/jdbc/datasource/package-info.java](https://github.com/spring-projects/spring-framework/blob/fb34264169a0bfe80b2bc5cdc9becf06c1f533b3/spring-jdbc/src/main/java/org/springframework/jdbc/datasource/package-info.java) requires null without an explicit `@Nullable` annotation.