### PR TITLE
Align MockHttpServletRequest.isRequestedSessionIdValid() with Servlet 6.1

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
@@ -250,7 +250,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 
 	private @Nullable HttpSession session;
 
-	private boolean requestedSessionIdValid = true;
+	private @Nullable Boolean requestedSessionIdValid;
 
 	private boolean requestedSessionIdFromCookie = true;
 
@@ -1348,9 +1348,25 @@ public class MockHttpServletRequest implements HttpServletRequest {
 		this.requestedSessionIdValid = requestedSessionIdValid;
 	}
 
+	/**
+	 * Return whether the requested session ID is still valid.
+	 * <p>If {@link #setRequestedSessionIdValid} has not been called explicitly,
+	 * this method calculates the value based on whether the
+	 * {@linkplain #getRequestedSessionId() requested session ID} matches the
+	 * ID of the {@linkplain #getSession(boolean) current session}, aligning
+	 * with the Servlet 6.1 specification.
+	 */
 	@Override
 	public boolean isRequestedSessionIdValid() {
-		return this.requestedSessionIdValid;
+		if (this.requestedSessionIdValid != null) {
+			return this.requestedSessionIdValid;
+		}
+		String requestedId = getRequestedSessionId();
+		if (requestedId == null) {
+			return false;
+		}
+		HttpSession currentSession = getSession(false);
+		return (currentSession != null && requestedId.equals(currentSession.getId()));
 	}
 
 	public void setRequestedSessionIdFromCookie(boolean requestedSessionIdFromCookie) {


### PR DESCRIPTION
Fixes #36631

## Summary
`MockHttpServletRequest.isRequestedSessionIdValid()` currently defaults to `true`, which does not match the Servlet 6.1 specification.

## Changes
- Changed `requestedSessionIdValid` field from `boolean` (default `true`) to `@Nullable Boolean` (default `null`)
- When not explicitly set via `setRequestedSessionIdValid()`, `isRequestedSessionIdValid()` now calculates the return value by checking if the requested session ID matches the current session's ID
- When explicitly set, the explicit value is used (backward compatible)

## Behavior
- No client session ID (`getRequestedSessionId()` returns `null`) -> `isRequestedSessionIdValid()` returns `false`
- After `changeSessionId()`, requested ID no longer matches -> returns `false`
- `setRequestedSessionIdValid(true/false)` still works as before for explicit control