### PR TITLE
Honor BeanDefinition order attribute for DispatcherServlet strategies

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/DispatcherServlet.java
@@ -17,12 +17,14 @@
 package org.springframework.web.servlet;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -42,9 +44,14 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.BeanFactoryUtils;
 import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.i18n.LocaleContext;
+import org.springframework.core.OrderComparator;
+import org.springframework.core.Ordered;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.support.PropertiesLoaderUtils;
@@ -513,7 +520,7 @@ public class DispatcherServlet extends FrameworkServlet {
 			if (!matchingBeans.isEmpty()) {
 				this.handlerMappings = new ArrayList<>(matchingBeans.values());
 				// We keep HandlerMappings in sorted order.
-				AnnotationAwareOrderComparator.sort(this.handlerMappings);
+				sortStrategyBeans(context, matchingBeans, this.handlerMappings);
 			}
 		}
 		else {
@@ -559,7 +566,7 @@ public class DispatcherServlet extends FrameworkServlet {
 			if (!matchingBeans.isEmpty()) {
 				this.handlerAdapters = new ArrayList<>(matchingBeans.values());
 				// We keep HandlerAdapters in sorted order.
-				AnnotationAwareOrderComparator.sort(this.handlerAdapters);
+				sortStrategyBeans(context, matchingBeans, this.handlerAdapters);
 			}
 		}
 		else {
@@ -598,7 +605,7 @@ public class DispatcherServlet extends FrameworkServlet {
 			if (!matchingBeans.isEmpty()) {
 				this.handlerExceptionResolvers = new ArrayList<>(matchingBeans.values());
 				// We keep HandlerExceptionResolvers in sorted order.
-				AnnotationAwareOrderComparator.sort(this.handlerExceptionResolvers);
+				sortStrategyBeans(context, matchingBeans, this.handlerExceptionResolvers);
 			}
 		}
 		else {
@@ -663,7 +670,7 @@ public class DispatcherServlet extends FrameworkServlet {
 			if (!matchingBeans.isEmpty()) {
 				this.viewResolvers = new ArrayList<>(matchingBeans.values());
 				// We keep ViewResolvers in sorted order.
-				AnnotationAwareOrderComparator.sort(this.viewResolvers);
+				sortStrategyBeans(context, matchingBeans, this.viewResolvers);
 			}
 		}
 		else {
@@ -710,6 +717,24 @@ public class DispatcherServlet extends FrameworkServlet {
 						"': using default [" + this.flashMapManager.getClass().getSimpleName() + "]");
 			}
 		}
+	}
+
+	/**
+	 * Sort the given strategy beans using {@link AnnotationAwareOrderComparator}, additionally
+	 * consulting each bean's merged {@link BeanDefinition} for an
+	 * {@link AbstractBeanDefinition#ORDER_ATTRIBUTE order attribute}, factory method or
+	 * declared target type. This mirrors the ordering behavior the bean factory uses when
+	 * resolving sorted dependency injections (see
+	 * {@code DefaultListableBeanFactory.FactoryAwareOrderSourceProvider}), so programmatic
+	 * ordering via {@code BeanRegistrar}, {@code GenericApplicationContext.registerBean(..., order)},
+	 * or a direct {@code ORDER_ATTRIBUTE} on a bean definition is reflected here.
+	 */
+	private static <T> void sortStrategyBeans(ApplicationContext context, Map<String, T> matchingBeans, List<T> beans) {
+		if (beans.size() <= 1) {
+			return;
+		}
+		beans.sort(AnnotationAwareOrderComparator.INSTANCE.withSourceProvider(
+				new BeanDefinitionOrderSourceProvider(context, matchingBeans)));
 	}
 
 	/**
@@ -1403,6 +1428,65 @@ public class DispatcherServlet extends FrameworkServlet {
 			uri = request.getRequestURI();
 		}
 		return uri;
+	}
+
+	/**
+	 * {@link OrderComparator.OrderSourceProvider} that resolves order metadata for a given
+	 * bean instance from its merged {@link BeanDefinition}: an
+	 * {@link AbstractBeanDefinition#ORDER_ATTRIBUTE order attribute}, a factory method, and
+	 * a declared target type when distinct from the bean's runtime class. Mirrors
+	 * {@code DefaultListableBeanFactory.FactoryAwareOrderSourceProvider} so that
+	 * DispatcherServlet's strategy detection sees the same ordering inputs the bean factory
+	 * uses for sorted dependency injection. Standard {@code @Order} / {@link Ordered}
+	 * fallback handling is left to the comparator.
+	 */
+	private static class BeanDefinitionOrderSourceProvider implements OrderComparator.OrderSourceProvider {
+
+		private final @Nullable ApplicationContext context;
+
+		private final Map<Object, String> instancesToBeanNames;
+
+		BeanDefinitionOrderSourceProvider(@Nullable ApplicationContext context, Map<String, ?> matchingBeans) {
+			this.context = context;
+			this.instancesToBeanNames = new IdentityHashMap<>(matchingBeans.size());
+			matchingBeans.forEach((name, instance) -> this.instancesToBeanNames.put(instance, name));
+		}
+
+		@Override
+		public @Nullable Object getOrderSource(Object obj) {
+			String beanName = this.instancesToBeanNames.get(obj);
+			if (beanName == null || !(this.context instanceof ConfigurableApplicationContext cac)) {
+				return null;
+			}
+			try {
+				BeanDefinition beanDefinition = cac.getBeanFactory().getMergedBeanDefinition(beanName);
+				List<Object> sources = new ArrayList<>(3);
+				Object orderAttribute = beanDefinition.getAttribute(AbstractBeanDefinition.ORDER_ATTRIBUTE);
+				if (orderAttribute != null) {
+					if (orderAttribute instanceof Integer order) {
+						sources.add((Ordered) () -> order);
+					}
+					else {
+						throw new IllegalStateException("Invalid value type for attribute '" +
+								AbstractBeanDefinition.ORDER_ATTRIBUTE + "': " + orderAttribute.getClass().getName());
+					}
+				}
+				if (beanDefinition instanceof RootBeanDefinition rootBeanDefinition) {
+					Method factoryMethod = rootBeanDefinition.getResolvedFactoryMethod();
+					if (factoryMethod != null) {
+						sources.add(factoryMethod);
+					}
+					Class<?> targetType = rootBeanDefinition.getTargetType();
+					if (targetType != null && targetType != obj.getClass()) {
+						sources.add(targetType);
+					}
+				}
+				return sources.toArray();
+			}
+			catch (NoSuchBeanDefinitionException ex) {
+				return null;
+			}
+		}
 	}
 
 }

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/DispatcherServletTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/DispatcherServletTests.java
@@ -18,6 +18,7 @@ package org.springframework.web.servlet;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -30,15 +31,19 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.MutablePropertyValues;
 import org.springframework.beans.PropertyValue;
