### PR TITLE
Fix typo in `HttpServiceProxyFactory` example

### DIFF
--- a/framework-docs/modules/ROOT/pages/integration/rest-clients.adoc
+++ b/framework-docs/modules/ROOT/pages/integration/rest-clients.adoc
@@ -1252,7 +1252,7 @@ built-in decorators to suppress 404 exceptions and return a `ResponseEntity` wit
 [source,java,indent=0,subs="verbatim,quotes"]
 ----
 	// For RestClient
-	HttpServiceProxyFactory factory = HttpServiceProxyFactory.builderFor(restCqlientAdapter)
+	HttpServiceProxyFactory factory = HttpServiceProxyFactory.builderFor(restClientAdapter)
 			.exchangeAdapterDecorator(NotFoundRestClientAdapterDecorator::new)
 			.build();
 

--- a/framework-platform/framework-platform.gradle
+++ b/framework-platform/framework-platform.gradle
@@ -138,7 +138,6 @@ dependencies {
 		api("org.seleniumhq.selenium:selenium-java:4.41.0")
 		api("org.skyscreamer:jsonassert:1.5.3")
 		api("org.testng:testng:7.12.0")
-		api("org.webjars:underscorejs:1.8.3")
 		api("org.webjars:webjars-locator-lite:1.1.0")
 		api("org.xmlunit:xmlunit-assertj:2.10.4")
 		api("org.xmlunit:xmlunit-matchers:2.10.4")

--- a/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
@@ -238,7 +238,7 @@ public abstract class MimeTypeUtils {
 						break;
 					}
 				}
