### PR TITLE
Log broker availability events as String messages

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/broker/AbstractBrokerMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/broker/AbstractBrokerMessageHandler.java
@@ -334,7 +334,7 @@ public abstract class AbstractBrokerMessageHandler
 		boolean shouldPublish = this.brokerAvailable.compareAndSet(false, true);
 		if (this.eventPublisher != null && shouldPublish) {
 			if (logger.isInfoEnabled()) {
-				logger.info(this.availableEvent);
+				logger.info(this.availableEvent.toString());
 			}
 			this.eventPublisher.publishEvent(this.availableEvent);
 		}
@@ -344,7 +344,7 @@ public abstract class AbstractBrokerMessageHandler
 		boolean shouldPublish = this.brokerAvailable.compareAndSet(true, false);
 		if (this.eventPublisher != null && shouldPublish) {
 			if (logger.isInfoEnabled()) {
-				logger.info(this.notAvailableEvent);
+				logger.info(this.notAvailableEvent.toString());
 			}
 			this.eventPublisher.publishEvent(this.notAvailableEvent);
 		}

--- a/spring-messaging/src/test/java/org/springframework/messaging/simp/broker/BrokerMessageHandlerTests.java
+++ b/spring-messaging/src/test/java/org/springframework/messaging/simp/broker/BrokerMessageHandlerTests.java
@@ -16,12 +16,15 @@
 
 package org.springframework.messaging.simp.broker;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.commons.logging.Log;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
@@ -30,9 +33,13 @@ import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessageType;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.ReflectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link org.springframework.messaging.simp.broker.AbstractBrokerMessageHandler}.
@@ -113,6 +120,22 @@ class BrokerMessageHandlerTests {
 	}
 
 	@Test
+	void publishBrokerAvailabilityEventsLogStringMessages() {
+		Log logger = mock();
+		when(logger.isInfoEnabled()).thenReturn(true);
+		this.handler.setLogger(logger);
+
+		this.handler.publishBrokerAvailableEvent();
+		this.handler.publishBrokerUnavailableEvent();
+
+		ArgumentCaptor<Object> messageCaptor = ArgumentCaptor.forClass(Object.class);
+		verify(logger, times(2)).info(messageCaptor.capture());
+		assertThat(messageCaptor.getAllValues()).containsExactly(
+				"BrokerAvailabilityEvent[available=true, " + this.handler + "]",
+				"BrokerAvailabilityEvent[available=false, " + this.handler + "]");
+	}
+
+	@Test
 	void checkDestination() {
 		TestBrokerMessageHandler theHandler = new TestBrokerMessageHandler("/topic");
 		theHandler.start();
@@ -166,6 +189,13 @@ class BrokerMessageHandlerTests {
 			super(mock(), mock(), mock(), Arrays.asList(destinationPrefixes));
 
 			setApplicationEventPublisher(this);
+		}
+
+		void setLogger(Log logger) {
+			Field field = ReflectionUtils.findField(AbstractBrokerMessageHandler.class, "logger");
+			assertThat(field).isNotNull();
+			ReflectionUtils.makeAccessible(field);
+			ReflectionUtils.setField(field, this, logger);
 		}
 
 		@Override


### PR DESCRIPTION
## Overview

`AbstractBrokerMessageHandler` logs `BrokerAvailabilityEvent` directly at INFO level when the broker becomes (un)available:

```java
logger.info(this.availableEvent);
```

With a structured JSON logging layout (e.g. Logstash/ECS encoders backed by Jackson), the logging framework may serialize the *event object* rather than its `toString()`. It then traverses `BrokerAvailabilityEvent.getSource()`, which is the `SimpleBrokerMessageHandler` itself.

That object graph contains a cyclic reference:

```
SimpleBrokerMessageHandler["clientInboundChannel"]
  -> ExecutorSubscribableChannel["executor"]
    -> ThreadPoolTaskExecutor["threadPoolExecutor"]
      -> ThreadPoolTaskExecutor$1["threadFactory"]   // anonymous inner class, holds outer ref
        -> ThreadPoolTaskExecutor["threadPoolExecutor"]
          -> ...
```

Because the thread factory is a non-static inner class, it keeps an implicit reference back to the enclosing `ThreadPoolTaskExecutor`, producing an effectively infinite graph. Jackson aborts at its maximum nesting depth:

```
com.fasterxml.jackson.databind.JsonMappingException:
Document nesting depth (1001) exceeds the maximum allowed (1000,
from `StreamWriteConstraints.getMaxNestingDepth()`)
```

The application keeps starting, but startup logs are flooded with a very large stack trace, which can hide real problems.

## Change

Log the event's `toString()` representation instead of the event object, in both `publishBrokerAvailableEvent()` and `publishBrokerUnavailableEvent()`:

```java
logger.info(this.availableEvent.toString());
```

`BrokerAvailabilityEvent.toString()` already produces a concise, safe message, so the operational signal is preserved while structured logging layouts no longer traverse framework internals.

## Notes

- Behavior with plain text layouts is unchanged (they already called `toString()`).
- Added a test verifying both lifecycle methods log the expected String messages.
