### PR TITLE
Expose validateIfApplicable and isBindExceptionRequired as protected extension points in ModelAttributeMethodArgumentResolver

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/ModelAttributeMethodArgumentResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/ModelAttributeMethodArgumentResolver.java
@@ -144,7 +144,7 @@ public class ModelAttributeMethodArgumentResolver extends HandlerMethodArgumentR
 									return adapter.fromPublisher(mono);
 								}
 								else {
-									if (errors.hasErrors() && !hasErrorsArgument(parameter)) {
+									if (errors.hasErrors() && isBindExceptionRequired(parameter)) {
 										throw new WebExchangeBindException(parameter, errors);
 									}
 									return attribute;
@@ -219,13 +219,30 @@ public class ModelAttributeMethodArgumentResolver extends HandlerMethodArgumentR
 		return binder.bind(exchange);
 	}
 
-	private boolean hasErrorsArgument(MethodParameter parameter) {
+	/**
+	 * Whether to raise a fatal bind exception on validation errors.
+	 * @param parameter the method parameter declaration
+	 * @return {@code true} if the next method parameter is not of type {@link Errors}
+	 * @since 6.2
+	 */
+	protected boolean isBindExceptionRequired(MethodParameter parameter) {
 		int i = parameter.getParameterIndex();
 		Class<?>[] paramTypes = parameter.getExecutable().getParameterTypes();
-		return (paramTypes.length > i + 1 && Errors.class.isAssignableFrom(paramTypes[i + 1]));
+		return !(paramTypes.length > i + 1 && Errors.class.isAssignableFrom(paramTypes[i + 1]));
 	}
 
-	private void validateIfApplicable(WebExchangeDataBinder binder, MethodParameter parameter, ServerWebExchange exchange) {
+	/**
+	 * Validate the model attribute if applicable.
+	 * <p>The default implementation checks for {@code @jakarta.validation.Valid},
+	 * Spring's {@link org.springframework.validation.annotation.Validated},
+	 * and custom annotations whose name starts with "Valid".
+	 * @param binder the DataBinder to be used
+	 * @param parameter the method parameter declaration
+	 * @param exchange the current exchange
+	 * @see WebExchangeDataBinder#validate(Object...)
+	 * @see org.springframework.validation.SmartValidator#validate(Object, Errors, Object...)
+	 */
+	protected void validateIfApplicable(WebExchangeDataBinder binder, MethodParameter parameter, ServerWebExchange exchange) {
 		LocaleContext localeContext = null;
 		try {
 			for (Annotation ann : parameter.getParameterAnnotations()) {

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/ModelAttributeMethodArgumentResolverTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/ModelAttributeMethodArgumentResolverTests.java
@@ -37,6 +37,7 @@ import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.support.ConfigurableWebBindingInitializer;
 import org.springframework.web.bind.support.WebExchangeBindException;
+import org.springframework.web.bind.support.WebExchangeDataBinder;
 import org.springframework.web.reactive.BindingContext;
 import org.springframework.web.server.ServerWebExchange;
 import org.springframework.web.testfixture.http.server.reactive.MockServerHttpRequest;
@@ -400,6 +401,29 @@ class ModelAttributeMethodArgumentResolverTests {
 
 	// TODO: SPR-15871, SPR-15542
 
+	@Test
+	void protectedMethodsCanBeOverridden() {
+		// Test that validateIfApplicable and isBindExceptionRequired can be overridden
+		CustomModelAttributeMethodArgumentResolver resolver = new CustomModelAttributeMethodArgumentResolver(
+				ReactiveAdapterRegistry.getSharedInstance(), false);
+		assertThat(resolver.validateIfApplicableCalled).isFalse();
+		assertThat(resolver.isBindExceptionRequiredCalled).isFalse();
+
+		MethodParameter parameter = this.testMethod.annotPresent(ModelAttribute.class).arg(Pojo.class);
+		
+		// Use invalid data to trigger validation errors, which will call isBindExceptionRequired
+		try {
+			resolver.resolveArgument(parameter, this.bindContext, postForm("name=Robert&age=invalid"))
+					.block(Duration.ZERO);
+		}
+		catch (WebExchangeBindException ex) {
+			// Expected - validation error
+		}
+
+		assertThat(resolver.validateIfApplicableCalled).isTrue();
+		assertThat(resolver.isBindExceptionRequiredCalled).isTrue();
+	}
+
 
 	private ModelAttributeMethodArgumentResolver createResolver() {
 		return new ModelAttributeMethodArgumentResolver(ReactiveAdapterRegistry.getSharedInstance(), false);
@@ -516,7 +540,7 @@ class ModelAttributeMethodArgumentResolverTests {
 		}
 
 		public int getAge() {
-			return this.age;
+			return age;
 		}
 
 		public int getCount() {
@@ -525,6 +549,32 @@ class ModelAttributeMethodArgumentResolverTests {
 
 		public void setCount(int count) {
 			this.count = count;
+		}
+	}
+
+
+	/**
+	 * Custom resolver that overrides protected methods to verify they can be extended.
+	 */
+	private static class CustomModelAttributeMethodArgumentResolver extends ModelAttributeMethodArgumentResolver {
+
+		boolean validateIfApplicableCalled = false;
+		boolean isBindExceptionRequiredCalled = false;
+
+		public CustomModelAttributeMethodArgumentResolver(ReactiveAdapterRegistry adapterRegistry, boolean useDefaultResolution) {
+			super(adapterRegistry, useDefaultResolution);
+		}
+
+		@Override
+		protected void validateIfApplicable(WebExchangeDataBinder binder, MethodParameter parameter, ServerWebExchange exchange) {
+			this.validateIfApplicableCalled = true;
+			super.validateIfApplicable(binder, parameter, exchange);
+		}
+
+		@Override
+		protected boolean isBindExceptionRequired(MethodParameter parameter) {
+			this.isBindExceptionRequiredCalled = true;
+			return super.isBindExceptionRequired(parameter);
 		}
 	}
 


### PR DESCRIPTION
Expose validateIfApplicable and isBindExceptionRequired as protected extension points in ModelAttributeMethodArgumentResolver

This change aligns WebFlux with Spring MVC by making validation-related
methods protected extension points, allowing subclasses to customize
validation behavior.

**Motivation:**
When migrating from Spring MVC to WebFlux, a common customization pattern is to
subclass ModelAttributeMethodProcessor and override validateIfApplicable to apply
group-based or context-aware validation — for example, selecting different @Validated
groups based on the HTTP method, tenant context, or feature flags. The same need
exists in WebFlux, but ModelAttributeMethodArgumentResolver does not support it.

Similarly, isBindExceptionRequired is overridden in MVC subclasses to control whether
a binding/validation failure should throw or be silently passed to a BindingResult
parameter — this decision sometimes needs to depend on runtime state, not just
parameter inspection.

**Changes:**
- Changed validateIfApplicable from private to protected with Javadoc
- Introduced isBindExceptionRequired as protected method with Javadoc
- Replaced private hasErrorsArgument helper with isBindExceptionRequired
- Updated call site to use isBindExceptionRequired
- Added test to verify protected methods can be overridden

**Precedent:**
This follows the same pattern established in PR #24947, which made bindRequestParameters
protected in ModelAttributeMethodArgumentResolver. The class currently exposes two
protected reactive extension points (constructAttribute and bindRequestParameters).
validateIfApplicable sits at the same level in the binding lifecycle and should
follow the same convention.

**Testing:**
- All existing tests pass
- Added new test [protectedMethodsCanBeOverridden](cci:1://file:///d:/Projects/spring-framework/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/ModelAttributeMethodArgumentResolverTests.java:402:1-416:2) to verify the protected methods
  can be successfully overridden by subclasses

**Behavioral Impact:**
No behavioral changes - purely additive changes that enable extension points for
subclasses. Existing behavior is unaffected for any code that does not subclass
ModelAttributeMethodArgumentResolver.

Fixes #36690