### PR TITLE
Use `String#replace` instead of `String#replaceAll` where appropriate

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/ResourceWebHandler.java
@@ -567,8 +567,8 @@ public class ResourceWebHandler implements WebHandler, InitializingBean {
 
 	private String locationToString(List<Resource> locations) {
 		return locations.toString()
-				.replaceAll("class path resource", "classpath")
-				.replaceAll("ServletContext resource", "ServletContext");
+				.replace("class path resource", "classpath")
+				.replace("ServletContext resource", "ServletContext");
 	}
 
 }

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/ResourceHttpRequestHandler.java
@@ -713,8 +713,8 @@ public class ResourceHttpRequestHandler extends WebContentGenerator
 
 	private String locationToString(List<Resource> locations) {
 		return locations.toString()
-				.replaceAll("class path resource", "classpath")
-				.replaceAll("ServletContext resource", "ServletContext");
+				.replace("class path resource", "classpath")
+				.replace("ServletContext resource", "ServletContext");
 	}
 
 }


### PR DESCRIPTION
Avoid using `String#replaceAll` when the pattern is not a regular expression.

Using `java.lang.String#replace(CharSequence, CharSequence)` will improve performance.