### PR TITLE
Fix client disconnect logged as error in WebFlux

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/server/adapter/HttpWebHandlerAdapter.java
+++ b/spring-web/src/main/java/org/springframework/web/server/adapter/HttpWebHandlerAdapter.java
@@ -362,15 +362,13 @@ public class HttpWebHandlerAdapter extends WebHandlerDecorator implements HttpHa
 		ServerHttpResponse response = exchange.getResponse();
 		String logPrefix = exchange.getLogPrefix();
 
-		// Sometimes a remote call error can look like a disconnected client.
-		// Try to set the response first before the "isDisconnectedClient" check.
-
-		if (response.setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR)) {
-			logger.error(logPrefix + "500 Server Error for " + formatRequest(request), ex);
+		// Check for client disconnect first; DisconnectedClientHelper already excludes remote-call wrappers.
+		if (disconnectedClientHelper.checkAndLogClientDisconnectedException(ex)) {
+			observationContext.setConnectionAborted(true);
 			return Mono.empty();
 		}
-		else if (disconnectedClientHelper.checkAndLogClientDisconnectedException(ex)) {
-			observationContext.setConnectionAborted(true);
+		else if (response.setStatusCode(HttpStatus.INTERNAL_SERVER_ERROR)) {
+			logger.error(logPrefix + "500 Server Error for " + formatRequest(request), ex);
 			return Mono.empty();
 		}
 		else {

--- a/spring-web/src/test/java/org/springframework/web/server/adapter/HttpWebHandlerAdapterObservabilityTests.java
+++ b/spring-web/src/test/java/org/springframework/web/server/adapter/HttpWebHandlerAdapterObservabilityTests.java
@@ -17,6 +17,7 @@
 package org.springframework.web.server.adapter;
 
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
@@ -25,7 +26,10 @@ import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccess
 import io.micrometer.observation.tck.TestObservationRegistry;
 import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import reactor.core.publisher.Mono;
+import reactor.netty.channel.AbortedException;
 import reactor.test.StepVerifier;
 
 import org.springframework.http.HttpStatus;
@@ -86,6 +90,36 @@ class HttpWebHandlerAdapterObservabilityTests {
 		HttpStatusSuccessStubWebHandler targetHandler = new HttpStatusSuccessStubWebHandler(HttpStatus.OK);
 		StepVerifier.create(createWebHandler(targetHandler).handle(this.request, this.response)).thenCancel().verify();
 		assertThatHttpObservation().hasLowCardinalityKeyValue("outcome", "UNKNOWN");
+	}
+
+	@ParameterizedTest
+	@MethodSource("disconnectExceptions")
+	void handlerShouldMarkConnectionAbortedForClientDisconnect(Exception disconnectEx) {
+		// ThrowingExceptionWebHandler captures ServerRequestObservationContext from exchange
+		// attributes; handleUnresolvedError operates on the same object, so setConnectionAborted(true)
+		// is visible after block().
+		ThrowingExceptionWebHandler throwingHandler = new ThrowingExceptionWebHandler(disconnectEx);
+		createWebHandler(throwingHandler).handle(this.request, this.response).block();
+		assertThat(throwingHandler.observationContext).isPresent();
+		assertThat(throwingHandler.observationContext.get().isConnectionAborted()).isTrue();
+	}
+
+	static List<Exception> disconnectExceptions() {
+		// Verified by DisconnectedClientHelperTests.disconnectedExceptions() and exceptionPhrases()
+		return List.of(
+				new AbortedException(""),
+				new IOException("Broken pipe")
+		);
+	}
+
+	@Test
+	void handlerShouldNotMarkConnectionAbortedForServerError() {
+		ThrowingExceptionWebHandler throwingHandler =
+				new ThrowingExceptionWebHandler(new IllegalStateException("server error"));
+		createWebHandler(throwingHandler).handle(this.request, this.response).block();
+		assertThat(throwingHandler.observationContext).isPresent();
+		assertThat(throwingHandler.observationContext.get().isConnectionAborted()).isFalse();
+		assertThat(this.response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 
 	private HttpWebHandlerAdapter createWebHandler(WebHandler targetHandler) {


### PR DESCRIPTION
In HttpWebHandlerAdapter.handleUnresolvedError(), when a client
disconnects before the response is committed (e.g., the client
sends a partial request body and closes the connection), the
resulting AbortedException arrives while setStatusCode(500)
still returns true. This causes the handler to immediately log
a 500 Server Error at ERROR level and return, making the
checkAndLogClientDisconnectedException branch unreachable.

This commit moves the disconnect check before the 500 status
assignment. DisconnectedClientHelper.isClientDisconnectedException
already excludes outbound/remote-call exception wrappers, so the
reordering does not affect server-side error handling.

Closes gh-36811