### PR TITLE
Simplify BUFFER_COUNT in ConcurrentLruCache to a constant

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/ConcurrentLruCache.java
+++ b/spring-core/src/main/java/org/springframework/util/ConcurrentLruCache.java
@@ -367,7 +367,7 @@ public final class ConcurrentLruCache<K, V> {
 
 	private static final class ReadOperations<K, V> {
 
-		private static final int BUFFER_COUNT = detectNumberOfBuffers();
+		private static final int BUFFER_COUNT = 4;
 
 		private static final int BUFFERS_MASK = BUFFER_COUNT - 1;
 
@@ -450,11 +450,6 @@ public final class ConcurrentLruCache<K, V> {
 			this.processedCount.lazySet(bufferIndex, writeCount);
 		}
 
-		private static int detectNumberOfBuffers() {
-			int availableProcessors = Runtime.getRuntime().availableProcessors();
-			int nextPowerOfTwo = 1 << (Integer.SIZE - Integer.numberOfLeadingZeros(availableProcessors - 1));
-			return Math.min(4, nextPowerOfTwo);
-		}
 	}
 
 


### PR DESCRIPTION
## Problem

The `detectNumberOfBuffers()` method in `ConcurrentLruCache.ReadOperations` attempts to scale the read buffer count based on the number of available processors:

```java
private static int detectNumberOfBuffers() {
    int availableProcessors = Runtime.getRuntime().availableProcessors();
    int nextPowerOfTwo = 1 << (Integer.SIZE - Integer.numberOfLeadingZeros(availableProcessors - 1));
    return Math.min(4, nextPowerOfTwo);
}
```

However, the use of `Math.min(4, nextPowerOfTwo)` caps the result at 4 for any system with 3 or more processors. For systems with 5+ processors, `nextPowerOfTwo` would be 8 or more, but the `Math.min` always returns 4. The CPU-detection logic adds complexity without any actual effect for the vast majority of deployment environments.

As noted in [gh-36780](https://github.com/spring-projects/spring-framework/issues/36780), the value is *"basically always just 4"*.

## Fix

Simplify `BUFFER_COUNT` to a plain constant `4`, removing the `detectNumberOfBuffers()` method entirely. This is consistent with the feedback from [gh-29520](https://github.com/spring-projects/spring-framework/issues/29520) that informed the original cap at 4.

Closes gh-36780