### PR TITLE
Optimize ClassNameReader.getClassName via direct ASM API

### DIFF
--- a/spring-core/src/main/java/org/springframework/cglib/core/ClassNameReader.java
+++ b/spring-core/src/main/java/org/springframework/cglib/core/ClassNameReader.java
@@ -34,9 +34,11 @@ public class ClassNameReader {
 	private static class EarlyExitException extends RuntimeException {
 	}
 
+	// SPRING PATCH BEGIN
 	public static String getClassName(ClassReader r) {
-		return getClassInfo(r)[0];
+		return r.getClassName().replace('/', '.');
 	}
+	// SPRING PATCH END
 
     public static String[] getClassInfo(ClassReader r) {
         final List<String> array = new ArrayList<>();


### PR DESCRIPTION

## Change

`ClassNameReader.getClassName` now calls `ClassReader.getClassName()` directly instead of delegating to the visitor-based `getClassInfo(r)[0]`.

>  `ClassReader` scans the class file during construction and indexes the offset of every constant pool entry, so it can locate `this_class` directly.
Rather than spinning up a visitor to re-traverse the class header, this change reuses that index and reads the class name in place.

**Before**

```java
public static String getClassName(ClassReader r) {
    return getClassInfo(r)[0];
}
```

**After**

```java
// SPRING PATCH BEGIN
public static String getClassName(ClassReader r) {
    return r.getClassName().replace('/', '.');
}
// SPRING PATCH END
```

## Motivation

`ClassNameReader.getClassName` is a small utility that extracts the FQCN from class bytecode (e.g. `byte[]` → `"com.example.MyService"`).
It sits **on the hot path of every CGLIB proxy class definition**.

The previous implementation did all of the following:

- Allocated an `ArrayList` and a `ClassVisitor`.
- Walked the class header, UTF-8 decoding `this_class`, `super_class`, and every interface name.
- Called `replace('/', '.')` and `array.add()` on each name.
- Threw `EARLY_EXIT` and caught it to break out of the visitor.
- Built the result array with `toArray(new String[0])`.

After all that work, the caller used **only `[0]` of the result** — `super_class` and the interface names were thrown away.

```java
public static String getClassName(ClassReader r) {
    return getClassInfo(r)[0];
}
```

## Impact

Per call, the new path:

- Cuts object allocations from ~7 down to 2.
- Skips UTF-8 decoding of `super_class` and every interface name.
- Removes the visitor dispatch and the `throw` / `catch` round-trip.

### JMH measurements

`ClassNameReaderBenchmark` (5 forks × 5 warmup × 5 measurement)

**Without additional interfaces** — proxy = `extends ProxyTarget implements Factory`

| Path                                  |          Score |   Memory Allocation |
|---------------------------------------|---------------:|--------------------:|
| `getClassInfo(r)[0]`                  |   216.9 ns/op  |     816 B/op        |
| `r.getClassName().replace('/', '.')`  | **22.0 ns/op** | **432 B/op**        |
| Improvement                           | **9.9× faster** | **1.9× less (-47%)** |

**With 3 additional interfaces** — `Cloneable, Comparable, Runnable`

| Path                                  |          Score |   Memory Allocation |
|---------------------------------------|---------------:|--------------------:|
| `getClassInfo(r)[0]`                  |   314.5 ns/op  |    1024 B/op        |
| `r.getClassName().replace('/', '.')`  | **21.7 ns/op** | **432 B/op**        |
| Improvement                           | **14.5× faster** | **2.4× less (-58%)** |

**How to run**

```bash
./gradlew :spring-core:jmhJar
java -jar spring-core/build/libs/spring-core-<version>-jmh.jar \
    "ClassNameReaderBenchmark" -prof gc
```

> On the current `main` branch, `<version>` is `7.1.0-SNAPSHOT`.

The new path's time and allocation stay constant regardless of how many interfaces the proxy declares. The legacy path, by contrast, decodes every interface name from the class header and runs the extra `replace` / `add` work — so the gap widens as the proxy implements more interfaces.
