### PR TITLE
Set host header consistently in STOMP relay CONNECT frames

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompBrokerRelayMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompBrokerRelayMessageHandler.java
@@ -456,10 +456,7 @@ public class StompBrokerRelayMessageHandler extends AbstractBrokerMessageHandler
 		accessor.setLogin(this.systemLogin);
 		accessor.setPasscode(this.systemPasscode);
 		accessor.setHeartbeat(this.systemHeartbeatSendInterval, this.systemHeartbeatReceiveInterval);
-		String virtualHost = getVirtualHost();
-		if (virtualHost != null) {
-			accessor.setHost(virtualHost);
-		}
+		accessor.setHost(getVirtualHost() != null ? getVirtualHost() : getRelayHost());
 		accessor.setSessionId(SYSTEM_SESSION_ID);
 		if (logger.isDebugEnabled()) {
 			logger.debug("Forwarding " + accessor.getShortLogMessage(EMPTY_PAYLOAD));
@@ -582,9 +579,7 @@ public class StompBrokerRelayMessageHandler extends AbstractBrokerMessageHandler
 			stompHeaderAccessor = (stompHeaderAccessor.isMutable() ? stompHeaderAccessor : StompHeaderAccessor.wrap(message));
 			stompHeaderAccessor.setLogin(this.clientLogin);
 			stompHeaderAccessor.setPasscode(this.clientPasscode);
-			if (getVirtualHost() != null) {
-				stompHeaderAccessor.setHost(getVirtualHost());
-			}
+			stompHeaderAccessor.setHost(getVirtualHost() != null ? getVirtualHost() : getRelayHost());
 			RelayConnectionHandler handler = new RelayConnectionHandler(sessionId, stompHeaderAccessor);
 			this.connectionHandlers.put(sessionId, handler);
 			this.stats.incrementConnectCount();


### PR DESCRIPTION
Closes #36663

`StompBrokerRelayMessageHandler` only set the `host` header in CONNECT frames when `virtualHost` was explicitly configured. Per STOMP 1.2 specification, the `host` header is required on CONNECT frames.

This change falls back to `relayHost` (the TCP connection target) when `virtualHost` is not configured, ensuring the `host` header is always present in both system session and client session CONNECT frames.