### PR TITLE
Fix incorrect Java version reference in overview docs

### DIFF
--- a/framework-docs/modules/ROOT/pages/overview.adoc
+++ b/framework-docs/modules/ROOT/pages/overview.adoc
@@ -5,7 +5,7 @@
 Spring makes it easy to create Java enterprise applications. It provides everything you
 need to embrace the Java language in an enterprise environment, with support for Groovy
 and Kotlin as alternative languages on the JVM, and with the flexibility to create many
-kinds of architectures depending on an application's needs. As of Spring Framework 6.0,
+kinds of architectures depending on an application's needs. As of Spring Framework 7.0,
 Spring requires Java 17+.
 
 Spring supports a wide range of application scenarios. In a large enterprise, applications


### PR DESCRIPTION
Fix incorrect Java version reference in overview documentation

The overview section currently states:

"As of Spring Framework 6.0, Spring requires Java 17+."

This is incorrect for the current documentation version and should refer to Spring Framework 7.0 instead.

This PR updates the text accordingly.

This is a documentation-only change.