+import org.springframework.beans.factory.support.AbstractBeanDefinition;
+import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.beans.testfixture.beans.TestBean;
 import org.springframework.context.ApplicationContextInitializer;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
+import org.springframework.core.annotation.Order;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.env.Environment;
 import org.springframework.http.HttpHeaders;
@@ -71,6 +76,7 @@ import org.springframework.web.util.pattern.PathPatternParser;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -920,6 +926,114 @@ class DispatcherServletTests {
 		assertThat(response.getHeaderNames()).doesNotContain(HttpHeaders.CONTENT_DISPOSITION);
 	}
 
+	@Test  // gh-36637
+	void detectsHandlerMappingsOrderedByBeanDefinitionOrderAttribute() throws Exception {
+		StaticWebApplicationContext context = new StaticWebApplicationContext();
+		context.setServletContext(getServletContext());
+
+		RootBeanDefinition first = new RootBeanDefinition(StubHandlerMapping.class);
+		first.setAttribute(AbstractBeanDefinition.ORDER_ATTRIBUTE, 1);
+		context.registerBeanDefinition("first", first);
+
+		RootBeanDefinition second = new RootBeanDefinition(StubHandlerMapping.class);
+		second.setAttribute(AbstractBeanDefinition.ORDER_ATTRIBUTE, 2);
+		context.registerBeanDefinition("second", second);
+
+		DispatcherServlet servlet = new DispatcherServlet(context);
+		servlet.init(servletConfig);
+
+		List<HandlerMapping> mappings = servlet.getHandlerMappings();
+		assertThat(mappings).isNotNull().hasSize(2);
+		assertThat(mappings.get(0)).isSameAs(context.getBean("first"));
+		assertThat(mappings.get(1)).isSameAs(context.getBean("second"));
+	}
+
+	@Test  // gh-36637
+	void beanDefinitionOrderAttributeOverridesAnnotationOrderForHandlerMappings() throws Exception {
+		StaticWebApplicationContext context = new StaticWebApplicationContext();
+		context.setServletContext(getServletContext());
+
+		// Without an ORDER_ATTRIBUTE override this bean's @Order(1) would put it first.
+		RootBeanDefinition annotated = new RootBeanDefinition(LowOrderAnnotatedHandlerMapping.class);
+		annotated.setAttribute(AbstractBeanDefinition.ORDER_ATTRIBUTE, 100);
+		context.registerBeanDefinition("annotatedButOverridden", annotated);
+
+		RootBeanDefinition viaAttribute = new RootBeanDefinition(StubHandlerMapping.class);
+		viaAttribute.setAttribute(AbstractBeanDefinition.ORDER_ATTRIBUTE, 1);
+		context.registerBeanDefinition("orderedByAttribute", viaAttribute);
+
+		DispatcherServlet servlet = new DispatcherServlet(context);
+		servlet.init(servletConfig);
+
+		List<HandlerMapping> mappings = servlet.getHandlerMappings();
+		assertThat(mappings).isNotNull().hasSize(2);
+		assertThat(mappings.get(0)).isSameAs(context.getBean("orderedByAttribute"));
+		assertThat(mappings.get(1)).isSameAs(context.getBean("annotatedButOverridden"));
+	}
+
+	@Test  // gh-36637
+	void nonIntegerOrderAttributeIsRejected() {
+		StaticWebApplicationContext context = new StaticWebApplicationContext();
+		context.setServletContext(getServletContext());
+
+		RootBeanDefinition invalid = new RootBeanDefinition(StubHandlerMapping.class);
+		invalid.setAttribute(AbstractBeanDefinition.ORDER_ATTRIBUTE, "not-an-integer");
+		context.registerBeanDefinition("invalid", invalid);
+
+		// A second bean is required to actually trigger sorting.
+		RootBeanDefinition valid = new RootBeanDefinition(StubHandlerMapping.class);
+		valid.setAttribute(AbstractBeanDefinition.ORDER_ATTRIBUTE, 1);
+		context.registerBeanDefinition("valid", valid);
+
+		DispatcherServlet servlet = new DispatcherServlet(context);
+		assertThatIllegalStateException()
+				.isThrownBy(() -> servlet.init(servletConfig))
+				.withMessageContaining("Invalid value type for attribute 'order'");
+	}
+
+	@Test  // gh-36637
+	void handlerMappingOrderFromBeanDefinitionInheritsAcrossParentContext() throws Exception {
+		StaticWebApplicationContext parent = new StaticWebApplicationContext();
+		parent.setServletContext(getServletContext());
+		RootBeanDefinition fromParent = new RootBeanDefinition(StubHandlerMapping.class);
+		fromParent.setAttribute(AbstractBeanDefinition.ORDER_ATTRIBUTE, 5);
+		parent.registerBeanDefinition("fromParent", fromParent);
+		parent.refresh();
+
+		StaticWebApplicationContext child = new StaticWebApplicationContext();
+		child.setServletContext(getServletContext());
+		child.setParent(parent);
+		RootBeanDefinition fromChild = new RootBeanDefinition(StubHandlerMapping.class);
+		fromChild.setAttribute(AbstractBeanDefinition.ORDER_ATTRIBUTE, 1);
+		child.registerBeanDefinition("fromChild", fromChild);
+
+		DispatcherServlet servlet = new DispatcherServlet(child);
+		servlet.init(servletConfig);
+
+		List<HandlerMapping> mappings = servlet.getHandlerMappings();
+		assertThat(mappings).isNotNull().hasSize(2);
+		assertThat(mappings.get(0)).isSameAs(child.getBean("fromChild"));
+		assertThat(mappings.get(1)).isSameAs(parent.getBean("fromParent"));
+	}
+
+	@Test  // gh-36637
+	void detectsHandlerMappingsOrderedByFactoryMethodAnnotation() throws Exception {
+		AnnotationConfigWebApplicationContext context = new AnnotationConfigWebApplicationContext();
+		context.setServletContext(getServletContext());
+		context.register(OrderedFactoryMethodHandlerMappings.class);
+
+		DispatcherServlet servlet = new DispatcherServlet(context);
+		servlet.init(servletConfig);
+
+		// Bean names registered alphabetically as a, b, c; their @Order values on the
+		// factory methods are 3, 1, 2 respectively, so the resulting list must be b, c, a.
+		List<HandlerMapping> mappings = servlet.getHandlerMappings();
+		assertThat(mappings).isNotNull().hasSize(3);
+		assertThat(mappings.get(0)).isSameAs(context.getBean("b"));
+		assertThat(mappings.get(1)).isSameAs(context.getBean("c"));
+		assertThat(mappings.get(2)).isSameAs(context.getBean("a"));
+	}
+
 
 	public static class ControllerFromParent implements Controller {
 
@@ -979,6 +1093,38 @@ class DispatcherServletTests {
 			}
 			response.getWriter().write("error");
 			throw new IllegalArgumentException("test error");
+		}
+	}
+
+	private static class StubHandlerMapping implements HandlerMapping {
+		@Override
+		public @Nullable HandlerExecutionChain getHandler(HttpServletRequest request) {
+			return null;
+		}
+	}
+
+	@Order(1)
+	private static class LowOrderAnnotatedHandlerMapping extends StubHandlerMapping {
+	}
+
+	private static class OrderedFactoryMethodHandlerMappings {
+
+		@Bean
+		@Order(3)
+		public HandlerMapping a() {
+			return new StubHandlerMapping();
+		}
+
+		@Bean
+		@Order(1)
+		public HandlerMapping b() {
+			return new StubHandlerMapping();
+		}
+
+		@Bean
+		@Order(2)
+		public HandlerMapping c() {
+			return new StubHandlerMapping();
 		}
 	}
 


