### PR TITLE
feat: Added an enum field for Content-Security-Policy response header…

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
@@ -225,6 +225,11 @@ public class HttpHeaders implements Serializable {
 	 */
 	public static final String CONTENT_RANGE = "Content-Range";
 	/**
+	 * The CORS {@code Content-Security-Policy} response header field name.
+	 * @see <a href="https://www.w3.org/TR/CSP3/">Content Security Policy Level 3 W3C recommendation</a>
+	 */
+	public static final String CONTENT_SECURITY_POLICY = "Content-Security-Policy";
+	/**
 	 * The HTTP {@code Content-Type} header field name.
 	 * @see <a href="https://tools.ietf.org/html/rfc7231#section-3.1.1.5">Section 3.1.1.5 of RFC 7231</a>
 	 */

--- a/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpHeaders.java
@@ -225,7 +225,7 @@ public class HttpHeaders implements Serializable {
 	 */
 	public static final String CONTENT_RANGE = "Content-Range";
 	/**
-	 * The CORS {@code Content-Security-Policy} response header field name.
+	 * The Security {@code Content-Security-Policy} response header field name.
 	 * @see <a href="https://www.w3.org/TR/CSP3/">Content Security Policy Level 3 W3C recommendation</a>
 	 */
 	public static final String CONTENT_SECURITY_POLICY = "Content-Security-Policy";


### PR DESCRIPTION
I have added the Content-Security-Policy response header as enum field. As per [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Security-Policy), the response header is considered baseline widely supported, so I figured it would make sense to get it added as an option to aid developers using this field.

Various Policy Directives are also defined in the same document with varying levels of support between browsers. I am not sure how to proceed with adding that kind of support into Spring Web at present moment, so I would like to use this PR as an opportunity to inquire about that as well! 