### PR TITLE
Replace thread-unsafe SimpleDateFormat with DateTimeFormatter in AbstractMockHttpServletRequestBuilder

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/request/AbstractMockHttpServletRequestBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/request/AbstractMockHttpServletRequestBuilder.java
@@ -25,8 +25,9 @@ import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -35,7 +36,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.TimeZone;
 import java.util.function.Consumer;
 
 import jakarta.servlet.ServletContext;
@@ -90,12 +90,9 @@ import org.springframework.web.util.UrlPathHelper;
 public abstract class AbstractMockHttpServletRequestBuilder<B extends AbstractMockHttpServletRequestBuilder<B>>
 		implements ConfigurableSmartRequestBuilder<B>, Mergeable {
 
-	private static final SimpleDateFormat simpleDateFormat;
-
-	static {
-		simpleDateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
-		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-	}
+	private static final DateTimeFormatter DATE_FORMAT =
+			DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
+					.withZone(ZoneId.of("GMT"));
 
 
 	private final HttpMethod method;
@@ -401,7 +398,7 @@ public abstract class AbstractMockHttpServletRequestBuilder<B extends AbstractMo
 
 		for (Object value : values) {
 			if (value instanceof Date date) {
-				this.headers.add(name, simpleDateFormat.format(date));
+				this.headers.add(name, DATE_FORMAT.format(date.toInstant()));
 			}
 			else {
 				this.headers.add(name, String.valueOf(value));

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/request/AbstractMockHttpServletRequestBuilder.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/request/AbstractMockHttpServletRequestBuilder.java
@@ -25,8 +25,9 @@ import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.Principal;
-import java.text.SimpleDateFormat;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -35,7 +36,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.TimeZone;
 import java.util.function.Consumer;
 
 import jakarta.servlet.ServletContext;
@@ -89,12 +89,9 @@ import org.springframework.web.util.UrlPathHelper;
 public abstract class AbstractMockHttpServletRequestBuilder<B extends AbstractMockHttpServletRequestBuilder<B>>
 		implements ConfigurableSmartRequestBuilder<B>, Mergeable {
 
-	private static final SimpleDateFormat simpleDateFormat;
-
-	static {
-		simpleDateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
-		simpleDateFormat.setTimeZone(TimeZone.getTimeZone("GMT"));
-	}
+	private static final DateTimeFormatter DATE_FORMAT =
+			DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US)
+					.withZone(ZoneId.of("GMT"));
 
 
 	private final HttpMethod method;
@@ -400,7 +397,7 @@ public abstract class AbstractMockHttpServletRequestBuilder<B extends AbstractMo
 
 		for (Object value : values) {
 			if (value instanceof Date date) {
-				this.headers.add(name, simpleDateFormat.format(date));
+				this.headers.add(name, DATE_FORMAT.format(date.toInstant()));
 			}
 			else {
 				this.headers.add(name, String.valueOf(value));


### PR DESCRIPTION
## Summary

Replace the static `SimpleDateFormat` instance with a thread-safe `DateTimeFormatter` in `AbstractMockHttpServletRequestBuilder`.

## Problem

A `static final SimpleDateFormat` is shared across all test request builder instances. `SimpleDateFormat.format()` mutates internal `Calendar` state and is not thread-safe. When tests run in parallel (e.g., with JUnit's `@Execution(CONCURRENT)`), concurrent calls to `header(name, dateValue)` can produce corrupt date strings or throw `ArrayIndexOutOfBoundsException`.

## Fix

Replace with `DateTimeFormatter.ofPattern(...)` using the same pattern (`EEE, dd MMM yyyy HH:mm:ss zzz`), locale (US), and timezone (UTC). `DateTimeFormatter` is immutable and thread-safe by design.