### PR TITLE
Fix reserveMethodNames to reserve each supplied name

### DIFF
--- a/spring-core/src/main/java/org/springframework/aot/generate/GeneratedClass.java
+++ b/spring-core/src/main/java/org/springframework/aot/generate/GeneratedClass.java
@@ -81,7 +81,7 @@ public final class GeneratedClass {
 	 */
 	public void reserveMethodNames(String... reservedMethodNames) {
 		for (String reservedMethodName : reservedMethodNames) {
-			String generatedName = generateSequencedMethodName(MethodName.of(reservedMethodNames));
+			String generatedName = generateSequencedMethodName(MethodName.of(reservedMethodName));
 			Assert.state(generatedName.equals(reservedMethodName),
 					() -> String.format("Unable to reserve method name '%s'", reservedMethodName));
 		}

--- a/spring-core/src/test/java/org/springframework/aot/generate/GeneratedClassTests.java
+++ b/spring-core/src/test/java/org/springframework/aot/generate/GeneratedClassTests.java
@@ -79,6 +79,14 @@ class GeneratedClassTests {
 	}
 
 	@Test
+	void reserveMethodNamesWhenMultipleNamesReservesEachName() {
+		GeneratedClass generatedClass = createGeneratedClass(TEST_CLASS_NAME);
+		generatedClass.reserveMethodNames("apply", "test");
+		assertThat(generatedClass.getMethods().add("apply", emptyMethodCustomizer).getName()).isEqualTo("apply1");
+		assertThat(generatedClass.getMethods().add("test", emptyMethodCustomizer).getName()).isEqualTo("test1");
+	}
+
+	@Test
 	void generateMethodNameWhenAllEmptyPartsGeneratesSetName() {
 		GeneratedClass generatedClass = createGeneratedClass(TEST_CLASS_NAME);
 		GeneratedMethod generatedMethod = generatedClass.getMethods().add("123", emptyMethodCustomizer);


### PR DESCRIPTION
## Overview

`GeneratedClass.reserveMethodNames(String...)` reserves a set of method names so that
generated methods will not collide with them.

## Problem

Inside the per-name loop, the whole varargs array was passed to `MethodName.of(...)` instead
of the current element:

```java
for (String reservedMethodName : reservedMethodNames) {
    String generatedName = generateSequencedMethodName(MethodName.of(reservedMethodNames)); // whole array
    Assert.state(generatedName.equals(reservedMethodName), ...);
}
```

`MethodName.of(String...)` joins all parts into a single camel-case name, so
`reserveMethodNames("apply", "test")` produced `"applyTest"`, and the per-element check
`Assert.state("applyTest".equals("apply"))` failed with `IllegalStateException`. Single-name
calls worked only by accident (a one-element array round-trips to the same name). The only
in-tree caller reserves a single name, so the multi-name path was never exercised.

## Fix

Pass the loop variable so that each supplied name is reserved individually. A regression test
in `GeneratedClassTests` reserves two names.

## Note on intent

This fix assumes `reserveMethodNames` is meant to reserve **each** supplied name individually.
The per-element assertion `Assert.state(generatedName.equals(reservedMethodName))` and the
javadoc ("a set of reserved method names") both indicate this. If the intent was instead to
reserve a single combined name, the loop and the per-element assertion would be inconsistent
and a different fix would be appropriate — happy to adjust if I have misread the intent.
