### PR TITLE
Add caching for Kotlin list serializers

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/KotlinSerializationSupport.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/KotlinSerializationSupport.java
@@ -30,6 +30,7 @@ import kotlin.reflect.jvm.ReflectJvmMapping;
 import kotlinx.serialization.KSerializer;
 import kotlinx.serialization.SerialFormat;
 import kotlinx.serialization.SerializersKt;
+import kotlinx.serialization.builtins.BuiltinSerializersKt;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.core.KotlinDetector;
@@ -60,6 +61,8 @@ public abstract class KotlinSerializationSupport<T extends SerialFormat> {
 	private final Map<Type, KSerializer<Object>> typeSerializerCache = new ConcurrentReferenceHashMap<>();
 
 	private final Map<KType, KSerializer<Object>> kTypeSerializerCache = new ConcurrentReferenceHashMap<>();
+
+	private final Map<KSerializer<Object>, KSerializer<List<Object>>> listSerializerCache = new ConcurrentReferenceHashMap<>();
 
 
 	private final T format;
@@ -178,5 +181,18 @@ public abstract class KotlinSerializationSupport<T extends SerialFormat> {
 			}
 		}
 		return serializer;
+	}
+
+	/**
+	 * Returns a serializer for {@code List} based on the given element serializer.
+	 * <p>This method wraps the Kotlin
+	 * {@link kotlinx.serialization.builtins.BuiltinSerializersKt#ListSerializer(KSerializer) ListSerializer}
+	 * function and caches the result for improved performance.
+	 * @param serializer the serializer for the list element type
+	 * @return a serializer for {@code List} with elements of the given type
+	 * @see <a href="https://kotlinlang.org/api/kotlinx.serialization/kotlinx-serialization-core/kotlinx.serialization.builtins/-list-serializer.html">ListSerializer</a>
+	 */
+	protected final KSerializer<List<Object>> listSerializer(KSerializer<Object> serializer) {
+		return this.listSerializerCache.computeIfAbsent(serializer, BuiltinSerializersKt::ListSerializer);
 	}
 }

--- a/spring-web/src/main/java/org/springframework/http/codec/json/KotlinSerializationJsonDecoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/json/KotlinSerializationJsonDecoder.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 import java.util.function.Predicate;
 
 import kotlinx.serialization.KSerializer;
-import kotlinx.serialization.builtins.BuiltinSerializersKt;
 import kotlinx.serialization.json.Json;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
@@ -121,7 +120,7 @@ public class KotlinSerializationJsonDecoder extends KotlinSerializationStringDec
 						if (signal.hasValue()) {
 							String value = Objects.requireNonNull(signal.get());
 							if (value.stripLeading().startsWith("[") && !List.class.isAssignableFrom(elementType.toClass())) {
-								KSerializer<List<Object>> listSerializer = BuiltinSerializersKt.ListSerializer(serializer);
+								KSerializer<List<Object>> listSerializer = listSerializer(serializer);
 								return flux
 										.flatMapIterable(string -> format().decodeFromString(listSerializer, string))
 										.onErrorMap(IllegalArgumentException.class, this::processException);


### PR DESCRIPTION
Changes made in 22bcac1eb5570dc4aac63b25a380c6f07fceeb0e introduced the creation of a new list serializer instance in `KotlinSerializationJsonDecoder` on each `decode()` invocation. This PR adds list serializer caching, similar to the existing element serializer caching, to address this.

See https://github.com/spring-projects/spring-framework/pull/36597

cc @sdeleuze 