### PR TITLE
validate samesite attribute in ResponseCookie

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ResponseCookie.java
+++ b/spring-web/src/main/java/org/springframework/http/ResponseCookie.java
@@ -75,6 +75,7 @@ public final class ResponseCookie extends HttpCookie {
 		Rfc6265Utils.validateCookieValue(value);
 		Rfc6265Utils.validateDomain(domain);
 		Rfc6265Utils.validatePath(path);
+		Rfc6265Utils.validateSameSite(sameSite);
 	}
 
 
@@ -430,6 +431,18 @@ public final class ResponseCookie extends HttpCookie {
 				char c = path.charAt(i);
 				if (c < 0x20 || c > 0x7E || c == ';') {
 					throw new IllegalArgumentException(path + ": Invalid cookie path char '" + c + "'");
+				}
+			}
+		}
+
+		public static void validateSameSite(@Nullable String sameSite) {
+			if (sameSite == null) {
+				return;
+			}
+			for (int i = 0; i < sameSite.length(); i++) {
+				char c = sameSite.charAt(i);
+				if (c < 0x20 || c > 0x7E || c == ';') {
+					throw new IllegalArgumentException(sameSite + ": Invalid cookie SameSite char '" + c + "'");
 				}
 			}
 		}

--- a/spring-web/src/test/java/org/springframework/http/ResponseCookieTests.java
+++ b/spring-web/src/test/java/org/springframework/http/ResponseCookieTests.java
@@ -82,6 +82,17 @@ class ResponseCookieTests {
 						.hasMessageContaining("invalid cookie domain char"));
 	}
 
+	@Test
+	void sameSiteChecks() {
+
+		Arrays.asList("Strict", "Lax", "None")
+				.forEach(sameSite -> ResponseCookie.from("n", "v").sameSite(sameSite).build());
+
+		Arrays.asList("Lax\r\nSet-Cookie: x=y", "Lax\n", "La;x", "Lax\t", "Lax\u0005")
+				.forEach(sameSite -> assertThatThrownBy(() -> ResponseCookie.from("n", "v").sameSite(sameSite).build())
+						.hasMessageContaining("Invalid cookie SameSite char"));
+	}
+
 	@Test // gh-24663
 	void domainWithEmptyDoubleQuotes() {
 


### PR DESCRIPTION
ResponseCookie validates the cookie name, value, domain and path but the SameSite attribute is appended to the Set-Cookie value as-is, so a value carrying control characters or a semicolon (for instance one taken from an upstream Set-Cookie by the reactive client cookie parsers) can add further attributes or split the header. It seemed safer to check it the same way as the other attributes, so this adds a SameSite check alongside the existing ones in the constructor. Control characters, non-ASCII and ';' are rejected while the usual Strict, Lax and None values still pass.