### PR TITLE
Remove javadoc.io links from Kotlin Conventions

### DIFF
--- a/buildSrc/src/main/java/org/springframework/build/KotlinConventions.java
+++ b/buildSrc/src/main/java/org/springframework/build/KotlinConventions.java
@@ -81,5 +81,4 @@ public class KotlinConventions {
 					spec.url("https://kotlinlang.org/api/kotlinx.coroutines/"));
 		});
 	}
-
 }

--- a/buildSrc/src/main/java/org/springframework/build/KotlinConventions.java
+++ b/buildSrc/src/main/java/org/springframework/build/KotlinConventions.java
@@ -79,14 +79,6 @@ public class KotlinConventions {
 					spec.url("https://www.reactive-streams.org/reactive-streams-1.0.3-javadoc/"));
 			externalDocumentationLinks.register("kotlinx-coroutines", spec ->
 					spec.url("https://kotlinlang.org/api/kotlinx.coroutines/"));
-			externalDocumentationLinks.register("hamcrest", spec ->
-					spec.url("https://javadoc.io/doc/org.hamcrest/hamcrest/2.1/"));
-			externalDocumentationLinks.register("jakarta-servlet", spec -> {
-				spec.url("https://javadoc.io/doc/jakarta.servlet/jakarta.servlet-api/latest/");
-				spec.packageListUrl("https://javadoc.io/doc/jakarta.servlet/jakarta.servlet-api/latest/element-list");
-			});
-			externalDocumentationLinks.register("rsocket-core", spec ->
-					spec.url("https://javadoc.io/static/io.rsocket/rsocket-core/1.1.1/"));
 		});
 	}
 


### PR DESCRIPTION
Removed remaining `javadoc.io` links from Kotlin Dokka external documentation configuration.

Addresses [#36779](https://github.com/spring-projects/spring-framework/issues/36779)
