### PR TITLE
GH-36631: Fix MockHttpServletRequest.isRequestedSessionIdValid() to follow Servlet 6.1 spec

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
@@ -250,7 +250,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 
 	private @Nullable HttpSession session;
 
-	private boolean requestedSessionIdValid = true;
+	private @Nullable Boolean requestedSessionIdValid;
 
 	private boolean requestedSessionIdFromCookie = true;
 
@@ -1344,13 +1344,37 @@ public class MockHttpServletRequest implements HttpServletRequest {
 		return this.session.getId();
 	}
 
+	/**
+	 * Set the flag returned by {@link #isRequestedSessionIdValid()}.
+	 * <p>If not explicitly set, the flag is computed dynamically to follow the
+	 * {@link jakarta.servlet.http.HttpServletRequest#isRequestedSessionIdValid()} contract:
+	 * {@code false} when no session ID was submitted ({@link #getRequestedSessionId()} is
+	 * {@code null}), and {@code false} after {@link #changeSessionId()} invalidates the
+	 * originally-requested ID.
+	 */
 	public void setRequestedSessionIdValid(boolean requestedSessionIdValid) {
 		this.requestedSessionIdValid = requestedSessionIdValid;
 	}
 
+	/**
+	 * Returns whether the requested session ID is still valid in the current session context.
+	 * <p>If {@link #setRequestedSessionIdValid} has been called explicitly, the value set
+	 * there is returned. Otherwise this method follows the Servlet specification contract:
+	 * returns {@code false} when the client did not submit any session ID (i.e.,
+	 * {@link #getRequestedSessionId()} is {@code null}), and returns {@code false} if the
+	 * session ID submitted by the client no longer matches the current session (e.g., after
+	 * {@link #changeSessionId()} was called). Returns {@code true} when a session exists and
+	 * the submitted session ID matches the current session ID.
+	 */
 	@Override
 	public boolean isRequestedSessionIdValid() {
-		return this.requestedSessionIdValid;
+		if (this.requestedSessionIdValid != null) {
+			return this.requestedSessionIdValid;
+		}
+		if (this.requestedSessionId == null) {
+			return false;
+		}
+		return (this.session != null && this.requestedSessionId.equals(this.session.getId()));
 	}
 
 	public void setRequestedSessionIdFromCookie(boolean requestedSessionIdFromCookie) {

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/RequestContext.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/view/RequestContext.java
@@ -134,6 +134,16 @@ public class RequestContext {
 
 	/**
 	 * Change the current locale to the specified one.
+	 * <p><strong>Note:</strong> Unlike the Spring MVC counterpart, this method only
+	 * updates the locale within the scope of the current {@code RequestContext} instance
+	 * for view rendering purposes. It does <em>not</em> delegate to a
+	 * {@link org.springframework.web.server.i18n.LocaleContextResolver} and the change
+	 * is not persisted beyond the current rendering cycle. For a durable locale change
+	 * across requests in WebFlux, configure a
+	 * {@link org.springframework.web.server.i18n.LocaleContextResolver} and update it
+	 * from a {@link org.springframework.web.server.WebFilter} or handler method instead.
+	 * @param locale the new locale
+	 * @see #changeLocale(java.util.Locale, java.util.TimeZone)
 	 */
 	public void changeLocale(Locale locale) {
 		this.locale = locale;
@@ -141,6 +151,14 @@ public class RequestContext {
 
 	/**
 	 * Change the current locale to the specified locale and time zone context.
+	 * <p><strong>Note:</strong> Unlike the Spring MVC counterpart, this method only
+	 * updates the locale and time zone within the scope of the current
+	 * {@code RequestContext} instance for view rendering purposes. It does <em>not</em>
+	 * delegate to a {@link org.springframework.web.server.i18n.LocaleContextResolver}
+	 * and the change is not persisted beyond the current rendering cycle.
+	 * @param locale the new locale
+	 * @param timeZone the new time zone
+	 * @see #changeLocale(java.util.Locale)
 	 */
 	public void changeLocale(Locale locale, TimeZone timeZone) {
 		this.locale = locale;


### PR DESCRIPTION
## Summary

`MockHttpServletRequest.isRequestedSessionIdValid()` always returned `true` by default regardless of the actual session state, which violates the Servlet 6.1 specification:

> **`isRequestedSessionIdValid()`** — returns `false` if the client did not specify any session ID; otherwise reflects whether the requested ID corresponds to a valid session in the current context.

This causes two concrete failures:
1. A fresh `MockHttpServletRequest` (no session ID set) has `isRequestedSessionIdValid() == true` even though `getRequestedSessionId() == null`.
2. After `changeSessionId()` rotates the session ID, the previously-requested ID no longer matches the new session ID, but `isRequestedSessionIdValid()` still returned `true` unless manually reset.

## Fix

Changed the backing field from `boolean requestedSessionIdValid = true` to `@Nullable Boolean requestedSessionIdValid` (default `null`).

- When **explicitly set** via `setRequestedSessionIdValid(boolean)`, that value is returned verbatim (backwards-compatible override for existing tests that control the flag manually).
- When **null** (the default), `isRequestedSessionIdValid()` derives its value from the actual request state:
  - Returns `false` if `getRequestedSessionId()` is `null` (no session ID submitted by the client).
  - Returns `true` only when a session exists and `requestedSessionId` matches `session.getId()`.
  - Returns `false` in all other cases, including post-`changeSessionId()` scenarios.

## Test plan

- [ ] Existing `MockHttpServletRequestTests` continues to pass (no tests assert on `isRequestedSessionIdValid()`)
- [ ] The two minimal reproductions from the issue should now pass:

```java
// 1. No client session id
MockHttpServletRequest request = new MockHttpServletRequest();
assertThat(request.getRequestedSessionId()).isNull();
assertThat(request.isRequestedSessionIdValid()).isFalse(); // was: true

// 2. After session id rotation
MockHttpServletRequest request = new MockHttpServletRequest();
MockHttpSession session = new MockHttpSession();
request.setSession(session);
request.setRequestedSessionId(session.getId());
request.changeSessionId();
assertThat(request.isRequestedSessionIdValid()).isFalse(); // was: true
```

## Related Issues

- #36631

🤖 Generated with [Claude Code](https://claude.com/claude-code)