### PR TITLE
Resolve WildcardType in GenericTypeResolver.resolveType()

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/GenericTypeResolver.java
+++ b/spring-core/src/main/java/org/springframework/core/GenericTypeResolver.java
@@ -193,6 +193,9 @@ public final class GenericTypeResolver {
 						else if (typeArgument instanceof ParameterizedType) {
 							generics[i] = ResolvableType.forType(resolveType(typeArgument, contextClass));
 						}
+						else if (typeArgument instanceof WildcardType) {
+							generics[i] = ResolvableType.forType(resolveType(typeArgument, contextClass));
+						}
 						else {
 							generics[i] = ResolvableType.forType(typeArgument);
 						}
@@ -201,6 +204,12 @@ public final class GenericTypeResolver {
 					if (rawClass != null) {
 						return ResolvableType.forClassWithGenerics(rawClass, generics).getType();
 					}
+				}
+			}
+			else if (genericType instanceof WildcardType wildcardType) {
+				Type[] upperBounds = wildcardType.getUpperBounds();
+				if (upperBounds.length == 1) {
+					return resolveType(upperBounds[0], contextClass);
 				}
 			}
 		}

--- a/spring-core/src/test/java/org/springframework/core/GenericTypeResolverTests.java
+++ b/spring-core/src/test/java/org/springframework/core/GenericTypeResolverTests.java
@@ -260,6 +260,16 @@ class GenericTypeResolverTests {
 		assertThat(resolvedType).isEqualTo(method(MyOptionalInterfaceType.class, "get").getGenericReturnType());
 	}
 
+	@Test
+	void resolveWildcardTypeArgument() {
+		Type genericReturnType = method(WildcardService.class, "findAll").getGenericReturnType();
+		Type resolvedType = resolveType(genericReturnType, PersonWildcardService.class);
+		assertThat(resolvedType).isInstanceOf(ParameterizedType.class);
+		ParameterizedType parameterizedType = (ParameterizedType) resolvedType;
+		assertThat(parameterizedType.getRawType()).isEqualTo(List.class);
+		assertThat(parameterizedType.getActualTypeArguments()[0]).isEqualTo(String.class);
+	}
+
 	private static Method method(Class<?> target, String methodName, Class<?>... parameterTypes) {
 		Method method = findMethod(target, methodName, parameterTypes);
 		assertThat(method).describedAs(target.getName() + "#" + methodName).isNotNull();
@@ -501,6 +511,19 @@ class GenericTypeResolverTests {
 	public static class InheritsDefaultMethod implements InterfaceWithDefaultMethod<InheritsDefaultMethod.ConcreteType> {
 
 		static class ConcreteType implements InterfaceWithDefaultMethod.AbstractType {
+		}
+	}
+
+	interface WildcardService<T> {
+
+		List<? extends T> findAll();
+	}
+
+	static class PersonWildcardService implements WildcardService<String> {
+
+		@Override
+		public List<? extends String> findAll() {
+			return List.of();
 		}
 	}
 


### PR DESCRIPTION
GenericTypeResolver.resolveType() did not handle WildcardType, causing wildcard type arguments like `? extends T` to remain unresolved when the type variable `T` could be resolved from the context class.

This affects scenarios where a service interface declares a return type like `List<? extends T>` and a concrete subclass binds `T` to a specific type — the wildcard was passed through as-is instead of being resolved to the concrete bound.

**Changes:**

- Add top-level `WildcardType` branch in `resolveType()` that resolves the upper bound recursively
- Add `WildcardType` case inside the `ParameterizedType` argument loop to delegate wildcard arguments to `resolveType()`
- Add test verifying `List<? extends T>` resolves to `List<String>` when `T = String`

Closes spring-projects#36474

Signed-off-by: tianhaocui <54015884+tianhaocui@users.noreply.github.com>