### PR TITLE
Clarify semantics of HttpMethod.valueOf()

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpMethod.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpMethod.java
@@ -110,6 +110,10 @@ public final class HttpMethod implements Comparable<HttpMethod>, Serializable {
 
 	/**
 	 * Return an {@code HttpMethod} object for the given value.
+	 * <p>Note that this lookup is case-sensitive. For predefined constants,
+	 * the method value must be provided in uppercase (e.g., {@code "GET"},
+	 * {@code "POST"}). If no predefined constant matches, a new
+	 * {@code HttpMethod} instance is returned for the given value as-is.
 	 * @param method the method value as a String
 	 * @return the corresponding {@code HttpMethod}
 	 */


### PR DESCRIPTION
This pull request updates the Javadoc for `HttpMethod.valueOf()` to explicitly document that it performs a case-sensitive lookup.

As requested by @sbrannen in gh-36642, this change is being submitted against the `7.0.x` branch to document the status quo.

### Motivation
The current behavior of `HttpMethod.valueOf()` can be ambiguous. This update ensures that developers understand:
- Standard uppercase inputs (e.g., `"GET"`) resolve to predefined constants.
- Lowercase or custom inputs (e.g., `"get"`) result in a newly created `HttpMethod` instance.

### Modifications
- Updated the `valueOf(String)` Javadoc in `HttpMethod.java` with clear examples of case-sensitive resolution.

Closes gh-36642