### PR TITLE
CronExpression skips days on midnight DST gap

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/support/BitsCronField.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/support/BitsCronField.java
@@ -177,7 +177,11 @@ final class BitsCronField extends CronField {
 		int next = nextSetBit(current);
 		if (next == -1) {
 			temporal = type().rollForward(temporal);
-			next = nextSetBit(0);
+			next = nextSetBit(type().get(temporal));
+			if (next == -1) {
+				temporal = type().rollForward(temporal);
+				next = nextSetBit(0);
+			}
 		}
 		if (next == current) {
 			return temporal;
@@ -191,7 +195,11 @@ final class BitsCronField extends CronField {
 				next = nextSetBit(current);
 				if (next == -1) {
 					temporal = type().rollForward(temporal);
-					next = nextSetBit(0);
+					next = nextSetBit(type().get(temporal));
+					if (next == -1) {
+						temporal = type().rollForward(temporal);
+						next = nextSetBit(0);
+					}
 				}
 			}
 			if (count >= CronExpression.MAX_ATTEMPTS) {

--- a/spring-context/src/main/java/org/springframework/scheduling/support/BitsCronField.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/support/BitsCronField.java
@@ -200,6 +200,7 @@ final class BitsCronField extends CronField {
 						temporal = type().rollForward(temporal);
 						next = nextSetBit(0);
 					}
+					current = type().get(temporal);
 				}
 			}
 			if (count >= CronExpression.MAX_ATTEMPTS) {

--- a/spring-context/src/test/java/org/springframework/scheduling/support/BitsCronFieldTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/support/BitsCronFieldTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.scheduling.support;
 
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 
 import org.assertj.core.api.Condition;
@@ -29,6 +30,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
  *
  * @author Arjen Poutsma
  * @author Sam Brannen
+ * @author Brian Clozel
  */
 class BitsCronFieldTests {
 
@@ -110,6 +112,24 @@ class BitsCronFieldTests {
 				.has(clear(0)).has(setRange(1, 12));
 		assertThat((BitsCronField)CronField.parseDaysOfWeek("SUN,MON,TUE,WED,THU,FRI,SAT"))
 				.has(clear(0)).has(setRange(1, 7));
+	}
+
+	@Test
+	void nextOrSameWithMidnightGap() {
+		BitsCronField field = BitsCronField.parseHours("0-23/2");
+		ZonedDateTime last = ZonedDateTime.parse("2025-04-24T23:00:00+02:00[Africa/Cairo]");
+		ZonedDateTime expected = ZonedDateTime.parse("2025-04-25T02:00:00+03:00[Africa/Cairo]");
+		ZonedDateTime actual = field.nextOrSame(last);
+		assertThat(actual).isEqualTo(expected);
+	}
+
+	@Test
+	void nextOrSameWithGapAfterRollForward() {
+		BitsCronField field = BitsCronField.parseHours("0,2");
+		ZonedDateTime last = ZonedDateTime.parse("2026-03-08T01:00:00-05:00[America/New_York]");
+		ZonedDateTime expected = ZonedDateTime.parse("2026-03-09T00:00:00-04:00[America/New_York]");
+		ZonedDateTime actual = field.nextOrSame(last);
+		assertThat(actual).isEqualTo(expected);
 	}
 
 

--- a/spring-context/src/test/java/org/springframework/scheduling/support/CronExpressionTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/support/CronExpressionTests.java
@@ -1367,6 +1367,14 @@ class CronExpressionTests {
 		actual = cronExpression.next(last);
 		assertThat(actual).isNotNull();
 		assertThat(actual).isEqualTo(expected);
+
+		cronExpression = CronExpression.parse("0 0 */2 * * ?");
+
+		last = ZonedDateTime.parse("2025-04-24T22:00:00+02:00[Africa/Cairo]");
+		expected = ZonedDateTime.parse("2025-04-25T02:00:00+03:00[Africa/Cairo]");
+		actual = cronExpression.next(last);
+		assertThat(actual).isNotNull();
+		assertThat(actual).isEqualTo(expected);
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #36859.

By default, BitsCronField#nextOrSame delegates to nextSetBit(0) after rollForward, which assumes the field value in the new period starts at zero. When daylight saving creates a gap at the start of a period (for example, Africa/Cairo advancing from 00:00 to 01:00), the rolled-forward temporal lands on a non-zero field value and matching from zero can advance an entire period too far, causing CronExpression#next to skip the calendar day.

This PR searches for the next matching bit from the actual field value in the new period instead, falling back to zero only when no bit matches in that period.

This does not change the existing contract for cron times that fall inside a DST gap: those executions are still skipped rather than deferred or replayed after the transition. The fix only ensures that subsequent valid matches on the same calendar day are still calculated correctly.

It also adds a regression test in CronExpressionTests#daylightSaving for a every-two-hours expression across the Cairo spring-forward boundary.