### PR TITLE
Include zone ID in CronTrigger's equals/hashCode implementations

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/support/CronTrigger.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/support/CronTrigger.java
@@ -19,6 +19,7 @@ package org.springframework.scheduling.support;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Objects;
 import java.util.TimeZone;
 
 import org.jspecify.annotations.Nullable;
@@ -26,7 +27,6 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.TriggerContext;
 import org.springframework.util.Assert;
-import org.springframework.util.ObjectUtils;
 
 /**
  * {@link Trigger} implementation for cron expressions. Wraps a
@@ -147,12 +147,12 @@ public class CronTrigger implements Trigger {
 	public boolean equals(@Nullable Object other) {
 		return (this == other || (other instanceof CronTrigger that &&
 				this.expression.equals(that.expression) &&
-				ObjectUtils.nullSafeEquals(this.zoneId, that.zoneId)));
+				Objects.equals(this.zoneId, that.zoneId)));
 	}
 
 	@Override
 	public int hashCode() {
-		return ObjectUtils.nullSafeHash(this.expression, this.zoneId);
+		return Objects.hash(this.expression, this.zoneId);
 	}
 
 	@Override

--- a/spring-context/src/main/java/org/springframework/scheduling/support/CronTrigger.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/support/CronTrigger.java
@@ -26,6 +26,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.TriggerContext;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 
 /**
  * {@link Trigger} implementation for cron expressions. Wraps a
@@ -145,12 +146,13 @@ public class CronTrigger implements Trigger {
 	@Override
 	public boolean equals(@Nullable Object other) {
 		return (this == other || (other instanceof CronTrigger that &&
-				this.expression.equals(that.expression)));
+				this.expression.equals(that.expression) &&
+				ObjectUtils.nullSafeEquals(this.zoneId, that.zoneId)));
 	}
 
 	@Override
 	public int hashCode() {
-		return this.expression.hashCode();
+		return ObjectUtils.nullSafeHash(this.expression, this.zoneId);
 	}
 
 	@Override

--- a/spring-context/src/test/java/org/springframework/scheduling/support/CronTriggerTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/support/CronTriggerTests.java
@@ -748,7 +748,7 @@ class CronTriggerTests {
 	}
 
 	@Test
-	void equalsAndHashCodeConsidersZoneId() {
+	void equalsAndHashCodeConsiderZoneId() {
 		String cron = "0 0 9 * * *";
 		CronTrigger amsterdam = new CronTrigger(cron, ZoneId.of("Europe/Amsterdam"));
 		CronTrigger newYork = new CronTrigger(cron, ZoneId.of("America/New_York"));

--- a/spring-context/src/test/java/org/springframework/scheduling/support/CronTriggerTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/support/CronTriggerTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.scheduling.support;
 
+import java.time.ZoneId;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -744,6 +745,16 @@ class CronTriggerTests {
 		TriggerContext context = getTriggerContext(lastCompletionTime);
 		Object nextExecutionTime = trigger.nextExecutionTime(context);
 		assertThat(nextExecutionTime).isEqualTo(this.calendar.getTime());
+	}
+
+	@Test
+	void equalsAndHashCodeConsidersZoneId() {
+		String cron = "0 0 9 * * *";
+		CronTrigger amsterdam = new CronTrigger(cron, ZoneId.of("Europe/Amsterdam"));
+		CronTrigger newYork = new CronTrigger(cron, ZoneId.of("America/New_York"));
+
+		assertThat(amsterdam).isNotEqualTo(newYork);
+		assertThat(amsterdam).doesNotHaveSameHashCodeAs(newYork);
 	}
 
 


### PR DESCRIPTION
By default, `CronTrigger#equals` and `#hashCode` consider only the wrapped
`CronExpression`. Since 5.3, `CronTrigger` also carries an optional `ZoneId`
that is used in `nextExecution()` when a time zone is configured explicitly.
Two triggers built with the same cron pattern but different zones can therefore
produce different next execution times while still comparing as equal and
sharing the same hash code.

This causes incorrect deduplication when triggers are stored in a `Set` or used
as `Map` keys, and breaks the general `Object` contract for a type whose runtime
behavior depends on both the expression and the zone.

This PR includes `zoneId` in `equals` and `hashCode`, using
`ObjectUtils.nullSafeEquals` and `ObjectUtils.nullSafeHash` so that triggers
with a `null` zone (the default constructor) remain equal to each other but
distinct from triggers with an explicit zone.

This does not change trigger scheduling behavior or how `nextExecution`
selects a zone at runtime; it only corrects value-based equality for triggers
that differ solely by time zone configuration.

It also adds a regression test in
`CronTriggerTests#equalsAndHashCodeConsidersZoneId`.

## Test plan
- [x] `./gradlew :spring-context:test --tests "org.springframework.scheduling.support.CronTriggerTests.equalsAndHashCodeConsidersZoneId"`