### PR TITLE
Strip query string from uri low-cardinality key in DefaultClientRequestObservationConvention

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/observation/DefaultClientRequestObservationConvention.java
+++ b/spring-web/src/main/java/org/springframework/http/client/observation/DefaultClientRequestObservationConvention.java
@@ -107,6 +107,10 @@ public class DefaultClientRequestObservationConvention implements ClientRequestO
 
 	private static String extractPath(String uriTemplate) {
 		String path = PATTERN_BEFORE_PATH.matcher(uriTemplate).replaceFirst("");
+		int queryIndex = path.indexOf('?');
+		if (queryIndex >= 0) {
+			path = path.substring(0, queryIndex);
+		}
 		return (path.startsWith("/") ? path : "/" + path);
 	}
 

--- a/spring-web/src/test/java/org/springframework/http/client/observation/DefaultClientRequestObservationConventionTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/observation/DefaultClientRequestObservationConventionTests.java
@@ -94,7 +94,7 @@ class DefaultClientRequestObservationConventionTests {
 				new MockClientHttpRequest(HttpMethod.GET, "https://example.org/resource/{id}?queryKey={queryValue}", 42, "Query"), response);
 		context.setUriTemplate("https://example.org/resource/{id}?queryKey={queryValue}");
 		assertThat(this.observationConvention.getLowCardinalityKeyValues(context))
-				.contains(KeyValue.of("exception", "none"), KeyValue.of("method", "GET"), KeyValue.of("uri", "/resource/{id}?queryKey={queryValue}"),
+				.contains(KeyValue.of("exception", "none"), KeyValue.of("method", "GET"), KeyValue.of("uri", "/resource/{id}"),
 						KeyValue.of("status", "200"), KeyValue.of("client.name", "example.org"), KeyValue.of("outcome", "SUCCESS"));
 		assertThat(this.observationConvention.getHighCardinalityKeyValues(context)).contains(KeyValue.of("http.url", "https://example.org/resource/42?queryKey=Query"));
 	}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientRequestObservationConvention.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientRequestObservationConvention.java
@@ -114,6 +114,10 @@ public class DefaultClientRequestObservationConvention implements ClientRequestO
 
 	private static String extractPath(String uriTemplate) {
 		String path = PATTERN_BEFORE_PATH.matcher(uriTemplate).replaceFirst("");
+		int queryIndex = path.indexOf('?');
+		if (queryIndex >= 0) {
+			path = path.substring(0, queryIndex);
+		}
 		return (path.startsWith("/") ? path : "/" + path);
 	}
 

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/DefaultClientRequestObservationConventionTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/DefaultClientRequestObservationConventionTests.java
@@ -120,10 +120,10 @@ class DefaultClientRequestObservationConventionTests {
 	}
 
 	@Test
-	void shouldKeepQueryParameterForUriKeyValue() {
+	void shouldStripQueryParametersFromUriKeyValue() {
 		ClientRequestObservationContext context = createContext(ClientRequest.create(HttpMethod.GET, URI.create("https://example.org/resource/42?queryKey=Query")));
 		context.setUriTemplate("https://example.org/resource/{id}?queryKey={queryValue}");
-		assertThat(this.observationConvention.getLowCardinalityKeyValues(context)).contains(KeyValue.of("uri", "/resource/{id}?queryKey={queryValue}"));
+		assertThat(this.observationConvention.getLowCardinalityKeyValues(context)).contains(KeyValue.of("uri", "/resource/{id}"));
 	}
 
 	private ClientRequestObservationContext createContext(ClientRequest.Builder request) {


### PR DESCRIPTION
## Summary

`extractPath()` in `DefaultClientRequestObservationConvention` stripped the scheme and host but preserved the query string. When HTTP Interface clients (`@HttpExchange`) use `@RequestParam` parameters, Spring injects URI template placeholders like `{queryParam-category}` into the query string. Because these differ per combination of present/absent optional parameters and per list length, the `uri` low-cardinality tag inherits combinatorial or even unbounded cardinality — defeating the purpose of the tag and causing Prometheus metric explosion.

## Changes

- **`spring-web`** `DefaultClientRequestObservationConvention.extractPath()`: strip everything from `?` onward
- **`spring-webflux`** `DefaultClientRequestObservationConvention.extractPath()`: same fix

Path template variables (`{id}`) continue to be preserved since they identify distinct endpoint routes. The full URI (including query string) is already captured in the `http.url` high-cardinality key, so no observability information is lost.

## Behavior change

Before:
```
uri="/resource/{id}?queryKey={queryValue}"    (high cardinality — varies per param combination)
```

After:
```
uri="/resource/{id}"    (low cardinality — matches server-side behavior)
```

This is consistent with how server-side `@RequestMapping` with `@RequestParam` already behaves (`uri="/api/v1/items"` regardless of query parameters).

Fixes #36547