### PR TITLE
Add `DataSize` converters to `DefaultConversionService`

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/support/DefaultConversionService.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/DefaultConversionService.java
@@ -142,6 +142,9 @@ public class DefaultConversionService extends GenericConversionService {
 		converterRegistry.addConverterFactory(new StringToNumberConverterFactory());
 		converterRegistry.addConverter(Number.class, String.class, new ObjectToStringConverter());
 
+		converterRegistry.addConverter(new StringToDataSizeConverter());
+		converterRegistry.addConverter(new NumberToDataSizeConverter());
+
 		converterRegistry.addConverter(new StringToCharacterConverter());
 		converterRegistry.addConverter(Character.class, String.class, new ObjectToStringConverter());
 

--- a/spring-core/src/main/java/org/springframework/core/convert/support/NumberToDataSizeConverter.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/NumberToDataSizeConverter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.convert.support;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.util.unit.DataSize;
+
+/**
+ * Converts from a {@link Number} to a {@link DataSize}.
+ *
+ * @author YeongJae Min
+ * @since 7.1
+ * @see DataSize#parse(CharSequence)
+ */
+final class NumberToDataSizeConverter implements Converter<Number, DataSize> {
+
+	@Override
+	public DataSize convert(Number source) {
+		return DataSize.parse(source.toString());
+	}
+
+}

--- a/spring-core/src/main/java/org/springframework/core/convert/support/StringToDataSizeConverter.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/StringToDataSizeConverter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.convert.support;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.util.unit.DataSize;
+
+/**
+ * Converts from a {@link String} to a {@link DataSize}.
+ *
+ * @author YeongJae Min
+ * @since 7.1
+ * @see DataSize#parse(CharSequence)
+ */
+final class StringToDataSizeConverter implements Converter<String, @Nullable DataSize> {
+
+	@Override
+	public @Nullable DataSize convert(String source) {
+		if (source.isEmpty()) {
+			return null;
+		}
+		return DataSize.parse(source);
+	}
+
+}

--- a/spring-core/src/test/java/org/springframework/core/convert/converter/DefaultConversionServiceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/converter/DefaultConversionServiceTests.java
@@ -58,6 +58,7 @@ import org.springframework.core.convert.ConverterNotFoundException;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.unit.DataSize;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -229,6 +230,37 @@ class DefaultConversionServiceTests {
 	@Test
 	void stringToNumberEmptyString() {
 		assertThat(conversionService.convert("", Number.class)).isNull();
+	}
+
+	@Test
+	void stringToDataSize() {
+		assertThat(conversionService.convert("10B", DataSize.class)).isEqualTo(DataSize.ofBytes(10));
+		assertThat(conversionService.convert("+10KB", DataSize.class)).isEqualTo(DataSize.ofKilobytes(10));
+		assertThat(conversionService.convert("-10MB", DataSize.class)).isEqualTo(DataSize.ofMegabytes(-10));
+		assertThat(conversionService.convert("10", DataSize.class)).isEqualTo(DataSize.ofBytes(10));
+	}
+
+	@Test
+	void stringToDataSizeEmptyString() {
+		assertThat(conversionService.convert("", DataSize.class)).isNull();
+	}
+
+	@Test
+	void stringToDataSizeInvalidString() {
+		assertThatExceptionOfType(ConversionFailedException.class).isThrownBy(() ->
+				conversionService.convert("10WB", DataSize.class));
+	}
+
+	@Test
+	void numberToDataSize() {
+		assertThat(conversionService.convert(10, DataSize.class)).isEqualTo(DataSize.ofBytes(10));
+		assertThat(conversionService.convert(-10L, DataSize.class)).isEqualTo(DataSize.ofBytes(-10));
+	}
+
+	@Test
+	void numberToDataSizeWithDecimalNumber() {
+		assertThatExceptionOfType(ConversionFailedException.class).isThrownBy(() ->
+				conversionService.convert(10.5, DataSize.class));
 	}
 
 	@Test


### PR DESCRIPTION
This PR adds default `String` and `Number` to `DataSize` converters to
`DefaultConversionService`.

Spring Boot already provides equivalent converters, and `DataSize` itself
already exposes parsing support via `DataSize.parse(...)`. This change makes
that conversion available through Spring Framework's default conversion service.

Changes:
- Add `StringToDataSizeConverter` delegating to `DataSize.parse(CharSequence)`
- Add `NumberToDataSizeConverter` delegating to `DataSize.parse(source.toString())`
- Register both converters with `DefaultConversionService`
- Add `DefaultConversionService` tests for string, number, empty, and invalid inputs

This intentionally does not move Spring Boot's `@DataSizeUnit` support into
Spring Framework.

Closes gh-28910