### PR TITLE
Close contexts when clearing test context cache

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/cache/ContextCache.java
+++ b/spring-test/src/main/java/org/springframework/test/context/cache/ContextCache.java
@@ -314,7 +314,10 @@ public interface ContextCache {
 	void reset();
 
 	/**
-	 * Clear all contexts from the cache, clearing context hierarchy information as well.
+	 * Clear all contexts from the cache, explicitly
+	 * {@linkplain org.springframework.context.ConfigurableApplicationContext#close() closing}
+	 * each context that is an instance of {@code ConfigurableApplicationContext}
+	 * and clearing context hierarchy information as well.
 	 */
 	void clear();
 

--- a/spring-test/src/main/java/org/springframework/test/context/cache/DefaultContextCache.java
+++ b/spring-test/src/main/java/org/springframework/test/context/cache/DefaultContextCache.java
@@ -426,6 +426,9 @@ public class DefaultContextCache implements ContextCache {
 	@Override
 	public void clear() {
 		synchronized (this.contextMap) {
+			for (MergedContextConfiguration key : new ArrayList<>(this.contextMap.keySet())) {
+				remove(key, HierarchyMode.CURRENT_LEVEL);
+			}
 			this.contextMap.clear();
 			this.hierarchyMap.clear();
 			this.contextUsageMap.clear();

--- a/spring-test/src/test/java/org/springframework/test/context/cache/LruContextCacheTests.java
+++ b/spring-test/src/test/java/org/springframework/test/context/cache/LruContextCacheTests.java
@@ -81,6 +81,42 @@ class LruContextCacheTests {
 		assertThatIllegalArgumentException().isThrownBy(() -> new DefaultContextCache(0));
 	}
 
+	@Test
+	void clearClosesContexts() {
+		DefaultContextCache cache = new DefaultContextCache(4);
+
+		cache.put(fooConfig, key -> fooContext);
+		cache.put(barConfig, key -> barContext);
+		cache.put(bazConfig, key -> bazContext);
+		assertCacheContents(cache, "Foo", "Bar", "Baz");
+
+		cache.clear();
+		assertCacheContents(cache);
+
+		verify(fooContext, times(1)).close();
+		verify(barContext, times(1)).close();
+		verify(bazContext, times(1)).close();
+		verify(abcContext, never()).close();
+	}
+
+	@Test
+	void resetClosesContexts() {
+		DefaultContextCache cache = new DefaultContextCache(4);
+
+		cache.put(fooConfig, key -> fooContext);
+		cache.put(barConfig, key -> barContext);
+		cache.get(fooConfig);
+		assertThat(cache.getHitCount()).isEqualTo(1);
+		assertCacheContents(cache, "Bar", "Foo");
+
+		cache.reset();
+		assertCacheContents(cache);
+		assertThat(cache.getHitCount()).isZero();
+
+		verify(fooContext, times(1)).close();
+		verify(barContext, times(1)).close();
+	}
+
 
 	@Nested
 	@SuppressWarnings("deprecation")


### PR DESCRIPTION
This updates the TestContext Framework cache so that clearing the cache also closes cached ConfigurableApplicationContext instances instead of only dropping the internal references. The implementation reuses the existing removal path, preserving the hierarchy-aware close behavior already used by cache eviction/removal.

The ContextCache contract now documents the close behavior for clear(), and LruContextCacheTests covers both clear() and reset(), since reset() delegates to clear().

Closes gh-26196

Tests:
- `./gradlew.bat --no-daemon --max-workers=1 :spring-test:test --tests org.springframework.test.context.cache.LruContextCacheTests`
- `./gradlew.bat --no-daemon --max-workers=1 :spring-test:test --tests org.springframework.test.context.cache.ContextCacheTests`
- `./gradlew.bat --no-daemon --max-workers=1 :spring-test:check`