### PR TITLE
Fix `OptionalToObjectConverter` applicability check

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/support/OptionalToObjectConverter.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/OptionalToObjectConverter.java
@@ -21,6 +21,7 @@ import java.util.Set;
 
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.core.ResolvableType;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.convert.converter.ConditionalGenericConverter;
@@ -51,7 +52,14 @@ final class OptionalToObjectConverter implements ConditionalGenericConverter {
 
 	@Override
 	public boolean matches(TypeDescriptor sourceType, TypeDescriptor targetType) {
-		return ConversionUtils.canConvertElements(sourceType.getElementTypeDescriptor(), targetType, this.conversionService);
+		ResolvableType elementType = sourceType.getResolvableType().getGeneric();
+		if (elementType.resolve() == null) {
+			// Unknown Optional element type (raw Optional, wildcard, or unresolved
+			// type variable): remain permissive.
+			return true;
+		}
+		TypeDescriptor sourceElementType = new TypeDescriptor(elementType, null, null);
+		return ConversionUtils.canConvertElements(sourceElementType, targetType, this.conversionService);
 	}
 
 	@Override

--- a/spring-core/src/test/java/org/springframework/core/convert/converter/DefaultConversionServiceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/converter/DefaultConversionServiceTests.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.AbstractList;
 import java.util.ArrayList;
@@ -961,6 +962,25 @@ class DefaultConversionServiceTests {
 
 		private static final TypeDescriptor rawOptionalType = TypeDescriptor.valueOf(Optional.class);
 
+
+		@Test
+		void canConvertOptionalToObjectReflectsContainedElementType() {
+			TypeDescriptor integerOptionalType =
+					new TypeDescriptor(ResolvableType.forClassWithGenerics(Optional.class, Integer.class), null, null);
+			TypeDescriptor localDateType = TypeDescriptor.valueOf(LocalDate.class);
+
+			// Integer -> String is convertible
+			assertThat(conversionService.canConvert(integerOptionalType, TypeDescriptor.valueOf(String.class))).isTrue();
+
+			// Integer -> LocalDate is not convertible, so canConvert must not over-report...
+			assertThat(conversionService.canConvert(integerOptionalType, localDateType)).isFalse();
+			// ...and must stay consistent with convert(): no converter is selected
+			assertThatExceptionOfType(ConverterNotFoundException.class)
+					.isThrownBy(() -> conversionService.convert(Optional.of(42), integerOptionalType, localDateType));
+
+			// An Optional with an unknown element type remains permissive
+			assertThat(conversionService.canConvert(rawOptionalType, localDateType)).isTrue();
+		}
 
 		@Test
 		@SuppressWarnings("unchecked")

--- a/spring-core/src/test/java/org/springframework/core/convert/converter/DefaultConversionServiceTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/converter/DefaultConversionServiceTests.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.AbstractList;
 import java.util.ArrayList;
@@ -1012,6 +1013,72 @@ class DefaultConversionServiceTests {
 
 		private static final TypeDescriptor rawOptionalType = TypeDescriptor.valueOf(Optional.class);
 
+		@SuppressWarnings("unused")
+		private Optional<?> unboundedWildcardOptional;
+
+		@SuppressWarnings("unused")
+		private Optional<? extends Number> boundedWildcardOptional;
+
+
+		@Test  // raw Optional: no element type information, so the converter remains permissive
+		void canConvertRawOptionalRemainsPermissive() {
+			assertThat(conversionService.canConvert(rawOptionalType, TypeDescriptor.valueOf(LocalDate.class))).isTrue();
+		}
+
+		@Test  // Optional<?>: the Object upper bound resolves to null, so the converter remains permissive
+		void canConvertOptionalWithUnboundedWildcardRemainsPermissive() throws Exception {
+			TypeDescriptor unboundedWildcardOptionalType = optionalTypeFor("unboundedWildcardOptional");
+			assertThat(conversionService.canConvert(unboundedWildcardOptionalType, TypeDescriptor.valueOf(LocalDate.class))).isTrue();
+		}
+
+		@Test  // Optional<T> with an unresolved type variable also remains permissive
+		void canConvertOptionalWithUnresolvedTypeVariableRemainsPermissive() throws Exception {
+			TypeDescriptor typeVariableOptionalType =
+					new TypeDescriptor(TypeVariableHolder.class.getDeclaredField("typeVariableOptional"));
+			assertThat(conversionService.canConvert(typeVariableOptionalType, TypeDescriptor.valueOf(LocalDate.class))).isTrue();
+		}
+
+		@Test  // Optional<? extends Number>: applicability is decided against the Number upper bound
+		void canConvertOptionalWithBoundedWildcardReflectsUpperBound() throws Exception {
+			TypeDescriptor boundedWildcardOptionalType = optionalTypeFor("boundedWildcardOptional");
+			TypeDescriptor localDateType = TypeDescriptor.valueOf(LocalDate.class);
+
+			assertThat(conversionService.canConvert(boundedWildcardOptionalType, TypeDescriptor.valueOf(String.class))).isTrue();
+			assertThat(conversionService.convert(Optional.of(42), boundedWildcardOptionalType,
+					TypeDescriptor.valueOf(String.class))).isEqualTo("42");
+			assertThat(conversionService.canConvert(boundedWildcardOptionalType, localDateType)).isFalse();
+			assertThatExceptionOfType(ConverterNotFoundException.class)
+					.isThrownBy(() -> conversionService.convert(Optional.of(42), boundedWildcardOptionalType, localDateType));
+		}
+
+		private static TypeDescriptor optionalTypeFor(String fieldName) throws Exception {
+			return new TypeDescriptor(OptionalConversionTests.class.getDeclaredField(fieldName));
+		}
+
+		@SuppressWarnings("unused")
+		private static class TypeVariableHolder<T> {
+
+			Optional<T> typeVariableOptional;
+		}
+
+		@Test
+		void canConvertOptionalToObjectReflectsContainedElementType() {
+			TypeDescriptor integerOptionalType =
+					new TypeDescriptor(ResolvableType.forClassWithGenerics(Optional.class, Integer.class), null, null);
+			TypeDescriptor localDateType = TypeDescriptor.valueOf(LocalDate.class);
+
+			// Integer -> String is convertible
+			assertThat(conversionService.canConvert(integerOptionalType, TypeDescriptor.valueOf(String.class))).isTrue();
+
+			// Integer -> LocalDate is not convertible, so canConvert must not over-report...
+			assertThat(conversionService.canConvert(integerOptionalType, localDateType)).isFalse();
+			// ...and must stay consistent with convert(): no converter is selected
+			assertThatExceptionOfType(ConverterNotFoundException.class)
+					.isThrownBy(() -> conversionService.convert(Optional.of(42), integerOptionalType, localDateType));
+
+			// An Optional with an unknown element type remains permissive
+			assertThat(conversionService.canConvert(rawOptionalType, localDateType)).isTrue();
+		}
 
 		@Test
 		@SuppressWarnings("unchecked")


### PR DESCRIPTION
## Overview

`OptionalToObjectConverter` (registered by `DefaultConversionService` for `Optional` -> `Object`) unwraps an `Optional` and delegates the contained value to the `ConversionService`.

## Problem

`matches()` derived the contained type with `TypeDescriptor.getElementTypeDescriptor()`:

```java
return ConversionUtils.canConvertElements(sourceType.getElementTypeDescriptor(), targetType, this.conversionService);
```

`TypeDescriptor.getElementTypeDescriptor()` only resolves element types for arrays, streams and collections, so for an `Optional` it returns `null`. `ConversionUtils.canConvertElements()` then treats a `null` source element type as "maybe" and returns `true` unconditionally. As a result `matches()` always matched, and `ConversionService.canConvert(Optional<X>, target)` returned `true` even when `X` cannot be converted to `target` — violating the `canConvert` contract (a `true` result implies `convert` is capable of converting), since the subsequent conversion fails.

For example, with the out-of-the-box `DefaultConversionService`:

```java
TypeDescriptor optionalInteger = new TypeDescriptor(
        ResolvableType.forClassWithGenerics(Optional.class, Integer.class), null, null);
cs.canConvert(optionalInteger, TypeDescriptor.valueOf(LocalDate.class)); // true (incorrect)
cs.convert(Optional.of(42), optionalInteger, TypeDescriptor.valueOf(LocalDate.class)); // fails
```

## Fix

Resolve the `Optional`'s element type from its generic and check it against the target, mirroring the sibling `ObjectToOptionalConverter`. A raw `Optional` (or otherwise unresolved element type) stays permissive, since the element type is unknown. A regression test is added to `DefaultConversionServiceTests`.

## Note on impact

This is a contract-correctness fix rather than a fix for data corruption: the conversion itself already fails loudly (the subsequent `convert` throws), so nothing is silently mis-converted. The value is that `canConvert`/`matches` is a *predicate* callers rely on to decide whether to attempt a conversion or take a different path. Returning an incorrect `true` defeats that — it turns what should be a clean negative answer into a deferred exception. Restoring an accurate `matches()` lets callers get the correct answer up front. Impact is bounded, since it only affects `Optional` used as a conversion *source* whose element type is not convertible to the target.