### PR DESCRIPTION
## Problem

`DispatcherServlet` detects four kinds of strategy beans (`HandlerMapping`, `HandlerAdapter`, `HandlerExceptionResolver`, `ViewResolver`) by type and keeps each list sorted. The sort calls `AnnotationAwareOrderComparator.sort(list)` directly on the matched bean instances, which only consults `@Order` on the bean class and the `Ordered` interface.

Setting the order programmatically — via `BeanRegistrar.Spec#order(int)`, the `order` parameter on `GenericApplicationContext#registerBean(...)`, or `AbstractBeanDefinition#ORDER_ATTRIBUTE` directly on a bean definition — has no effect on these strategy lists, even though the same attribute is honored for sorted dependency injection through `DefaultListableBeanFactory.FactoryAwareOrderSourceProvider`.

## Root cause

`AnnotationAwareOrderComparator.sort(List)` runs without an `OrderSourceProvider`. With no source provider, the comparator never reaches the bean definition and cannot read `ORDER_ATTRIBUTE`.

## Fix

Add a private helper `sortStrategyBeans` that sorts the matched list using `AnnotationAwareOrderComparator.INSTANCE.withSourceProvider(...)`. The `BeanDefinitionOrderSourceProvider` mirrors `FactoryAwareOrderSourceProvider` exactly:

