### PR TITLE
Fix fragment parsing for relative URI in RFC URI parser

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/RfcUriParser.java
+++ b/spring-web/src/main/java/org/springframework/web/util/RfcUriParser.java
@@ -178,7 +178,7 @@ abstract class RfcUriParser {
 						parser.capturePath().advanceTo(QUERY, i + 1);
 						break;
 					case '#':
-						parser.capturePath().advanceTo(FRAGMENT);
+						parser.capturePath().advanceTo(FRAGMENT, i + 1);
 						break;
 				}
 			}

--- a/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/UriComponentsBuilderTests.java
@@ -270,6 +270,27 @@ class UriComponentsBuilderTests {
 				UriComponentsBuilder.fromUriString("http://[1abc:2abc:3abc::5ABC:6abc:8080/resource", parserType));
 	}
 
+	@ParameterizedTest // gh-36759
+	@EnumSource
+	void fromUriStringRelativeUriWithFragment(ParserType parserType) {
+		UriComponents result = UriComponentsBuilder.fromUriString("path2#foo", parserType).build();
+		assertThat(result.getScheme()).isNull();
+		assertThat(result.getHost()).isNull();
+		assertThat(result.getPath()).isEqualTo("path2");
+		assertThat(result.getFragment()).isEqualTo("foo");
+		assertThat(result.toUriString()).isEqualTo("path2#foo");
+	}
+
+	@ParameterizedTest // gh-36759
+	@EnumSource
+	void fromUriStringRelativeUriWithEmptyFragment(ParserType parserType) {
+		UriComponents result = UriComponentsBuilder.fromUriString("path2#", parserType).build();
+		assertThat(result.getScheme()).isNull();
+		assertThat(result.getHost()).isNull();
+		assertThat(result.getPath()).isEqualTo("path2");
+		assertThat(result.getFragment()).isNull();
+	}
+
 	@ParameterizedTest // see SPR-11970
 	@EnumSource
 	void fromUriStringNoPathWithReservedCharInQuery(ParserType parserType) {


### PR DESCRIPTION
## Problem

`UriComponentsBuilder.fromUriString("path2#foo")` parses a relative URI with a fragment incorrectly:

```
path     = "path2"      (correct)
fragment = "path2#foo"  (should be "foo")
```

As a result, `toUriString()` produces `path2#path2#foo` instead of `path2#foo`.

## Root Cause

In `RfcUriParser`, every state that transitions into `FRAGMENT` advances the component index to `i + 1` so the fragment starts after the `#` character — except `SCHEME_OR_PATH`, which calls `advanceTo(FRAGMENT)` without the index argument. For a schemeless single-segment input the parser enters `SCHEME_OR_PATH` at index 0, the component index stays at 0, and `captureFragmentIfNotEmpty()` ends up returning `uri.substring(0, length)` — the entire input.

URIs with `/` in the path don't hit this code path: they leave `SCHEME_OR_PATH` for `PATH` on the first `/`, and `PATH`'s `#` case correctly passes `i + 1`. The `WhatWG` parser is also unaffected (it produces the expected output for this input today).

## Fix

In `RfcUriParser.SCHEME_OR_PATH`, change `advanceTo(FRAGMENT)` to `advanceTo(FRAGMENT, i + 1)`, mirroring the sibling `?` → `QUERY` transition two lines above and every other `→ FRAGMENT` transition in the parser.

## Tests Added

| Change Point | Test |
|---|---|
| `SCHEME_OR_PATH` `#` advances component index past `#` | `fromUriStringRelativeUriWithFragment` — verifies `path2#foo` splits as `path = "path2"`, `fragment = "foo"` and round-trips via `toUriString()` |
|  | `fromUriStringRelativeUriWithEmptyFragment` — boundary: trailing `#` with no fragment yields `path = "path2"`, `fragment = null` |

Both tests are parameterized over `ParserType` (`RFC` and `WHAT_WG`). Without the fix they fail for `RFC` and pass for `WHAT_WG` (which already handled this case correctly); with the fix both parsers agree.

The pre-existing assertion for `docs/guide/collections/designfaq.html#28` in `fromUriString(ParserType)` (which goes through the `PATH` state, not `SCHEME_OR_PATH`) continues to pass, providing regression coverage for multi-segment relative URIs.

## Impact

- Scope: `spring-web` only — one-line behavioral change in a private parser, no public API surface added.
- Affects: schemeless single-segment URIs with a fragment, when using the default `ParserType.RFC` parser.
- Unaffected: URIs with a scheme, authority, or `/` in the path (different parser states); `ParserType.WHAT_WG`.

Closes gh-36759