-				else if (ch == '"') {
+				else if (ch == '"' && mimeType.charAt(nextIndex - 1) != '\\') {
 					quoted = !quoted;
 				}
 				nextIndex++;

--- a/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
+++ b/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
@@ -98,13 +98,22 @@ class MimeTypeTests {
 	}
 
 	@Test
-	void parseQuotedSeparator() {
+	void parseQuotedParameterValue() {
 		String s = "application/xop+xml;charset=utf-8;type=\"application/soap+xml;action=\\\"https://x.y.z\\\"\"";
 		MimeType mimeType = MimeType.valueOf(s);
 		assertThat(mimeType.getType()).as("Invalid type").isEqualTo("application");
 		assertThat(mimeType.getSubtype()).as("Invalid subtype").isEqualTo("xop+xml");
 		assertThat(mimeType.getCharset()).as("Invalid charset").isEqualTo(StandardCharsets.UTF_8);
 		assertThat(mimeType.getParameter("type")).isEqualTo("\"application/soap+xml;action=\\\"https://x.y.z\\\"\"");
+	}
+
+	@Test
+	void parseParameterWithQuotedPair() {
+		String s = "text/plain;twelve=\"1\\\"2\"";
+		MimeType mimeType = MimeType.valueOf(s);
+		assertThat(mimeType.getType()).as("Invalid type").isEqualTo("text");
+		assertThat(mimeType.getSubtype()).as("Invalid subtype").isEqualTo("plain");
+		assertThat(mimeType.getParameter("twelve")).isEqualTo("\"1\\\"2\"");
 	}
 
 	@Test

--- a/spring-webflux/spring-webflux.gradle
+++ b/spring-webflux/spring-webflux.gradle
@@ -61,7 +61,7 @@ dependencies {
 	testRuntimeOnly("org.glassfish:jakarta.el")
 	testRuntimeOnly("org.jruby:jruby")
 	testRuntimeOnly("org.python:jython-standalone")
-	testRuntimeOnly("org.webjars:underscorejs")
+	testRuntimeOnly("org.webjars:momentjs:2.29.4")
 }
 
 test {

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/LiteWebJarsResourceResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/LiteWebJarsResourceResolver.java
@@ -90,7 +90,8 @@ public class LiteWebJarsResourceResolver extends AbstractResourceResolver {
 				.switchIfEmpty(Mono.defer(() -> {
 					String webJarResourcePath = findWebJarResourcePath(resourceUrlPath);
 					if (webJarResourcePath != null) {
-						return chain.resolveUrlPath(webJarResourcePath, locations);
+						Mono<String> fallback = (webJarResourcePath.endsWith("/")) ? Mono.just(webJarResourcePath) : Mono.empty();
+						return chain.resolveUrlPath(webJarResourcePath, locations).switchIfEmpty(fallback);
 					}
 					else {
 						return Mono.empty();

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/resource/LiteWebJarsResourceResolverTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/resource/LiteWebJarsResourceResolverTests.java
@@ -29,6 +29,8 @@ import org.springframework.web.testfixture.http.server.reactive.MockServerHttpRe
 import org.springframework.web.testfixture.server.MockServerWebExchange;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -80,8 +82,8 @@ class LiteWebJarsResourceResolverTests {
 
 	@Test
 	void resolveUrlWebJarResource() {
-		String file = "underscorejs/underscore.js";
-		String expected = "underscorejs/1.8.3/underscore.js";
+		String file = "momentjs/momentjs.js";
+		String expected = "momentjs/2.29.4/momentjs.js";
 		given(this.chain.resolveUrlPath(file, this.locations)).willReturn(Mono.empty());
 		given(this.chain.resolveUrlPath(expected, this.locations)).willReturn(Mono.just(expected));
 
@@ -93,9 +95,23 @@ class LiteWebJarsResourceResolverTests {
 	}
 
 	@Test
+	void resolveUrlWebJarDirectory() {
+		String folder = "momentjs/locale/";
+		String expected = "momentjs/2.29.4/locale/";
+		given(this.chain.resolveUrlPath(folder, this.locations)).willReturn(Mono.empty());
+		given(this.chain.resolveUrlPath(expected, this.locations)).willReturn(Mono.empty());
+
+		String actual = this.resolver.resolveUrlPath(folder, this.locations, this.chain).block(TIMEOUT);
+
+		assertThat(actual).isEqualTo(expected);
+		verify(this.chain, times(1)).resolveUrlPath(folder, this.locations);
+		verify(this.chain, times(1)).resolveUrlPath(expected, this.locations);
+	}
+
+	@Test
 	void resolveUrlWebJarResourceNotFound() {
-		String file = "something/something.js";
-		given(this.chain.resolveUrlPath(file, this.locations)).willReturn(Mono.empty());
+		String file = "momentjs/locale/unknown.js";
+		given(this.chain.resolveUrlPath(anyString(), eq(this.locations))).willReturn(Mono.empty());
 
 		String actual = this.resolver.resolveUrlPath(file, this.locations, this.chain).block(TIMEOUT);
 
@@ -134,11 +150,11 @@ class LiteWebJarsResourceResolverTests {
 
 	@Test
 	void resolveResourceWebJar() {
-		String file = "underscorejs/underscore.js";
+		String file = "momentjs/momentjs.js";
 		given(this.chain.resolveResource(this.exchange, file, this.locations)).willReturn(Mono.empty());
 
 		Resource expected = mock();
-		String expectedPath = "underscorejs/1.8.3/underscore.js";
+		String expectedPath = "momentjs/2.29.4/momentjs.js";
 		given(this.chain.resolveResource(this.exchange, expectedPath, this.locations))
 				.willReturn(Mono.just(expected));
 

--- a/spring-webmvc/spring-webmvc.gradle
+++ b/spring-webmvc/spring-webmvc.gradle
@@ -80,5 +80,5 @@ dependencies {
 	testRuntimeOnly("org.glassfish:jakarta.el")
 	testRuntimeOnly("org.jruby:jruby")
 	testRuntimeOnly("org.python:jython-standalone")
-	testRuntimeOnly("org.webjars:underscorejs")
+	testRuntimeOnly("org.webjars:momentjs:2.29.4")
 }

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/LiteWebJarsResourceResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/LiteWebJarsResourceResolver.java
@@ -88,7 +88,10 @@ public class LiteWebJarsResourceResolver extends AbstractResourceResolver {
 		if (path == null) {
 			String webJarResourcePath = findWebJarResourcePath(resourceUrlPath);
 			if (webJarResourcePath != null) {
-				return chain.resolveUrlPath(webJarResourcePath, locations);
+				path = chain.resolveUrlPath(webJarResourcePath, locations);
+				if (path == null && webJarResourcePath.endsWith("/")) {
+					path = webJarResourcePath;
+				}
 			}
 		}
 		return path;

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/resource/LiteWebJarsResourceResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/resource/LiteWebJarsResourceResolverTests.java
@@ -26,6 +26,8 @@ import org.springframework.core.io.Resource;
 import org.springframework.web.testfixture.servlet.MockHttpServletRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -74,8 +76,8 @@ class LiteWebJarsResourceResolverTests {
 
 	@Test
 	void resolveUrlWebJarResource() {
-		String file = "underscorejs/underscore.js";
-		String expected = "underscorejs/1.8.3/underscore.js";
+		String file = "momentjs/momentjs.js";
+		String expected = "momentjs/2.29.4/momentjs.js";
 		given(this.chain.resolveUrlPath(file, this.locations)).willReturn(null);
 		given(this.chain.resolveUrlPath(expected, this.locations)).willReturn(expected);
 
@@ -87,9 +89,23 @@ class LiteWebJarsResourceResolverTests {
 	}
 
 	@Test
+	void resolveUrlWebJarDirectory() {
+		String folder = "momentjs/locale/";
+		String expected = "momentjs/2.29.4/locale/";
+		given(this.chain.resolveUrlPath(folder, this.locations)).willReturn(null);
+		given(this.chain.resolveUrlPath(expected, this.locations)).willReturn(null);
+
+		String actual = this.resolver.resolveUrlPath(folder, this.locations, this.chain);
+
+		assertThat(actual).isEqualTo(expected);
+		verify(this.chain, times(1)).resolveUrlPath(folder, this.locations);
+		verify(this.chain, times(1)).resolveUrlPath(expected, this.locations);
+	}
+
+	@Test
 	void resolveUrlWebJarResourceNotFound() {
-		String file = "something/something.js";
-		given(this.chain.resolveUrlPath(file, this.locations)).willReturn(null);
+		String file = "momentjs/locale/unknown.js";
+		given(this.chain.resolveUrlPath(anyString(), eq(this.locations))).willReturn(null);
 
 		String actual = this.resolver.resolveUrlPath(file, this.locations, this.chain);
 
@@ -125,8 +141,8 @@ class LiteWebJarsResourceResolverTests {
 	@Test
 	void resolveResourceWebJar() {
 		Resource expected = mock();
-		String file = "underscorejs/underscore.js";
-		String expectedPath = "underscorejs/1.8.3/underscore.js";
+		String file = "momentjs/momentjs.js";
+		String expectedPath = "momentjs/2.29.4/momentjs.js";
 		given(this.chain.resolveResource(this.request, expectedPath, this.locations)).willReturn(expected);
 
 		Resource actual = this.resolver.resolveResource(this.request, file, this.locations, this.chain);


### PR DESCRIPTION
Fix a typo in the REST clients reference documentation.