### PR TITLE
Use immutable map for static cache in TypeDescriptor

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/TypeDescriptor.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/TypeDescriptor.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -36,6 +35,7 @@ import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.lang.Contract;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.CollectionUtils;
 
 /**
  * Contextual descriptor about a type to convert from or to.
@@ -55,7 +55,7 @@ import org.springframework.util.ClassUtils;
 @SuppressWarnings("serial")
 public class TypeDescriptor implements Serializable {
 
-	private static final Map<Class<?>, TypeDescriptor> commonTypesCache = new HashMap<>(32);
+	private static final Map<Class<?>, TypeDescriptor> commonTypesCache;
 
 	private static final Class<?>[] CACHED_COMMON_TYPES = {
 			boolean.class, Boolean.class, byte.class, Byte.class, char.class, Character.class,
@@ -63,9 +63,11 @@ public class TypeDescriptor implements Serializable {
 			long.class, Long.class, short.class, Short.class, String.class, Object.class};
 
 	static {
+		Map<Class<?>, TypeDescriptor> commonTypes = CollectionUtils.newHashMap(CACHED_COMMON_TYPES.length);
 		for (Class<?> preCachedClass : CACHED_COMMON_TYPES) {
-			commonTypesCache.put(preCachedClass, valueOf(preCachedClass));
+			commonTypes.put(preCachedClass, new TypeDescriptor(ResolvableType.forClass(preCachedClass), null, null));
 		}
+		commonTypesCache = Map.copyOf(commonTypes);
 	}
 
 


### PR DESCRIPTION
Switch to Map.of for the static commonTypesCache field for immutability.

The rationale for this change is one of hygiene (the read-only map should be immutable), and the fact that the immutable collections added in Java 9 are "trusted" by the JVM and therefore can be constant folded (see a similar JDK issue [here](https://bugs.openjdk.org/browse/JDK-8384430) where legacy code is being switched the modern immutable collections). I don't have any benchmark supporting any claim in that area, and it would be workload dependent obviously, but it seems like one of those worthwhile changes regardless. If there's alignment there are likely a few other places in spring that could be modernized in this respect.

Note that The `valueOf` static factory couldn't be used here since it tries to read from the static `commonTypesCache` field, which with this change wouldn't be initialized yet.