### PR TITLE
GH-36738: Document rendering-scope limitation of WebFlux RequestContext.changeLocale()

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/RequestContext.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/RequestContext.java
@@ -134,6 +134,16 @@ public class RequestContext {
 
 	/**
 	 * Change the current locale to the specified one.
+	 * <p><strong>Note:</strong> Unlike the Spring MVC counterpart, this method only
+	 * updates the locale within the scope of the current {@code RequestContext} instance
+	 * for view rendering purposes. It does <em>not</em> delegate to a
+	 * {@link org.springframework.web.server.i18n.LocaleContextResolver} and the change
+	 * is not persisted beyond the current rendering cycle. For a durable locale change
+	 * across requests in WebFlux, configure a
+	 * {@link org.springframework.web.server.i18n.LocaleContextResolver} and update it
+	 * from a {@link org.springframework.web.server.WebFilter} or handler method instead.
+	 * @param locale the new locale
+	 * @see #changeLocale(java.util.Locale, java.util.TimeZone)
 	 */
 	public void changeLocale(Locale locale) {
 		this.locale = locale;
@@ -141,6 +151,14 @@ public class RequestContext {
 
 	/**
 	 * Change the current locale to the specified locale and time zone context.
+	 * <p><strong>Note:</strong> Unlike the Spring MVC counterpart, this method only
+	 * updates the locale and time zone within the scope of the current
+	 * {@code RequestContext} instance for view rendering purposes. It does <em>not</em>
+	 * delegate to a {@link org.springframework.web.server.i18n.LocaleContextResolver}
+	 * and the change is not persisted beyond the current rendering cycle.
+	 * @param locale the new locale
+	 * @param timeZone the new time zone
+	 * @see #changeLocale(java.util.Locale)
 	 */
 	public void changeLocale(Locale locale, TimeZone timeZone) {
 		this.locale = locale;


### PR DESCRIPTION
## Summary

Closes #36738.

The Spring MVC `RequestContext.changeLocale()` delegates through the configured `LocaleResolver`, persisting the new locale for subsequent requests. The WebFlux equivalent updates only a private field on the current `RequestContext` instance; the change is silently discarded at the end of the rendering cycle. This asymmetry was undocumented, causing developers to expect the same durable behavior as in MVC.

This PR adds Javadoc to both `changeLocale` overloads in `org.springframework.web.reactive.result.view.RequestContext`, clearly documenting:

- The change affects only the current rendering context (not the underlying request or response).
- It does **not** delegate to a `LocaleContextResolver`.
- It is not persisted beyond the current rendering cycle.
- For durable locale changes in WebFlux, developers should configure a `LocaleContextResolver` and update it from a `WebFilter` or handler method.

Spring MVC's `RequestContext.changeLocale()` already has explicit Javadoc (including `@see LocaleResolver#setLocale`) — this PR closes the MVC/WebFlux documentation parity gap for this method.

## Test plan

- [ ] Existing tests continue to pass (no behaviour change — Javadoc only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)