### PR TITLE
Document LocaleContextHolder inheritable behavior

### DIFF
--- a/spring-context/src/main/java/org/springframework/context/i18n/LocaleContextHolder.java
+++ b/spring-context/src/main/java/org/springframework/context/i18n/LocaleContextHolder.java
@@ -30,6 +30,17 @@ import org.springframework.core.NamedThreadLocal;
  * by any child threads spawned by the current thread if the
  * {@code inheritable} flag is set to {@code true}.
  *
+ * <p><b>Note:</b> The {@code inheritable} flag relies on JDK
+ * {@link java.lang.InheritableThreadLocal} semantics, which only propagates
+ * the context value to <em>newly created</em> child threads at the time of
+ * their creation. In thread pool environments where threads are reused across
+ * tasks, the context is not refreshed per task submission; reused threads
+ * retain whatever value was inherited when they were originally created.
+ * This mechanism is therefore not suitable for per-task context propagation
+ * in thread pool environments. Instead, consider using a
+ * {@link org.springframework.core.task.TaskDecorator} that captures and
+ * restores the locale context around each task execution.
+ *
  * <p>Used as a central holder for the current Locale in Spring,
  * wherever necessary: for example, in MessageSourceAccessor.
  * DispatcherServlet automatically exposes its current Locale here.
@@ -42,6 +53,7 @@ import org.springframework.core.NamedThreadLocal;
  * @see LocaleContext
  * @see org.springframework.context.support.MessageSourceAccessor
  * @see org.springframework.web.servlet.DispatcherServlet
+ * @see org.springframework.core.task.TaskDecorator
  */
 public final class LocaleContextHolder {
 
@@ -91,7 +103,9 @@ public final class LocaleContextHolder {
 	 * @param localeContext the current LocaleContext,
 	 * or {@code null} to reset the thread-bound context
 	 * @param inheritable whether to expose the LocaleContext as inheritable
-	 * for child threads (using an {@link InheritableThreadLocal})
+	 * for child threads (using an {@link InheritableThreadLocal}); note that
+	 * this only propagates to newly created threads, not to threads reused
+	 * in a thread pool &mdash; see the class-level note for details
 	 * @see SimpleLocaleContext
 	 * @see SimpleTimeZoneAwareLocaleContext
 	 */


### PR DESCRIPTION
Closes #36687

This change documents that `LocaleContextHolder`'s `inheritable` flag relies on
JDK `InheritableThreadLocal` semantics, which only propagate values to newly
created child threads at the time of their creation.

In thread pool environments where threads are reused across tasks, the context
is not refreshed per task submission, so this mechanism is not suitable for
per-task context propagation to reused threads.

The documentation now points users toward `TaskDecorator` for explicit per-task
locale context propagation.

Verification:
- `./gradlew :spring-context:compileJava`
- `./gradlew :spring-context:test --tests "org.springframework.context.i18n.LocaleContextHolderTests"`