### PR TITLE
Preserve user-supplied bracket map keys when flattening YAML

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlProcessor.java
@@ -340,7 +340,19 @@ public abstract class YamlProcessor {
 		source.forEach((key, value) -> {
 			if (StringUtils.hasText(path)) {
 				if (key.startsWith("[")) {
-					key = path + key;
+					if (containsKeyPathSeparator(key)) {
+						// User-supplied YAML key whose literal brackets must be preserved
+						// when flattened to property paths (for example a YAML key such as
+						// "[domain.test:8080]" must round-trip as "[[domain.test:8080]]" so
+						// that consumers like the Spring Boot binder treat the original
+						// brackets as part of the key rather than as a map-key marker).
+						key = path + '[' + key + ']';
+					}
+					else {
+						// Bracket-wrapped key generated internally — collection index or
+						// the toString() of a non-CharSequence map key. No dot separator.
+						key = path + key;
+					}
 				}
 				else {
 					key = path + '.' + key;
@@ -370,6 +382,25 @@ public abstract class YamlProcessor {
 				result.put(key, (value != null ? value : (includeEmpty ? emptyValue : "")));
 			}
 		});
+	}
+
+	/**
+	 * Detect whether the given bracket-prefixed key contains characters that downstream
+	 * consumers of the flattened properties would interpret as path separators. Keys
+	 * generated internally by this class for collection indices and for the
+	 * {@code toString()} of non-CharSequence map keys do not contain such characters,
+	 * so the presence of a {@code '.'} or {@code ':'} indicates a user-supplied key
+	 * whose brackets are part of the key itself and need additional wrapping to be
+	 * preserved.
+	 */
+	private static boolean containsKeyPathSeparator(String key) {
+		for (int i = 0; i < key.length(); i++) {
+			char c = key.charAt(i);
+			if (c == '.' || c == ':') {
+				return true;
+			}
+		}
+		return false;
 	}
 
 

--- a/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlPropertiesFactoryBeanTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlPropertiesFactoryBeanTests.java
@@ -226,6 +226,40 @@ class YamlPropertiesFactoryBeanTests {
 		assertThat(properties.get("foo")).isNull();
 	}
 
+	@Test  // gh-27020
+	void loadNestedMapWithBracketedKeyContainingDotAndColon() {
+		YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+		factory.setResources(new ByteArrayResource((
+				"root:\n" +
+				"  webservices:\n" +
+				"    \"[domain.test:8080]\":\n" +
+				"      - username: me\n" +
+				"        password: mypassword\n").getBytes()));
+		Properties properties = factory.getObject();
+		assertThat(properties.getProperty("root.webservices[[domain.test:8080]][0].username"))
+				.isEqualTo("me");
+		assertThat(properties.getProperty("root.webservices[[domain.test:8080]][0].password"))
+				.isEqualTo("mypassword");
+	}
+
+	@Test  // gh-27020
+	void loadNestedMapWithBracketedKeyContainingDot() {
+		YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+		factory.setResources(new ByteArrayResource(
+				"root:\n  \"[my.dotted.key]\": value\n".getBytes()));
+		Properties properties = factory.getObject();
+		assertThat(properties.getProperty("root[[my.dotted.key]]")).isEqualTo("value");
+	}
+
+	@Test  // gh-27020
+	void loadNestedMapWithBracketedKeyContainingColon() {
+		YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+		factory.setResources(new ByteArrayResource(
+				"root:\n  \"[host:8080]\": value\n".getBytes()));
+		Properties properties = factory.getObject();
+		assertThat(properties.getProperty("root[[host:8080]]")).isEqualTo("value");
+	}
+
 	@Test
 	@SuppressWarnings("unchecked")
 	void yaml() {


### PR DESCRIPTION
## Problem

`YamlPropertiesFactoryBean` (and any other `YamlProcessor` consumer) drops the literal brackets on user-supplied YAML map keys whose textual form starts with `[`. For example:

```yaml
root:
  webservices:
    "[domain.test:8080]":
      - username: me
        password: mypassword
```

today flattens to:

```properties
root.webservices[domain.test:8080][0].username=me
```

so a downstream consumer such as Spring Boot's relaxed binder sees the map key as `domain.test:8080`, losing the user-typed brackets entirely.

## Root Cause

`YamlProcessor#buildFlattenedMap` (`spring-beans/.../YamlProcessor.java`) treats every key starting with `[` the same way:

```java
if (key.startsWith("[")) {
    key = path + key;          // no dot separator
}
```

That branch is intended for internally-generated bracket keys – collection indices (`[0]`, `[1]`, …) and the `toString()` of non-`CharSequence` map keys (`asMap` line 254 wraps them as `[<toString>]`). When a user-supplied YAML key happens to start with `[` it is silently misclassified as an internal index marker and the brackets are stripped from the resulting property path.

## Fix

Distinguish the two cases by inspecting characters that never appear in internally-generated bracket keys:

- collection indices are always `[<digits>]`
- `toString()` of common non-`CharSequence` keys (Integer, Long, Boolean, …) contains no `.` or `:`

So, inside the `key.startsWith("[")` branch, when the key contains `.` or `:` it must have been written by the user. In that case the key is wrapped in an extra pair of brackets so the original brackets become part of the property path:

```
root.webservices[[domain.test:8080]][0].username=me
```

`asMap` and the value-tree returned to `YamlMapFactoryBean` users are unchanged – the additional wrapping happens only inside `buildFlattenedMap`, on the flatten path.

## Tests Added

| Change point | Test |
|--------------|------|
| Bracket-prefixed user key with `.` and `:` (the exact reproduction from the issue) is wrapped | `loadNestedMapWithBracketedKeyContainingDotAndColon()` |
| Bracket-prefixed user key with `.` only is wrapped | `loadNestedMapWithBracketedKeyContainingDot()` |
| Bracket-prefixed user key with `:` only is wrapped | `loadNestedMapWithBracketedKeyContainingColon()` |
| Internal collection-index keys (`[0]`, `[1]`, …) and Integer map keys (`[1]`) are unchanged | existing `loadArrayOf*` and `integerKeyBehaves` / `integerDeepKeyBehaves` tests still pass |

All `spring-beans` YAML tests (`YamlPropertiesFactoryBeanTests`, `YamlMapFactoryBeanTests`, `YamlProcessorTests` – 43 tests) pass locally.

## Impact

- `YamlPropertiesFactoryBean` / any `YamlProcessor` consumer that calls `getFlattenedMap`: bracket-prefixed YAML keys with `.` or `:` are now preserved with an additional bracket pair, matching what the Spring Boot binder expects for map keys with special characters.
- `YamlMapFactoryBean` (tree path) and existing internal bracket keys: unchanged.

Closes gh-27020