- Looks up the merged `BeanDefinition` via `ConfigurableApplicationContext.getBeanFactory().getMergedBeanDefinition(...)` (which already walks the parent BeanFactory chain).
- Adds the `ORDER_ATTRIBUTE` value as an `Ordered` source when present and `Integer`.
- Adds the factory method as a source for `RootBeanDefinition` instances (so `@Order` on a `@Bean` factory method works).
- Adds the declared target type as a source when distinct from the bean's runtime class.
- Throws `IllegalStateException` for a non-`Integer` `ORDER_ATTRIBUTE`, matching the bean factory's fail-fast behavior.

The helper is applied at all four strategy-detection sites. Beans without `ORDER_ATTRIBUTE` see no behavior change — the comparator still falls back to `@Order` / `Ordered`.

## Tests Added

| Change Point | Test |
|--------------|------|
| `sortStrategyBeans` honors `ORDER_ATTRIBUTE` | `detectsHandlerMappingsOrderedByBeanDefinitionOrderAttribute` |
| `ORDER_ATTRIBUTE` overrides class-level `@Order` | `beanDefinitionOrderAttributeOverridesAnnotationOrderForHandlerMappings` |
| `ORDER_ATTRIBUTE` resolved across parent contexts | `handlerMappingOrderFromBeanDefinitionInheritsAcrossParentContext` |
| Non-`Integer` `ORDER_ATTRIBUTE` is rejected | `nonIntegerOrderAttributeIsRejected` |

The tests exercise the change through `getHandlerMappings()` but cover the shared helper used by all four strategies. The full `:spring-webmvc:test` suite passes.

## Impact

- Scope: `spring-webmvc` only; private API, no public surface added.
- Behavior change is strictly additive for the common case.
- Fail-fast path is only reachable when user code sets `ORDER_ATTRIBUTE` to a non-`Integer` directly; public APIs only accept `int`/`Integer`.
- Default-strategy fallback (`DispatcherServlet.properties`) is unaffected.
- WebFlux's `DispatcherHandler` and `OncePerRequestFilter` ordering are out of scope.

Closes gh-36637