### PR TITLE
Introduce immediate attribute on @CacheEvict

### DIFF
--- a/spring-aspects/src/test/java/org/springframework/cache/aspectj/AbstractCacheAnnotationTests.java
+++ b/spring-aspects/src/test/java/org/springframework/cache/aspectj/AbstractCacheAnnotationTests.java
@@ -182,6 +182,20 @@ abstract class AbstractCacheAnnotationTests {
 		assertThat(r2).isNotSameAs(r1);
 	}
 
+	protected void testEvictImmediate(CacheableService<?> service) {
+		Cache cache = this.cm.getCache("testCache");
+
+		Object o1 = new Object();
+		cache.putIfAbsent(o1, -1L);
+		Object r1 = service.cache(o1);
+
+		service.evictImmediate(o1);
+		assertThat(cache.get(o1)).isNull();
+
+		Object r2 = service.cache(o1);
+		assertThat(r2).isNotSameAs(r1);
+	}
+
 	protected void testEvictException(CacheableService<?> service) {
 		Object o1 = new Object();
 		Object r1 = service.cache(o1);
@@ -272,6 +286,28 @@ abstract class AbstractCacheAnnotationTests {
 		catch (Exception ex) {
 			// expected
 		}
+		assertThat(cache.get(o1)).isNull();
+		assertThat(cache.get(o2)).isNull();
+
+		Object r3 = service.cache(o1);
+		Object r4 = service.cache(o2);
+		assertThat(r3).isNotSameAs(r1);
+		assertThat(r4).isNotSameAs(r2);
+	}
+
+	protected void testEvictAllImmediate(CacheableService<?> service) {
+		Cache cache = this.cm.getCache("testCache");
+
+		Object o1 = new Object();
+		Object o2 = new Object();
+		cache.putIfAbsent(o1, -1L);
+		cache.putIfAbsent(o2, -2L);
+
+		Object r1 = service.cache(o1);
+		Object r2 = service.cache(o2);
+		assertThat(r2).isNotSameAs(r1);
+
+		service.evictAllImmediate(new Object());
 		assertThat(cache.get(o1)).isNull();
 		assertThat(cache.get(o2)).isNull();
 
@@ -587,6 +623,11 @@ abstract class AbstractCacheAnnotationTests {
 	}
 
 	@Test
+	void evictImmediate() {
+		testEvictImmediate(this.cs);
+	}
+
+	@Test
 	void evictWithException() {
 		testEvictException(this.cs);
 	}
@@ -599,6 +640,11 @@ abstract class AbstractCacheAnnotationTests {
 	@Test
 	void evictAllEarly() {
 		testEvictAllEarly(this.cs);
+	}
+
+	@Test
+	void evictAllImmediate() {
+		testEvictAllImmediate(this.cs);
 	}
 
 	@Test
@@ -657,8 +703,18 @@ abstract class AbstractCacheAnnotationTests {
 	}
 
 	@Test
+	void classEvictImmediate() {
+		testEvictImmediate(this.ccs);
+	}
+
+	@Test
 	void classEvictAll() {
 		testEvictAll(this.ccs, true);
+	}
+
+	@Test
+	void classEvictAllImmediate() {
+		testEvictAllImmediate(this.ccs);
 	}
 
 	@Test

--- a/spring-aspects/src/test/java/org/springframework/cache/config/AnnotatedClassCacheableService.java
+++ b/spring-aspects/src/test/java/org/springframework/cache/config/AnnotatedClassCacheableService.java
@@ -97,6 +97,11 @@ public class AnnotatedClassCacheableService implements CacheableService<Object> 
 	}
 
 	@Override
+	@CacheEvict(cacheNames = "testCache", key = "#p0", immediate = true)
+	public void evictImmediate(Object arg1) {
+	}
+
+	@Override
 	@CacheEvict(cacheNames = "testCache", allEntries = true)
 	public void evictAll(Object arg1) {
 	}
@@ -105,6 +110,11 @@ public class AnnotatedClassCacheableService implements CacheableService<Object> 
 	@CacheEvict(cacheNames = "testCache", allEntries = true, beforeInvocation = true)
 	public void evictAllEarly(Object arg1) {
 		throw new RuntimeException("exception thrown - evict should still occur");
+	}
+
+	@Override
+	@CacheEvict(cacheNames = "testCache", allEntries = true, immediate = true)
+	public void evictAllImmediate(Object arg1) {
 	}
 
 	@Override

--- a/spring-aspects/src/test/java/org/springframework/cache/config/CacheableService.java
+++ b/spring-aspects/src/test/java/org/springframework/cache/config/CacheableService.java
@@ -43,9 +43,13 @@ public interface CacheableService<T> {
 
 	void evictEarly(Object arg1);
 
+	void evictImmediate(Object arg1);
+
 	void evictAll(Object arg1);
 
 	void evictAllEarly(Object arg1);
+
+	void evictAllImmediate(Object arg1);
 
 	T conditional(int field);
 

--- a/spring-aspects/src/test/java/org/springframework/cache/config/DefaultCacheableService.java
+++ b/spring-aspects/src/test/java/org/springframework/cache/config/DefaultCacheableService.java
@@ -84,6 +84,11 @@ public class DefaultCacheableService implements CacheableService<Long> {
 	}
 
 	@Override
+	@CacheEvict(cacheNames = "testCache", key = "#p0", immediate = true)
+	public void evictImmediate(Object arg1) {
+	}
+
+	@Override
 	@CacheEvict(cacheNames = "testCache", allEntries = true)
 	public void evictAll(Object arg1) {
 	}
@@ -92,6 +97,11 @@ public class DefaultCacheableService implements CacheableService<Long> {
 	@CacheEvict(cacheNames = "testCache", allEntries = true, beforeInvocation = true)
 	public void evictAllEarly(Object arg1) {
 		throw new RuntimeException("exception thrown - evict should still occur");
+	}
+
+	@Override
+	@CacheEvict(cacheNames = "testCache", allEntries = true, immediate = true)
+	public void evictAllImmediate(Object arg1) {
 	}
 
 	@Override

--- a/spring-context/src/main/java/org/springframework/cache/annotation/CacheEvict.java
+++ b/spring-context/src/main/java/org/springframework/cache/annotation/CacheEvict.java
@@ -154,4 +154,29 @@ public @interface CacheEvict {
 	 */
 	boolean beforeInvocation() default false;
 
+	/**
+	 * Whether the eviction must be performed immediately, with all affected
+	 * entries expected to be invisible to subsequent lookups as soon as this
+	 * operation returns.
+	 * <p>Setting this attribute to {@code true} causes the framework to invoke
+	 * {@link org.springframework.cache.Cache#evictIfPresent} (for a single key)
+	 * or {@link org.springframework.cache.Cache#invalidate} (when
+	 * {@link #allEntries} is {@code true}) instead of
+	 * {@link org.springframework.cache.Cache#evict} /
+	 * {@link org.springframework.cache.Cache#clear}. The latter pair is allowed
+	 * by contract to perform the removal in an asynchronous or deferred fashion,
+	 * which can lead to a concurrently inserted entry being removed by a late
+	 * eviction — for example, when a Redis-backed cache implements
+	 * {@link org.springframework.cache.Cache#clear} via an asynchronous
+	 * {@code UNLINK} while a subsequent {@code @CachePut} writes a new value.
+	 * <p>Defaults to {@code false}, preserving the previous behavior where the
+	 * immediacy of the eviction implicitly follows {@link #beforeInvocation()}:
+	 * a before-invocation eviction is always immediate, whereas an
+	 * after-invocation eviction may be deferred by the underlying cache
+	 * implementation.
+	 * @since 7.0
+	 * @see org.springframework.cache.Cache#evictIfPresent
+	 * @see org.springframework.cache.Cache#invalidate
+	 */
+	boolean immediate() default false;
 }

--- a/spring-context/src/main/java/org/springframework/cache/annotation/SpringCacheAnnotationParser.java
+++ b/spring-context/src/main/java/org/springframework/cache/annotation/SpringCacheAnnotationParser.java
@@ -140,6 +140,7 @@ public class SpringCacheAnnotationParser implements CacheAnnotationParser, Seria
 		builder.setCacheResolver(cacheEvict.cacheResolver());
 		builder.setCacheWide(cacheEvict.allEntries());
 		builder.setBeforeInvocation(cacheEvict.beforeInvocation());
+		builder.setImmediate(cacheEvict.immediate());
 
 		defaultConfig.applyDefault(builder);
 		CacheEvictOperation op = builder.build();

--- a/spring-context/src/main/java/org/springframework/cache/config/CacheAdviceParser.java
+++ b/spring-context/src/main/java/org/springframework/cache/config/CacheAdviceParser.java
@@ -136,6 +136,11 @@ class CacheAdviceParser extends AbstractSingleBeanDefinitionParser {
 				builder.setBeforeInvocation(Boolean.parseBoolean(after.trim()));
 			}
 
+			String immediate = opElement.getAttribute("immediate");
+			if (StringUtils.hasText(immediate)) {
+				builder.setImmediate(Boolean.parseBoolean(immediate.trim()));
+			}
+
 			Collection<CacheOperation> col = cacheOpMap.computeIfAbsent(nameHolder, key -> new ArrayList<>(2));
 			col.add(builder.build());
 		}

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/CacheAspectSupport.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/CacheAspectSupport.java
@@ -674,17 +674,19 @@ public abstract class CacheAspectSupport extends AbstractCacheInvoker
 			CacheEvictOperation operation = (CacheEvictOperation) context.metadata.operation;
 			if (isConditionPassing(context, result)) {
 				Object key = context.getGeneratedKey();
+				// A before-invocation eviction is always immediate (backwards-compatible default).
+				boolean immediate = operation.isImmediate() || operation.isBeforeInvocation();
 				for (Cache cache : context.getCaches()) {
 					if (operation.isCacheWide()) {
 						logInvalidating(context, operation, null);
-						doClear(cache, operation.isBeforeInvocation());
+						doClear(cache, immediate);
 					}
 					else {
 						if (key == null) {
 							key = generateKey(context, result);
 						}
 						logInvalidating(context, operation, key);
-						doEvict(cache, key, operation.isBeforeInvocation());
+						doEvict(cache, key, immediate);
 					}
 				}
 			}

--- a/spring-context/src/main/java/org/springframework/cache/interceptor/CacheEvictOperation.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/CacheEvictOperation.java
@@ -29,6 +29,8 @@ public class CacheEvictOperation extends CacheOperation {
 
 	private final boolean beforeInvocation;
 
+	private final boolean immediate;
+
 
 	/**
 	 * Create a new {@link CacheEvictOperation} instance from the given builder.
@@ -38,6 +40,7 @@ public class CacheEvictOperation extends CacheOperation {
 		super(b);
 		this.cacheWide = b.cacheWide;
 		this.beforeInvocation = b.beforeInvocation;
+		this.immediate = b.immediate;
 	}
 
 
@@ -47,6 +50,10 @@ public class CacheEvictOperation extends CacheOperation {
 
 	public boolean isBeforeInvocation() {
 		return this.beforeInvocation;
+	}
+
+	public boolean isImmediate() {
+		return this.immediate;
 	}
 
 
@@ -60,12 +67,18 @@ public class CacheEvictOperation extends CacheOperation {
 
 		private boolean beforeInvocation = false;
 
+		private boolean immediate = false;
+
 		public void setCacheWide(boolean cacheWide) {
 			this.cacheWide = cacheWide;
 		}
 
 		public void setBeforeInvocation(boolean beforeInvocation) {
 			this.beforeInvocation = beforeInvocation;
+		}
+
+		public void setImmediate(boolean immediate) {
+			this.immediate = immediate;
 		}
 
 		@Override
@@ -75,6 +88,8 @@ public class CacheEvictOperation extends CacheOperation {
 			sb.append(this.cacheWide);
 			sb.append(',');
 			sb.append(this.beforeInvocation);
+			sb.append(',');
+			sb.append(this.immediate);
 			return sb;
 		}
 

--- a/spring-context/src/main/resources/org/springframework/cache/config/spring-cache.xsd
+++ b/spring-context/src/main/resources/org/springframework/cache/config/spring-cache.xsd
@@ -300,6 +300,14 @@
 	invoked (default) or before.]]></xsd:documentation>
 										</xsd:annotation>
 									</xsd:attribute>
+									<xsd:attribute name="immediate" type="xsd:boolean" use="optional">
+										<xsd:annotation>
+											<xsd:documentation><![CDATA[
+	Whether the eviction must be performed immediately, expecting all affected
+	entries to be invisible for subsequent lookups as soon as the operation
+	returns. A before-invocation eviction is always immediate.]]></xsd:documentation>
+										</xsd:annotation>
+									</xsd:attribute>
 								</xsd:extension>
 							</xsd:complexContent>
 						</xsd:complexType>

--- a/spring-context/src/test/resources/org/springframework/cache/config/cache-advice.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/cache-advice.xml
@@ -30,8 +30,10 @@
 			<cache:cache-evict method="evict" key="#p0" cache="testCache"/>
 			<cache:cache-evict method="evictWithException" cache="testCache"/>
 			<cache:cache-evict method="evictEarly" cache="testCache" before-invocation="true"/>
+			<cache:cache-evict method="evictImmediate" key="#p0" cache="testCache" immediate="true"/>
 			<cache:cache-evict method="evictAll" cache="testCache" all-entries="true"/>
 			<cache:cache-evict method="evictAllEarly" cache="testCache" all-entries="true" before-invocation="true"/>
+			<cache:cache-evict method="evictAllImmediate" cache="testCache" all-entries="true" immediate="true"/>
 		</cache:caching>
 		<cache:caching cache="testCache">
 			<cache:cache-put method="update"/>
@@ -75,7 +77,9 @@
 			<cache:cache-evict method="evictWithException" cache="testCache"/>
 			<cache:cache-evict method="evictEarly" cache="testCache" before-invocation="true"/>
 			<cache:cache-evict method="invalidateEarly" key="#p0" cache="testCache" before-invocation="true"/>
+			<cache:cache-evict method="evictImmediate" key="#p0" cache="testCache" immediate="true"/>
 			<cache:cache-evict method="evictAll" cache="testCache" all-entries="true"/>
+			<cache:cache-evict method="evictAllImmediate" cache="testCache" all-entries="true" immediate="true"/>
 		</cache:caching>
 		<cache:caching cache="testCache">
 			<cache:cache-put method="update"/>

--- a/spring-context/src/testFixtures/java/org/springframework/context/testfixture/cache/AbstractCacheAnnotationTests.java
+++ b/spring-context/src/testFixtures/java/org/springframework/context/testfixture/cache/AbstractCacheAnnotationTests.java
@@ -171,6 +171,20 @@ public abstract class AbstractCacheAnnotationTests {
 		assertThat(r2).isNotSameAs(r1);
 	}
 
+	protected void testEvictImmediate(CacheableService<?> service) {
+		Cache cache = this.cm.getCache("testCache");
+
+		Object o1 = new Object();
+		cache.putIfAbsent(o1, -1L);
+		Object r1 = service.cache(o1);
+
+		service.evictImmediate(o1);
+		assertThat(cache.get(o1)).isNull();
+
+		Object r2 = service.cache(o1);
+		assertThat(r2).isNotSameAs(r1);
+	}
+
 	protected void testEvictException(CacheableService<?> service) {
 		Object o1 = new Object();
 		Object r1 = service.cache(o1);
@@ -261,6 +275,28 @@ public abstract class AbstractCacheAnnotationTests {
 		catch (Exception ex) {
 			// expected
 		}
+		assertThat(cache.get(o1)).isNull();
+		assertThat(cache.get(o2)).isNull();
+
+		Object r3 = service.cache(o1);
+		Object r4 = service.cache(o2);
+		assertThat(r3).isNotSameAs(r1);
+		assertThat(r4).isNotSameAs(r2);
+	}
+
+	protected void testEvictAllImmediate(CacheableService<?> service) {
+		Cache cache = this.cm.getCache("testCache");
+
+		Object o1 = new Object();
+		Object o2 = new Object();
+		cache.putIfAbsent(o1, -1L);
+		cache.putIfAbsent(o2, -2L);
+
+		Object r1 = service.cache(o1);
+		Object r2 = service.cache(o2);
+		assertThat(r2).isNotSameAs(r1);
+
+		service.evictAllImmediate(new Object());
 		assertThat(cache.get(o1)).isNull();
 		assertThat(cache.get(o2)).isNull();
 
@@ -595,6 +631,11 @@ public abstract class AbstractCacheAnnotationTests {
 	}
 
 	@Test
+	protected void evictImmediate() {
+		testEvictImmediate(this.cs);
+	}
+
+	@Test
 	protected void evictWithException() {
 		testEvictException(this.cs);
 	}
@@ -607,6 +648,11 @@ public abstract class AbstractCacheAnnotationTests {
 	@Test
 	protected void evictAllEarly() {
 		testEvictAllEarly(this.cs);
+	}
+
+	@Test
+	protected void evictAllImmediate() {
+		testEvictAllImmediate(this.cs);
 	}
 
 	@Test
@@ -665,8 +711,18 @@ public abstract class AbstractCacheAnnotationTests {
 	}
 
 	@Test
+	protected void classEvictImmediate() {
+		testEvictImmediate(this.ccs);
+	}
+
+	@Test
 	protected void classEvictAll() {
 		testEvictAll(this.ccs, true);
+	}
+
+	@Test
+	protected void classEvictAllImmediate() {
+		testEvictAllImmediate(this.ccs);
 	}
 
 	@Test

--- a/spring-context/src/testFixtures/java/org/springframework/context/testfixture/cache/beans/AnnotatedClassCacheableService.java
+++ b/spring-context/src/testFixtures/java/org/springframework/context/testfixture/cache/beans/AnnotatedClassCacheableService.java
@@ -93,6 +93,11 @@ public class AnnotatedClassCacheableService implements CacheableService<Object> 
 	}
 
 	@Override
+	@CacheEvict(cacheNames = "testCache", key = "#p0", immediate = true)
+	public void evictImmediate(Object arg1) {
+	}
+
+	@Override
 	@CacheEvict(cacheNames = "testCache", allEntries = true)
 	public void evictAll(Object arg1) {
 	}
@@ -101,6 +106,11 @@ public class AnnotatedClassCacheableService implements CacheableService<Object> 
 	@CacheEvict(cacheNames = "testCache", allEntries = true, beforeInvocation = true)
 	public void evictAllEarly(Object arg1) {
 		throw new RuntimeException("exception thrown - evict should still occur");
+	}
+
+	@Override
+	@CacheEvict(cacheNames = "testCache", allEntries = true, immediate = true)
+	public void evictAllImmediate(Object arg1) {
 	}
 
 	@Override

--- a/spring-context/src/testFixtures/java/org/springframework/context/testfixture/cache/beans/CacheableService.java
+++ b/spring-context/src/testFixtures/java/org/springframework/context/testfixture/cache/beans/CacheableService.java
@@ -39,9 +39,13 @@ public interface CacheableService<T> {
 
 	void evictEarly(Object arg1);
 
+	void evictImmediate(Object arg1);
+
 	void evictAll(Object arg1);
 
 	void evictAllEarly(Object arg1);
+
+	void evictAllImmediate(Object arg1);
 
 	T conditional(int field);
 

--- a/spring-context/src/testFixtures/java/org/springframework/context/testfixture/cache/beans/DefaultCacheableService.java
+++ b/spring-context/src/testFixtures/java/org/springframework/context/testfixture/cache/beans/DefaultCacheableService.java
@@ -80,6 +80,11 @@ public class DefaultCacheableService implements CacheableService<Long> {
 	}
 
 	@Override
+	@CacheEvict(cacheNames = "testCache", key = "#p0", immediate = true)
+	public void evictImmediate(Object arg1) {
+	}
+
+	@Override
 	@CacheEvict(cacheNames = "testCache", allEntries = true)
 	public void evictAll(Object arg1) {
 	}
@@ -88,6 +93,11 @@ public class DefaultCacheableService implements CacheableService<Long> {
 	@CacheEvict(cacheNames = "testCache", allEntries = true, beforeInvocation = true)
 	public void evictAllEarly(Object arg1) {
 		throw new RuntimeException("exception thrown - evict should still occur");
+	}
+
+	@Override
+	@CacheEvict(cacheNames = "testCache", allEntries = true, immediate = true)
+	public void evictAllImmediate(Object arg1) {
 	}
 
 	@Override


### PR DESCRIPTION
Fixes #36806.

 By default, `@CacheEvict` delegates to `Cache#clear` / `Cache#evict`, which the `Cache` contract allows to be performed in an asynchronous or deferred fashion. With a Redis-backed cache, for example, `Cache#clear` may translate to an asynchronous `UNLINK` that can later remove an entry written by a concurrent `@CachePut`.

This PR introduces a new `immediate` attribute on `@CacheEvict` that delegates to `Cache#invalidate` / `Cache#evictIfPresent` instead, expecting all affected entries to be invisible for subsequent lookups as soon as the operation returns.

`beforeInvocation=true` continues to imply immediate eviction for backwards compatibility, since the original contract has always used `Cache#invalidate` in that case.

  It also aligns the call site with the existing `immediate` parameter on `AbstractCacheInvoker#doEvict` / `#doClear`, which `CacheAspectSupport` had been driving from `isBeforeInvocation()`, conflating scheduling with visibility.