### PR TITLE
Document @Conditional gating of nested @Configuration classes

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/beans/java/composing-configuration-classes.adoc
+++ b/framework-docs/modules/ROOT/pages/core/beans/java/composing-configuration-classes.adoc
@@ -620,7 +620,7 @@ independently of its enclosing class, for example via `@ComponentScan` or
 by directly registering it against the application context, it is processed
 using only its own `@Conditional` annotations. In that case, redeclare the
 relevant conditions on the nested class, or extract them into a composed
-meta-annotation applied to both, if the same gating is intended.
+annotation applied to both, if the same gating is intended.
 ====
 
 

--- a/framework-docs/modules/ROOT/pages/core/beans/java/composing-configuration-classes.adoc
+++ b/framework-docs/modules/ROOT/pages/core/beans/java/composing-configuration-classes.adoc
@@ -610,6 +610,19 @@ Kotlin::
 See the {spring-framework-api}/context/annotation/Conditional.html[`@Conditional`]
 javadoc for more detail.
 
+[NOTE]
+====
+A `@Conditional` declared on an enclosing `@Configuration` class gates the
+registration of nested `@Configuration` classes within it only when the
+nested class is reached through the parser's recursion from its enclosing
+class, or through `@Import`. When the nested class is discovered
+independently of its enclosing class, for example via `@ComponentScan` or
+by directly registering it against the application context, it is processed
+using only its own `@Conditional` annotations. In that case, redeclare the
+relevant conditions on the nested class, or extract them into a composed
+meta-annotation applied to both, if the same gating is intended.
+====
+
 
 [[beans-java-combining]]
 == Combining Java and XML Configuration

--- a/spring-context/src/main/java/org/springframework/context/annotation/Configuration.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/Configuration.java
@@ -351,7 +351,7 @@ import org.springframework.stereotype.Component;
  * class against the application context, it is processed using only its own
  * {@code @Conditional} annotations. In that case, redeclare the relevant
  * conditions on the nested class, or extract them into a composed
- * meta-annotation applied to both, if the same gating is intended.
+ * annotation applied to both, if the same gating is intended.
  *
  * <h2>Configuring lazy initialization</h2>
  *

--- a/spring-context/src/main/java/org/springframework/context/annotation/Configuration.java
+++ b/spring-context/src/main/java/org/springframework/context/annotation/Configuration.java
@@ -341,6 +341,18 @@ import org.springframework.stereotype.Component;
  * with the {@code @Profile} annotation to provide two options of the same bean to the
  * enclosing {@code @Configuration} class.
  *
+ * <p>{@link Conditional @Conditional} annotations declared on an enclosing
+ * {@code @Configuration} class gate registration of any nested
+ * {@code @Configuration} classes within it when the nested class is reached
+ * through the parser's recursion from its enclosing class (the case shown
+ * above) or via {@link Import @Import}. When the nested class is discovered
+ * independently of its enclosing class, for example via
+ * {@link ComponentScan @ComponentScan} or by directly registering the nested
+ * class against the application context, it is processed using only its own
+ * {@code @Conditional} annotations. In that case, redeclare the relevant
+ * conditions on the nested class, or extract them into a composed
+ * meta-annotation applied to both, if the same gating is intended.
+ *
  * <h2>Configuring lazy initialization</h2>
  *
  * <p>By default, {@code @Bean} methods will be <em>eagerly instantiated</em> at container


### PR DESCRIPTION
## Summary

The "With nested `@Configuration` classes" section of the `@Configuration` Javadoc previously mentioned `@Profile` working with nested classes but was silent on how `@Conditional` interacts with them. The corresponding reference-doc section ("Conditionally Include `@Configuration` Classes or `@Bean` Methods" in `composing-configuration-classes.adoc`) was similarly silent.

In practice, whether an enclosing class's `@Conditional` gates a nested `@Configuration` depends on how the nested class is discovered. Nested classes reached through parser recursion from their enclosing class or via `@Import` inherit the enclosing's conditions through the existing `importedBy` mechanism (`ConfigurationClassBeanDefinitionReader.TrackedConditionEvaluator.shouldSkip`). Nested classes discovered independently (via `@ComponentScan` or by directly registering them) are processed using only their own conditions. The rule is real, long-standing, and currently undocumented.

This PR adds a paragraph to the `@Configuration` Javadoc and a `[NOTE]` admonition to the reference-doc page documenting that rule and recommending the redeclare-or-meta-annotation workaround when the same gating is intended on independent discovery paths.

See also #36820 for a separate proposal to close the discovery-path asymmetry at the framework level. This PR is independent of that proposal; it documents current behavior.

## Test plan

- `./gradlew :spring-context:check` (includes javadoc with `-Werror`, checkstyle, runtime-hints, tests), all green
- `./gradlew :framework-docs:antora`, all green
- Locally rendered Antora site verified, admonition renders correctly under "Conditionally Include `@Configuration` Classes or `@Bean` Methods"
- Locally rendered Javadoc for `@Configuration` verified, new paragraph reads cleanly and `{@link}` references resolve