### PR TITLE
Add dedicated exception for HttpStatus.PRECONDITION_FAILED

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/HttpClientErrorException.java
+++ b/spring-web/src/main/java/org/springframework/web/client/HttpClientErrorException.java
@@ -126,6 +126,9 @@ public class HttpClientErrorException extends HttpStatusCodeException {
 				case GONE -> message != null ?
 						new Gone(message, statusText, headers, body, charset) :
 						new Gone(statusText, headers, body, charset);
+				case PRECONDITION_FAILED -> message != null ?
+						new PreconditionFailed(message, statusText, headers, body, charset) :
+						new PreconditionFailed(statusText, headers, body, charset);
 				case UNSUPPORTED_MEDIA_TYPE -> message != null ?
 						new UnsupportedMediaType(message, statusText, headers, body, charset) :
 						new UnsupportedMediaType(statusText, headers, body, charset);
@@ -291,6 +294,22 @@ public class HttpClientErrorException extends HttpStatusCodeException {
 
 		private Gone(String message, String statusText, HttpHeaders headers, byte @Nullable [] body, @Nullable Charset charset) {
 			super(message, HttpStatus.GONE, statusText, headers, body, charset);
+		}
+	}
+
+	/**
+	 * {@link HttpClientErrorException} for status HTTP 412 Precondition Failed.
+	 * @since 7.1
+	 */
+	@SuppressWarnings("serial")
+	public static final class PreconditionFailed extends HttpClientErrorException {
+
+		private PreconditionFailed(String statusText, HttpHeaders headers, byte @Nullable [] body, @Nullable Charset charset) {
+			super(HttpStatus.PRECONDITION_FAILED, statusText, headers, body, charset);
+		}
+
+		private PreconditionFailed(String message, String statusText, HttpHeaders headers, byte @Nullable [] body, @Nullable Charset charset) {
+			super(message, HttpStatus.PRECONDITION_FAILED, statusText, headers, body, charset);
 		}
 	}
 

--- a/spring-web/src/test/java/org/springframework/web/client/DefaultResponseErrorHandlerHttpStatusTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/DefaultResponseErrorHandlerHttpStatusTests.java
@@ -41,6 +41,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.GATEWAY_TIMEOUT;
+import static org.springframework.http.HttpStatus.GONE;
 import static org.springframework.http.HttpStatus.HTTP_VERSION_NOT_SUPPORTED;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.I_AM_A_TEAPOT;
@@ -48,9 +49,12 @@ import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED;
 import static org.springframework.http.HttpStatus.NOT_ACCEPTABLE;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 import static org.springframework.http.HttpStatus.NOT_IMPLEMENTED;
+import static org.springframework.http.HttpStatus.PRECONDITION_FAILED;
+import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
 import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 import static org.springframework.http.HttpStatus.TOO_MANY_REQUESTS;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
+import static org.springframework.http.HttpStatus.UNPROCESSABLE_CONTENT;
 import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 
 /**
@@ -98,8 +102,12 @@ class DefaultResponseErrorHandlerHttpStatusTests {
 			args(METHOD_NOT_ALLOWED, HttpClientErrorException.MethodNotAllowed.class),
 			args(NOT_ACCEPTABLE, HttpClientErrorException.NotAcceptable.class),
 			args(CONFLICT, HttpClientErrorException.Conflict.class),
+			args(GONE, HttpClientErrorException.Gone.class),
+			args(PRECONDITION_FAILED, HttpClientErrorException.PreconditionFailed.class),
+			args(UNSUPPORTED_MEDIA_TYPE, HttpClientErrorException.UnsupportedMediaType.class),
 			args(TOO_MANY_REQUESTS, HttpClientErrorException.TooManyRequests.class),
 			args(UNPROCESSABLE_ENTITY, HttpClientErrorException.UnprocessableEntity.class),
+			args(UNPROCESSABLE_CONTENT, HttpClientErrorException.UnprocessableContent.class),
 			args(I_AM_A_TEAPOT, HttpClientErrorException.class),
 			// 5xx
 			args(INTERNAL_SERVER_ERROR, HttpServerErrorException.InternalServerError.class),


### PR DESCRIPTION
Add a dedicated `HttpClientErrorException.PreconditionFailed` subclass for HTTP 412 status code, consistent with the existing pattern for other 4xx status codes (NotFound, Gone, Conflict, etc.).

This allows callers to catch `HttpClientErrorException.PreconditionFailed` directly rather than inspecting the status code on a generic `HttpClientErrorException`.