### PR TITLE
Add missing `@Nullable` type annotation to Iterator declaration

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/UriComponents.java
+++ b/spring-web/src/main/java/org/springframework/web/util/UriComponents.java
@@ -345,7 +345,7 @@ public abstract class UriComponents implements Serializable {
 	 */
 	private static class VarArgsTemplateVariables implements UriTemplateVariables {
 
-		private final Iterator<Object> valueIterator;
+		private final Iterator<@Nullable Object> valueIterator;
 
 		public VarArgsTemplateVariables(@Nullable Object... uriVariableValues) {
 			this.valueIterator = Arrays.asList(uriVariableValues).iterator();


### PR DESCRIPTION
## Context
Nullaway had a warning highlighted in https://github.com/uber/NullAway/actions/runs/27324825986/job/80868514610.
On taking a look, it seemed to have merit.

In the covered code:
https://github.com/spring-projects/spring-framework/blob/0c60266986197a191ff33eb498ebc8bac3dc933f/spring-web/src/main/java/org/springframework/web/util/UriComponents.java#L348-L352

The varargs param is `@Nullable Object...`, so `Arrays.asList(uriVariableValues)` is `List<@Nullable Object>` and `.iterator()` is `Iterator<@Nullable Object>`, but the field is declared `Iterator<Object>`.

The PR aligns the type signatures by adding the missing `@Nullable` annotation to the declaration.