### PR TITLE
Support Map<String, String> in FormHttpMessageWriter and FormHttpMessageReader

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageReader.java
@@ -48,7 +48,7 @@ import org.springframework.util.StringUtils;
  * @since 5.0
  */
 public class FormHttpMessageReader extends LoggingCodecSupport
-		implements HttpMessageReader<MultiValueMap<String, String>> {
+		implements HttpMessageReader<Map<String, ?>> {
 
 	/**
 	 * The default charset used by the reader.
@@ -57,6 +57,9 @@ public class FormHttpMessageReader extends LoggingCodecSupport
 
 	private static final ResolvableType MULTIVALUE_STRINGS_TYPE =
 			ResolvableType.forClassWithGenerics(MultiValueMap.class, String.class, String.class);
+
+	private static final ResolvableType MAP_STRINGS_TYPE =
+			ResolvableType.forClassWithGenerics(Map.class, String.class, String.class);
 
 
 	private Charset defaultCharset = DEFAULT_CHARSET;
@@ -107,10 +110,14 @@ public class FormHttpMessageReader extends LoggingCodecSupport
 		if (!supportsMediaType(mediaType)) {
 			return false;
 		}
+		if (!Map.class.isAssignableFrom(elementType.toClass())) {
+			return false;
+		}
 		if (MultiValueMap.class.isAssignableFrom(elementType.toClass()) && elementType.hasUnresolvableGenerics()) {
 			return true;
 		}
-		return MULTIVALUE_STRINGS_TYPE.isAssignableFrom(elementType);
+		return MULTIVALUE_STRINGS_TYPE.isAssignableFrom(elementType) ||
+				MAP_STRINGS_TYPE.isAssignableFrom(elementType);
 	}
 
 	private static boolean supportsMediaType(@Nullable MediaType mediaType) {
@@ -118,14 +125,14 @@ public class FormHttpMessageReader extends LoggingCodecSupport
 	}
 
 	@Override
-	public Flux<MultiValueMap<String, String>> read(ResolvableType elementType,
+	public Flux<Map<String, ?>> read(ResolvableType elementType,
 			ReactiveHttpInputMessage message, Map<String, Object> hints) {
 
 		return Flux.from(readMono(elementType, message, hints));
 	}
 
 	@Override
-	public Mono<MultiValueMap<String, String>> readMono(ResolvableType elementType,
+	public Mono<Map<String, ?>> readMono(ResolvableType elementType,
 			ReactiveHttpInputMessage message, Map<String, Object> hints) {
 
 		MediaType contentType = message.getHeaders().getContentType();
@@ -137,6 +144,9 @@ public class FormHttpMessageReader extends LoggingCodecSupport
 					DataBufferUtils.release(buffer);
 					MultiValueMap<String, String> formData = parseFormData(charset, body);
 					logFormData(formData, hints);
+					if (!MultiValueMap.class.isAssignableFrom(elementType.toClass())) {
+						return formData.asSingleValueMap();
+					}
 					return formData;
 				});
 	}

--- a/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/FormHttpMessageWriter.java
@@ -39,8 +39,8 @@ import org.springframework.util.MultiValueMap;
 
 /**
  * {@link HttpMessageWriter} for writing a {@code MultiValueMap<String, String>}
- * as HTML form data, i.e. {@code "application/x-www-form-urlencoded"}, to the
- * body of a request.
+ * or a {@code Map<String, String>} as HTML form data, i.e.
+ * {@code "application/x-www-form-urlencoded"}, to the body of a request.
  *
  * <p>Note that unless the media type is explicitly set to
  * {@link MediaType#APPLICATION_FORM_URLENCODED}, the {@link #canWrite} method
@@ -58,7 +58,7 @@ import org.springframework.util.MultiValueMap;
  * @see org.springframework.http.codec.multipart.MultipartHttpMessageWriter
  */
 public class FormHttpMessageWriter extends LoggingCodecSupport
-		implements HttpMessageWriter<MultiValueMap<String, String>> {
+		implements HttpMessageWriter<Map<String, ?>> {
 
 	/** The default charset used by the writer. */
 	public static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
@@ -68,6 +68,9 @@ public class FormHttpMessageWriter extends LoggingCodecSupport
 
 	private static final ResolvableType MULTIVALUE_TYPE =
 			ResolvableType.forClassWithGenerics(MultiValueMap.class, String.class, String.class);
+
+	private static final ResolvableType MAP_TYPE =
+			ResolvableType.forClassWithGenerics(Map.class, String.class, String.class);
 
 
 	private Charset defaultCharset = DEFAULT_CHARSET;
@@ -99,22 +102,24 @@ public class FormHttpMessageWriter extends LoggingCodecSupport
 
 	@Override
 	public boolean canWrite(ResolvableType elementType, @Nullable MediaType mediaType) {
-		if (!MultiValueMap.class.isAssignableFrom(elementType.toClass())) {
+		if (!Map.class.isAssignableFrom(elementType.toClass())) {
 			return false;
 		}
 		if (MediaType.APPLICATION_FORM_URLENCODED.isCompatibleWith(mediaType)) {
-			// Optimistically, any MultiValueMap with or without generics
+			// Optimistically, any Map with or without generics
 			return true;
 		}
 		if (mediaType == null) {
-			// Only String-based MultiValueMap
-			return MULTIVALUE_TYPE.isAssignableFrom(elementType);
+			// Only String-based Map or MultiValueMap
+			return MULTIVALUE_TYPE.isAssignableFrom(elementType) ||
+					MAP_TYPE.isAssignableFrom(elementType);
 		}
 		return false;
 	}
 
 	@Override
-	public Mono<Void> write(Publisher<? extends MultiValueMap<String, String>> inputStream,
+	@SuppressWarnings("unchecked")
+	public Mono<Void> write(Publisher<? extends Map<String, ?>> inputStream,
 			ResolvableType elementType, @Nullable MediaType mediaType, ReactiveHttpOutputMessage message,
 			Map<String, Object> hints) {
 
@@ -125,7 +130,13 @@ public class FormHttpMessageWriter extends LoggingCodecSupport
 
 		return Mono.from(inputStream).flatMap(form -> {
 			logFormData(form, hints);
-			String value = serializeForm(form, charset);
+			String value;
+			if (form instanceof MultiValueMap<?, ?> multiValueMap) {
+				value = serializeForm((MultiValueMap<String, String>) multiValueMap, charset);
+			}
+			else {
+				value = serializeForm((Map<String, String>) form, charset);
+			}
 			ByteBuffer byteBuffer = charset.encode(value);
 			DataBuffer buffer = message.bufferFactory().wrap(byteBuffer); // wrapping only, no allocation
 			message.getHeaders().setContentLength(byteBuffer.remaining());
@@ -151,7 +162,7 @@ public class FormHttpMessageWriter extends LoggingCodecSupport
 		return mediaType;
 	}
 
-	private void logFormData(MultiValueMap<String, String> form, Map<String, Object> hints) {
+	private void logFormData(Map<String, ?> form, Map<String, Object> hints) {
 		LogFormatUtils.traceDebug(logger, traceOn -> Hints.getLogPrefix(hints) + "Writing " +
 				(isEnableLoggingRequestDetails() ?
 						LogFormatUtils.formatValue(form, !traceOn) :
@@ -171,6 +182,21 @@ public class FormHttpMessageWriter extends LoggingCodecSupport
 						builder.append(URLEncoder.encode(value, charset));
 					}
 				}));
+		return builder.toString();
+	}
+
+	protected String serializeForm(Map<String, String> formData, Charset charset) {
+		StringBuilder builder = new StringBuilder();
+		formData.forEach((name, value) -> {
+			if (builder.length() != 0) {
+				builder.append('&');
+			}
+			builder.append(URLEncoder.encode(name, charset));
+			if (value != null) {
+				builder.append('=');
+				builder.append(URLEncoder.encode(value, charset));
+			}
+		});
 		return builder.toString();
 	}
 

--- a/spring-web/src/main/java/org/springframework/http/codec/multipart/MultipartHttpMessageWriter.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/multipart/MultipartHttpMessageWriter.java
@@ -81,7 +81,7 @@ public class MultipartHttpMessageWriter extends MultipartWriterSupport
 
 	private final Supplier<List<HttpMessageWriter<?>>> partWritersSupplier;
 
-	private final @Nullable HttpMessageWriter<MultiValueMap<String, String>> formWriter;
+	private final @Nullable HttpMessageWriter<? super MultiValueMap<String, String>> formWriter;
 
 
 	/**
@@ -109,7 +109,7 @@ public class MultipartHttpMessageWriter extends MultipartWriterSupport
 	 * @param formWriter the fallback writer for form data, {@code null} by default
 	 */
 	public MultipartHttpMessageWriter(List<HttpMessageWriter<?>> partWriters,
-			@Nullable HttpMessageWriter<MultiValueMap<String, String>> formWriter) {
+			@Nullable HttpMessageWriter<? super MultiValueMap<String, String>> formWriter) {
 
 		this(() -> partWriters, formWriter);
 	}
@@ -124,7 +124,7 @@ public class MultipartHttpMessageWriter extends MultipartWriterSupport
 	 * @since 6.0.3
 	 */
 	public MultipartHttpMessageWriter(Supplier<List<HttpMessageWriter<?>>> partWritersSupplier,
-			@Nullable HttpMessageWriter<MultiValueMap<String, String>> formWriter) {
+			@Nullable HttpMessageWriter<? super MultiValueMap<String, String>> formWriter) {
 
 		super(initMediaTypes(formWriter));
 		this.partWritersSupplier = partWritersSupplier;
@@ -153,8 +153,9 @@ public class MultipartHttpMessageWriter extends MultipartWriterSupport
 	 * Return the configured form writer.
 	 * @since 5.1.13
 	 */
+	@SuppressWarnings("unchecked")
 	public @Nullable HttpMessageWriter<MultiValueMap<String, String>> getFormWriter() {
-		return this.formWriter;
+		return (HttpMessageWriter<MultiValueMap<String, String>>) this.formWriter;
 	}
 
 


### PR DESCRIPTION
Closes #36536

Widens `FormHttpMessageWriter` and `FormHttpMessageReader` to support `Map<String, String>` in addition to `MultiValueMap<String, String>`, aligning the reactive codecs with the imperative `FormHttpMessageConverter` updated in #36408.

**FormHttpMessageWriter:**
- Widens generic type from `MultiValueMap` to `Map`
- `canWrite()` accepts both `Map` and `MultiValueMap` with String values
- `write()` dispatches between `MultiValueMap` and plain `Map` serialization
- Adds `serializeForm(Map)` overload for plain Map entries

**FormHttpMessageReader:**
- Widens generic type from `MultiValueMap` to `Map`
- `canRead()` accepts both `Map` and `MultiValueMap` with String values
- `readMono()` returns `asSingleValueMap()` for plain `Map` target type

**MultipartHttpMessageWriter:**
- Widens `formWriter` field type to `HttpMessageWriter<? super MultiValueMap<String, String>>`