### PR TITLE
Restore thread interrupt flag in `DefaultMvcResult` when catching `InterruptedException`

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/DefaultMvcResult.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/DefaultMvcResult.java
@@ -153,6 +153,7 @@ class DefaultMvcResult implements MvcResult {
 			return this.asyncDispatchLatch.await(timeout, TimeUnit.MILLISECONDS);
 		}
 		catch (InterruptedException ex) {
+			Thread.currentThread().interrupt();
 			return false;
 		}
 	}

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/DefaultMvcResultTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/DefaultMvcResultTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.mock.web.MockHttpServletRequest;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 /**
@@ -44,6 +45,21 @@ class DefaultMvcResultTests {
 	void getAsyncResultFailure() {
 		assertThatIllegalStateException().isThrownBy(() ->
 				this.mvcResult.getAsyncResult(0));
+	}
+
+	@Test
+	void getAsyncResultRestoresInterruptStatusWhenInterrupted() {
+		this.mvcResult.setAsyncDispatchLatch(new CountDownLatch(1));
+		Thread.currentThread().interrupt();
+		try {
+			assertThatIllegalStateException().isThrownBy(() ->
+					this.mvcResult.getAsyncResult(1000));
+			assertThat(Thread.currentThread().isInterrupted()).isTrue();
+		}
+		finally {
+			// Clear the interrupt status so it does not leak to other tests.
+			Thread.interrupted();
+		}
 	}
 
 }


### PR DESCRIPTION
`DefaultMvcResult.awaitAsyncDispatch()` catches `InterruptedException` and returns `false` without restoring the thread's interrupt status, so the interruption is silently lost.

When `InterruptedException` is caught without being rethrown, the interrupt status should be reasserted, as the framework already does elsewhere. For example, `ConcurrencyThrottleSupport` re-interrupts the current thread on the same exception ("Re-interrupt current thread, to allow other threads to react."). This applies the same handling with `Thread.currentThread().interrupt()` before returning `false`.

There is no other behavior change: an interruption already makes `getAsyncResult(...)` throw `IllegalStateException` via the `false` return, so this only preserves the interrupt status as it propagates. The added test interrupts the current thread before calling `getAsyncResult(...)` and verifies the interrupt status is still set afterwards.
