### PR TITLE
Expose `ClassLoader` from `DefaultDeserializer`

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/serializer/DefaultDeserializer.java
+++ b/spring-core/src/main/java/org/springframework/core/serializer/DefaultDeserializer.java
@@ -60,6 +60,17 @@ public class DefaultDeserializer implements Deserializer<Object> {
 
 
 	/**
+	 * Return the {@link ClassLoader} to use for deserialization, or {@code null}
+	 * to use the "latest user-defined ClassLoader" of {@link ObjectInputStream}.
+	 * @since 7.1
+	 * @see ConfigurableObjectInputStream#ConfigurableObjectInputStream(InputStream, ClassLoader)
+	 */
+	public @Nullable ClassLoader getClassLoader() {
+		return this.classLoader;
+	}
+
+
+	/**
 	 * Read from the supplied {@code InputStream} and deserialize the contents
 	 * into an object.
 	 * @see ObjectInputStream#readObject()

--- a/spring-core/src/test/java/org/springframework/core/serializer/SerializerTests.java
+++ b/spring-core/src/test/java/org/springframework/core/serializer/SerializerTests.java
@@ -79,6 +79,17 @@ class SerializerTests {
 	}
 
 	@Test
+	void defaultDeserializerExposesNullClassLoaderByDefault() {
+		assertThat(new DefaultDeserializer().getClassLoader()).isNull();
+	}
+
+	@Test
+	void defaultDeserializerExposesConfiguredClassLoader() {
+		ClassLoader classLoader = getClass().getClassLoader();
+		assertThat(new DefaultDeserializer(classLoader).getClassLoader()).isSameAs(classLoader);
+	}
+
+	@Test
 	void serializationDelegateWithExplicitSerializerAndDeserializer() throws IOException {
 		SerializationDelegate delegate = new SerializationDelegate(new DefaultSerializer(), new DefaultDeserializer());
 		byte[] serializedObj = delegate.serializeToByteArray(SPRING_FRAMEWORK);


### PR DESCRIPTION
This commit adds a public `getClassLoader()` accessor on
`DefaultDeserializer` to expose the `ClassLoader` configured via the
constructor introduced in 4.2.1.

The motivation for this is described in gh-36827: Spring Integration's
`AllowListDeserializingConverter` currently reads the private
`classLoader` field via `DirectFieldAccessor` reflection in order to
forward it to a `ConfigurableObjectInputStream` subclass. Exposing a
proper getter avoids the reflection and removes the need for any
related native image hint.

The accessor mirrors the nullability of the underlying field. A pair of
unit tests in `SerializerTests` cover both the no-arg and explicit
`ClassLoader` constructors.

Closes gh-36827