### PR TITLE
Add TestCompiler deprecation warning shortcut

### DIFF
--- a/spring-beans/src/test/java/org/springframework/beans/factory/aot/CodeWarningsTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/aot/CodeWarningsTests.java
@@ -49,7 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CodeWarningsTests {
 
 	private static final TestCompiler TEST_COMPILER = TestCompiler.forSystem()
-			.withCompilerOptions("-Xlint:all", "-Werror");
+			.failOnDeprecationWarning();
 
 	private final CodeWarnings codeWarnings = new CodeWarnings();
 

--- a/spring-core-test/src/main/java/org/springframework/core/test/tools/TestCompiler.java
+++ b/spring-core-test/src/main/java/org/springframework/core/test/tools/TestCompiler.java
@@ -231,6 +231,18 @@ public final class TestCompiler {
 	}
 
 	/**
+	 * Create a new {@link TestCompiler} instance that fails if a deprecation
+	 * warning is encountered. This sets the {@code -Xlint:deprecation},
+	 * {@code -Xlint:removal}, and {@code -Werror} compiler options.
+	 * @return a new {@code TestCompiler} instance
+	 * @since 7.1
+	 * @see #withCompilerOptions(String...)
+	 */
+	public TestCompiler failOnDeprecationWarning() {
+		return withCompilerOptions("-Xlint:deprecation", "-Xlint:removal", "-Werror");
+	}
+
+	/**
 	 * Compile content from this instance along with the additional provided
 	 * content.
 	 * @param content the additional content to compile

--- a/spring-core-test/src/test/java/org/springframework/core/test/tools/TestCompilerTests.java
+++ b/spring-core-test/src/test/java/org/springframework/core/test/tools/TestCompilerTests.java
@@ -109,6 +109,21 @@ class TestCompilerTests {
 			}
 			""";
 
+	private static final String HELLO_DEPRECATED_FOR_REMOVAL = """
+			package com.example;
+
+			import java.util.function.Supplier;
+
+			public class Hello implements Supplier<String> {
+
+				@Deprecated(forRemoval = true)
+				public String get() {
+					return "Hello Deprecated";
+				}
+
+			}
+			""";
+
 	@Test
 	@SuppressWarnings("unchecked")
 	void compileWhenHasDifferentClassesWithSameClassNameCompilesBoth() {
@@ -206,6 +221,101 @@ class TestCompilerTests {
 				""");
 		TestCompiler.forSystem().failOnWarning().withSources(
 				SourceFile.of(HELLO_DEPRECATED), main).compile(compiled -> {
+			Supplier<String> supplier = compiled.getInstance(Supplier.class,
+					"com.example.Hello");
+			assertThat(supplier.get()).isEqualTo("Hello Deprecated");
+		});
+	}
+
+	@Test
+	void compileWhenSourceUseDeprecateCodeAndFailOnDeprecationWarningIsSet() {
+		SourceFile main = sourceFileUsingDeprecatedHello("""
+				public static void main(String[] args) {
+					new Hello().get();
+				}
+				""");
+		assertThatExceptionOfType(CompilationException.class).isThrownBy(
+				() -> TestCompiler.forSystem().failOnDeprecationWarning().withSources(
+						SourceFile.of(HELLO_DEPRECATED), main).compile(compiled -> {
+				})).satisfies(compilationException -> {
+			assertThat(compilationException.getProblems(Diagnostic.Kind.ERROR)).singleElement()
+					.satisfies(error -> assertThat(error.message())
+							.contains("-Werror"));
+			assertThat(compilationException.getProblems(Diagnostic.Kind.MANDATORY_WARNING)).singleElement()
+					.satisfies(warning -> assertThat(warning.message())
+							.contains("get()", "com.example.Hello"));
+		});
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void compileWhenSourceUseDeprecateCodeAndFailOnDeprecationWarningWithSuppressWarnings() {
+		SourceFile main = sourceFileUsingDeprecatedHello("""
+				@SuppressWarnings("deprecation")
+				public static void main(String[] args) {
+					new Hello().get();
+				}
+				""");
+		TestCompiler.forSystem().failOnDeprecationWarning().withSources(
+				SourceFile.of(HELLO_DEPRECATED), main).compile(compiled -> {
+			Supplier<String> supplier = compiled.getInstance(Supplier.class,
+					"com.example.Hello");
+			assertThat(supplier.get()).isEqualTo("Hello Deprecated");
+		});
+	}
+
+	@Test
+	void compileWhenSourceExposesDeprecateTypeAndFailOnDeprecationWarningIsSet() {
+		SourceFile main = sourceFileUsingDeprecatedHello("""
+				public Hello getHello() {
+					return new Hello();
+				}
+				""");
+		assertThatExceptionOfType(CompilationException.class).isThrownBy(
+				() -> TestCompiler.forSystem().failOnDeprecationWarning().withSources(
+						SourceFile.of(HELLO_WORLD), main).compile(compiled -> {
+				})).satisfies(compilationException -> {
+			assertThat(compilationException.getProblems(Diagnostic.Kind.ERROR)).singleElement()
+					.satisfies(error -> assertThat(error.message())
+							.contains("-Werror"));
+			assertThat(compilationException.getProblems(Diagnostic.Kind.MANDATORY_WARNING))
+					.hasSize(2)
+					.allSatisfy(warning -> assertThat(warning.message())
+							.contains("Hello", "com.example"));
+		});
+	}
+
+	@Test
+	void compileWhenSourceUseDeprecateForRemovalCodeAndFailOnDeprecationWarningIsSet() {
+		SourceFile main = sourceFileUsingDeprecatedHello("""
+				public static void main(String[] args) {
+					new Hello().get();
+				}
+				""");
+		assertThatExceptionOfType(CompilationException.class).isThrownBy(
+				() -> TestCompiler.forSystem().failOnDeprecationWarning().withSources(
+						SourceFile.of(HELLO_DEPRECATED_FOR_REMOVAL), main).compile(compiled -> {
+				})).satisfies(compilationException -> {
+			assertThat(compilationException.getProblems(Diagnostic.Kind.ERROR)).singleElement()
+					.satisfies(error -> assertThat(error.message())
+							.contains("-Werror"));
+			assertThat(compilationException.getProblems(Diagnostic.Kind.MANDATORY_WARNING)).singleElement()
+					.satisfies(warning -> assertThat(warning.message())
+							.contains("get()", "com.example.Hello"));
+		});
+	}
+
+	@Test
+	@SuppressWarnings({ "removal", "unchecked" })
+	void compileWhenSourceUseDeprecateForRemovalCodeAndFailOnDeprecationWarningWithSuppressWarnings() {
+		SourceFile main = sourceFileUsingDeprecatedHello("""
+				@SuppressWarnings("removal")
+				public static void main(String[] args) {
+					new Hello().get();
+				}
+				""");
+		TestCompiler.forSystem().failOnDeprecationWarning().withSources(
+				SourceFile.of(HELLO_DEPRECATED_FOR_REMOVAL), main).compile(compiled -> {
 			Supplier<String> supplier = compiled.getInstance(Supplier.class,
 					"com.example.Hello");
 			assertThat(supplier.get()).isEqualTo("Hello Deprecated");
@@ -396,6 +506,18 @@ class TestCompilerTests {
 	private void assertHasResource(Compiled compiled) {
 		assertThat(compiled.getClassLoader().getResourceAsStream(
 				"META-INF/myfile")).hasContent("test");
+	}
+
+	private SourceFile sourceFileUsingDeprecatedHello(String method) {
+		return SourceFile.of("""
+				package com.example;
+
+				public class Main {
+
+				%s
+
+				}
+				""".formatted(method.indent(1)));
 	}
 
 	@SupportedAnnotationTypes("java.lang.Deprecated")


### PR DESCRIPTION
This adds a focused `TestCompiler` shortcut for failing compilation when generated code uses deprecated APIs without suppressing the corresponding compiler warning.

Specifically, `failOnDeprecationWarning()` enables `-Xlint:deprecation`, `-Xlint:removal`, and `-Werror`, which lets AOT-related tests assert deprecation/removal cleanliness without failing on unrelated warning categories.

Closes gh-36036

Tests:
- `./gradlew.bat --no-daemon :spring-core-test:test --tests org.springframework.core.test.tools.TestCompilerTests`
- `./gradlew.bat --no-daemon :spring-core-test:test --tests org.springframework.core.test.tools.TestCompilerTests :spring-beans:test --tests org.springframework.beans.factory.aot.CodeWarningsTests`
- `./gradlew.bat --no-daemon :spring-core-test:check :spring-beans:check`