### PR TITLE
Deprecate setDisallowedFields in DataBinder for removal

### DIFF
--- a/framework-docs/modules/ROOT/partials/web/web-data-binding-model-design.adoc
+++ b/framework-docs/modules/ROOT/partials/web/web-data-binding-model-design.adoc
@@ -28,8 +28,8 @@ For example:
 	}
 ----
 
-NOTE: It is also possible to configure `disallowedFields`, but that's fragile, and
-due to be https://github.com/spring-projects/spring-framework/issues/36802[deprecated] in Spring Framework 7.1.
+NOTE: It is also possible to configure `disallowedFields`, but that's fragile and
+https://github.com/spring-projects/spring-framework/issues/36802[deprecated as of Spring Framework 7.1].
 It is easy to overlook fields or introduce additional fields over time that should also be excluded.
 
 By default, `DataBinder` applies both constructor and setter binding.

--- a/spring-context/src/main/java/org/springframework/validation/DataBinder.java
+++ b/spring-context/src/main/java/org/springframework/validation/DataBinder.java
@@ -508,7 +508,6 @@ public class DataBinder implements PropertyEditorRegistry, TypeConverter {
 	 * account.
 	 * <p>More sophisticated matching can be implemented by overriding the
 	 * {@link #isAllowed} method.
-	 * <p>Alternatively, specify a list of <i>disallowed</i> field patterns.
 	 * <p>Used for binding to fields with {@link #bind(PropertyValues)}, and not
 	 * applicable to constructor binding via {@link #construct},
 	 * which uses only the values it needs.
@@ -551,7 +550,9 @@ public class DataBinder implements PropertyEditorRegistry, TypeConverter {
 	 * @param disallowedFields array of disallowed field patterns
 	 * @see #setAllowedFields
 	 * @see #isAllowed(String)
+	 * @deprecated as of 7.1, in favor of {@link #setAllowedFields}.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public void setDisallowedFields(String @Nullable ... disallowedFields) {
 		if (disallowedFields == null) {
 			this.disallowedFields = null;
@@ -569,7 +570,9 @@ public class DataBinder implements PropertyEditorRegistry, TypeConverter {
 	 * Return the field patterns that should <i>not</i> be allowed for binding.
 	 * @return array of disallowed field patterns
 	 * @see #setDisallowedFields(String...)
+	 * @deprecated as of 7.1, in favor of {@link #getAllowedFields()}.
 	 */
+	@Deprecated(since = "7.1", forRemoval = true)
 	public String @Nullable [] getDisallowedFields() {
 		return this.disallowedFields;
 	}

--- a/spring-context/src/test/java/org/springframework/validation/DataBinderTests.java
+++ b/spring-context/src/test/java/org/springframework/validation/DataBinderTests.java
@@ -715,6 +715,7 @@ class DataBinderTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void bindingWithDisallowedFields() throws BindException {
 		TestBean rod = new TestBean();
 		DataBinder binder = new DataBinder(rod);
@@ -734,6 +735,7 @@ class DataBinderTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void bindingWithAllowedAndDisallowedFields() throws BindException {
 		TestBean rod = new TestBean();
 		DataBinder binder = new DataBinder(rod);
@@ -752,6 +754,7 @@ class DataBinderTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void bindingWithOverlappingAllowedAndDisallowedFields() throws BindException {
 		TestBean rod = new TestBean();
 		DataBinder binder = new DataBinder(rod);
@@ -797,6 +800,7 @@ class DataBinderTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void bindingWithAllowedAndDisallowedMapFields() throws BindException {
 		TestBean rod = new TestBean();
 		DataBinder binder = new DataBinder(rod);

--- a/spring-web/src/test/java/org/springframework/web/bind/support/WebRequestDataBinderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/bind/support/WebRequestDataBinderTests.java
@@ -329,6 +329,7 @@ class WebRequestDataBinderTests {
 		}
 
 		@Test
+		@SuppressWarnings("removal")
 		void shouldNotTriggerBindingWhenFieldIsDisallowed() {
 			TestBean tb = new TestBean();
 
@@ -363,6 +364,7 @@ class WebRequestDataBinderTests {
 
 		@ParameterizedTest
 		@ValueSource(strings = { "stringArray*", "stringArray[]" })
+		@SuppressWarnings("removal")
 		void shouldNotTriggerBindingWhenFieldIsDisallowedWithEmptyArrayIndex(String disallowedField) {
 			TestBean tb = new TestBean();
 
@@ -398,6 +400,7 @@ class WebRequestDataBinderTests {
 
 		@ParameterizedTest
 		@ValueSource(strings = { "someMap*", "someMap[*]", "someMap[key1]" })
+		@SuppressWarnings("removal")
 		void shouldNotTriggerAutoGrowWhenFieldIsDisallowed(String disallowedField) {
 			TestBean tb = new TestBean();
 			tb.setSomeMap(null);

--- a/spring-web/src/test/java/org/springframework/web/method/annotation/InitBinderDataBinderFactoryTests.java
+++ b/spring-web/src/test/java/org/springframework/web/method/annotation/InitBinderDataBinderFactoryTests.java
@@ -56,6 +56,7 @@ class InitBinderDataBinderFactoryTests {
 
 
 	@Test
+	@SuppressWarnings("removal")
 	void createBinder() throws Exception {
 		WebDataBinderFactory factory = createFactory("initBinder", WebDataBinder.class);
 		WebDataBinder dataBinder = factory.createBinder(this.webRequest, null, null);
@@ -76,6 +77,7 @@ class InitBinderDataBinderFactoryTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void createBinderWithAttrName() throws Exception {
 		WebDataBinderFactory factory = createFactory("initBinderWithAttributeName", WebDataBinder.class);
 		WebDataBinder dataBinder = factory.createBinder(this.webRequest, null, "foo");
@@ -85,6 +87,7 @@ class InitBinderDataBinderFactoryTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void createBinderWithAttrNameNoMatch() throws Exception {
 		WebDataBinderFactory factory = createFactory("initBinderWithAttributeName", WebDataBinder.class);
 		WebDataBinder dataBinder = factory.createBinder(this.webRequest, null, "invalidName");
@@ -93,6 +96,7 @@ class InitBinderDataBinderFactoryTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void createBinderNullAttrName() throws Exception {
 		WebDataBinderFactory factory = createFactory("initBinderWithAttributeName", WebDataBinder.class);
 		WebDataBinder dataBinder = factory.createBinder(this.webRequest, null, null);
@@ -108,6 +112,7 @@ class InitBinderDataBinderFactoryTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void createBinderTypeConversion() throws Exception {
 		this.webRequest.getNativeRequest(MockHttpServletRequest.class).setParameter("requestParam", "22");
 		this.argumentResolvers.addResolver(new RequestParamMethodArgumentResolver(null, false));
@@ -138,11 +143,13 @@ class InitBinderDataBinderFactoryTests {
 	private static class InitBinderHandler {
 
 		@InitBinder
+		@SuppressWarnings("removal")
 		public void initBinder(WebDataBinder dataBinder) {
 			dataBinder.setDisallowedFields("id");
 		}
 
 		@InitBinder(value="foo")
+		@SuppressWarnings("removal")
 		public void initBinderWithAttributeName(WebDataBinder dataBinder) {
 			dataBinder.setDisallowedFields("id");
 		}
@@ -153,6 +160,7 @@ class InitBinderDataBinderFactoryTests {
 		}
 
 		@InitBinder
+		@SuppressWarnings("removal")
 		public void initBinderTypeConversion(WebDataBinder dataBinder, @RequestParam int requestParam) {
 			dataBinder.setDisallowedFields("requestParam-" + requestParam);
 		}

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/InitBinderBindingContextTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/InitBinderBindingContextTests.java
@@ -62,6 +62,7 @@ class InitBinderBindingContextTests {
 
 
 	@Test
+	@SuppressWarnings("removal")
 	void createBinder() throws Exception {
 		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/"));
 		BindingContext context = createBindingContext("initBinder", WebDataBinder.class);
@@ -84,6 +85,7 @@ class InitBinderBindingContextTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void createBinderWithAttrName() throws Exception {
 		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/"));
 		BindingContext context = createBindingContext("initBinderWithAttributeName", WebDataBinder.class);
@@ -94,6 +96,7 @@ class InitBinderBindingContextTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void createBinderWithAttrNameNoMatch() throws Exception {
 		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/"));
 		BindingContext context = createBindingContext("initBinderWithAttributeName", WebDataBinder.class);
@@ -103,6 +106,7 @@ class InitBinderBindingContextTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void createBinderNullAttrName() throws Exception {
 		MockServerWebExchange exchange = MockServerWebExchange.from(MockServerHttpRequest.get("/"));
 		BindingContext context = createBindingContext("initBinderWithAttributeName", WebDataBinder.class);
@@ -119,6 +123,7 @@ class InitBinderBindingContextTests {
 	}
 
 	@Test
+	@SuppressWarnings("removal")
 	void createBinderTypeConversion() throws Exception {
 		MockServerHttpRequest request = MockServerHttpRequest.get("/path?requestParam=22").build();
 		MockServerWebExchange exchange = MockServerWebExchange.from(request);
@@ -260,11 +265,13 @@ class InitBinderBindingContextTests {
 	private static class InitBinderHandler {
 
 		@InitBinder
+		@SuppressWarnings("removal")
 		public void initBinder(WebDataBinder dataBinder) {
 			dataBinder.setDisallowedFields("id");
 		}
 
 		@InitBinder(value="foo")
+		@SuppressWarnings("removal")
 		public void initBinderWithAttributeName(WebDataBinder dataBinder) {
 			dataBinder.setDisallowedFields("id");
 		}
@@ -275,6 +282,7 @@ class InitBinderBindingContextTests {
 		}
 
 		@InitBinder
+		@SuppressWarnings("removal")
 		public void initBinderTypeConversion(WebDataBinder dataBinder, @RequestParam int requestParam) {
 			dataBinder.setDisallowedFields("requestParam-" + requestParam);
 		}


### PR DESCRIPTION
This PR deprecates `setDisallowedFields()` and `getDisallowedFields()` in `DataBinder` as discussed in #36802.

## Changes

- Deprecate `setDisallowedFields()` and `getDisallowedFields()` in `DataBinder` with `@Deprecated(since = "7.1", forRemoval = true)`
- Remove the reference to `disallowedFields` as an alternative in `setAllowedFields()` Javadoc
- Update reference documentation to reflect the deprecated status
- Add `@SuppressWarnings("removal")` to affected test methods

Closes gh-36802
