### PR TITLE
Update to NullAway 0.13.7

### DIFF
--- a/gradle/spring-module.gradle
+++ b/gradle/spring-module.gradle
@@ -115,6 +115,8 @@ publishing {
 	}
 }
 
+nullability { nullAwayVersion = "0.13.6" }
+
 // Disable publication of test fixture artifacts.
 components.java.withVariantsFromConfiguration(configurations.testFixturesApiElements) { skip() }
 components.java.withVariantsFromConfiguration(configurations.testFixturesRuntimeElements) { skip() }

--- a/spring-web/src/main/java/org/springframework/web/util/UriComponents.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponents.java
@@ -345,7 +345,7 @@ public abstract class UriComponents implements Serializable {
 	 */
 	private static class VarArgsTemplateVariables implements UriTemplateVariables {
 
-		private final Iterator<Object> valueIterator;
+		private final Iterator<@Nullable Object> valueIterator;
 
 		public VarArgsTemplateVariables(@Nullable Object... uriVariableValues) {
 			this.valueIterator = Arrays.asList(uriVariableValues).iterator();


### PR DESCRIPTION
Updates to NullAway 0.13.6.  This version produces a new warning, which is fixed by adding a `@Nullable` annotation. From the surrounding code it is clear that `valueIterator` should have type `Iterator<@Nullable Object>`.