### PR TITLE
Set 500 status for disconnected client exceptions

### DIFF
--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ExceptionHandlerExceptionResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/ExceptionHandlerExceptionResolver.java
@@ -465,6 +465,9 @@ public class ExceptionHandlerExceptionResolver extends AbstractHandlerMethodExce
 		}
 		catch (Throwable invocationEx) {
 			if (disconnectedClientHelper.checkAndLogClientDisconnectedException(invocationEx)) {
+				if (!response.isCommitted()) {
+					response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+				}
 				return new ModelAndView();
 			}
 			// Any other than the original exception (or a cause) is unintended here,

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/support/DefaultHandlerExceptionResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/support/DefaultHandlerExceptionResolver.java
@@ -510,7 +510,8 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 	 * typically an {@link IOException} of a specific subtype or with a message
 	 * specific to the underlying Servlet container. Those are detected through
 	 * {@link DisconnectedClientHelper#isClientDisconnectedException(Throwable)}
-	 * <p>By default, do nothing since the response is not usable.
+	 * <p>By default, set the response status to 500 but otherwise do nothing
+	 * since the response may not be usable.
 	 * @param ex the {@code Exception} to be handled
 	 * @param request current HTTP request
 	 * @param response current HTTP response
@@ -522,6 +523,9 @@ public class DefaultHandlerExceptionResolver extends AbstractHandlerExceptionRes
 	protected ModelAndView handleDisconnectedClientException(
 			Exception ex, HttpServletRequest request, HttpServletResponse response, @Nullable Object handler) {
 
+		if (!response.isCommitted()) {
+			response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+		}
 		return new ModelAndView();
 	}
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ExceptionHandlerExceptionResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ExceptionHandlerExceptionResolverTests.java
@@ -437,6 +437,18 @@ class ExceptionHandlerExceptionResolverTests {
 	}
 
 	@Test
+	void resolveExceptionHandlerRethrowsDisconnectedClientException() throws Exception {
+		IOException ex = new IOException("Broken pipe");
+		HandlerMethod handlerMethod = new HandlerMethod(new RethrowingExceptionController(), "handle");
+		this.resolver.afterPropertiesSet();
+		ModelAndView mav = this.resolver.resolveException(this.request, this.response, handlerMethod, ex);
+
+		assertThat(mav).isNotNull();
+		assertThat(mav.isEmpty()).isTrue();
+		assertThat(this.response.getStatus()).isEqualTo(500);
+	}
+
+	@Test
 	void resolveExceptionJsonMediaType() throws UnsupportedEncodingException, NoSuchMethodException {
 		IllegalArgumentException ex = new IllegalArgumentException();
 		HandlerMethod handlerMethod = new HandlerMethod(new MediaTypeController(), "handle");
@@ -546,6 +558,18 @@ class ExceptionHandlerExceptionResolverTests {
 
 		@ExceptionHandler(IOException.class)
 		public void handleException() {
+		}
+	}
+
+
+	@Controller
+	static class RethrowingExceptionController {
+
+		public void handle() {}
+
+		@ExceptionHandler(IOException.class)
+		public void handleException(IOException ex) throws IOException {
+			throw ex;
 		}
 	}
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/support/DefaultHandlerExceptionResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/support/DefaultHandlerExceptionResolverTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.web.servlet.mvc.support;
 
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
@@ -165,6 +166,15 @@ class DefaultHandlerExceptionResolverTests {
 	@Test
 	void handleHttpMessageNotWritable() {
 		HttpMessageNotWritableException ex = new HttpMessageNotWritableException("foo");
+		ModelAndView mav = exceptionResolver.resolveException(request, response, null, ex);
+		assertThat(mav).as("No ModelAndView returned").isNotNull();
+		assertThat(mav.isEmpty()).as("No Empty ModelAndView returned").isTrue();
+		assertThat(response.getStatus()).as("Invalid status code").isEqualTo(500);
+	}
+
+	@Test
+	void handleDisconnectedClientException() {
+		Exception ex = new IOException("Broken pipe");
 		ModelAndView mav = exceptionResolver.resolveException(request, response, null, ex);
 		assertThat(mav).as("No ModelAndView returned").isNotNull();
 		assertThat(mav.isEmpty()).as("No Empty ModelAndView returned").isTrue();


### PR DESCRIPTION
## Summary

This PR updates Spring MVC disconnected-client exception handling to set the response status to 500 instead of leaving it at the default 200 status.

The change covers both paths discussed in gh-34481:

- `DefaultHandlerExceptionResolver`, which handles default Spring MVC exception resolution
- `ExceptionHandlerExceptionResolver`, where an `@ExceptionHandler` rethrows a disconnected-client style exception

For an actual disconnected client, the client will not observe the response. For cases where the exception is incorrectly classified as a disconnected-client exception, this avoids silently reporting a failed request as successful.

This is based on the latest issue discussion; happy to adjust the scope or implementation if the maintainers prefer a different approach.

## Testing

- `./gradlew :spring-webmvc:test --tests org.springframework.web.servlet.mvc.support.DefaultHandlerExceptionResolverTests --tests org.springframework.web.servlet.mvc.method.annotation.ExceptionHandlerExceptionResolverTests`
- `git diff --check`

See gh-34481