### PR TITLE
Honor `sourceStart` offset in `AbstractXMLStreamReader#getTextCharacters`

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/xml/AbstractXMLStreamReader.java
+++ b/spring-core/src/main/java/org/springframework/util/xml/AbstractXMLStreamReader.java
@@ -190,7 +190,7 @@ abstract class AbstractXMLStreamReader implements XMLStreamReader {
 	@Override
 	public int getTextCharacters(int sourceStart, char[] target, int targetStart, int length) {
 		char[] source = getTextCharacters();
-		length = Math.min(length, source.length);
+		length = Math.min(length, source.length - sourceStart);
 		System.arraycopy(source, sourceStart, target, targetStart, length);
 		return length;
 	}

--- a/spring-core/src/test/java/org/springframework/util/xml/XMLEventStreamReaderTests.java
+++ b/spring-core/src/test/java/org/springframework/util/xml/XMLEventStreamReaderTests.java
@@ -21,6 +21,7 @@ import java.io.StringWriter;
 
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stax.StAXSource;
@@ -66,6 +67,22 @@ class XMLEventStreamReaderTests {
 		Predicate<Node> nodeFilter = n ->
 				n.getNodeType() != Node.DOCUMENT_TYPE_NODE && n.getNodeType() != Node.PROCESSING_INSTRUCTION_NODE;
 		assertThat(XmlContent.from(writer)).isSimilarTo(XML, nodeFilter);
+	}
+
+	@Test  // getTextCharacters(sourceStart, ...) must not read past the source
+	void getTextCharactersHonorsSourceStart() throws Exception {
+		advanceToCharacters();
+		// text node is "content" (7 chars); copy from index 4 with an oversized buffer
+		char[] target = new char[10];
+		int count = streamReader.getTextCharacters(4, target, 0, 10);
+		assertThat(count).isEqualTo(3);
+		assertThat(new String(target, 0, count)).isEqualTo("ent");
+	}
+
+	private void advanceToCharacters() throws Exception {
+		while (streamReader.getEventType() != XMLStreamConstants.CHARACTERS) {
+			streamReader.next();
+		}
 	}
 
 }


### PR DESCRIPTION
## Overview

`AbstractXMLStreamReader` (the base for `XMLEventStreamReader`, reachable via the public
`StaxUtils.createEventStreamReader(XMLEventReader)`) implements
`getTextCharacters(int sourceStart, char[] target, int targetStart, int length)`.

## Problem

The copy length was capped with `Math.min(length, source.length)`, ignoring `sourceStart`:

```java
char[] source = getTextCharacters();
length = Math.min(length, source.length);
System.arraycopy(source, sourceStart, target, targetStart, length);
```

When `sourceStart > 0` and `sourceStart + length` exceeds the text length, `System.arraycopy`
reads past the end of `source` and throws `ArrayIndexOutOfBoundsException`. This breaks the
`XMLStreamReader#getTextCharacters(int, char[], int, int)` contract, which copies up to `length`
characters starting at `sourceStart` and returns the number actually copied — exactly the pattern
a consumer uses to read a long text node in chunks (`sourceStart += copied`).

## Fix

Cap the length by the number of characters remaining from `sourceStart`
(`Math.min(length, source.length - sourceStart)`). A regression test is added to
`XMLEventStreamReaderTests`.
