### PR TITLE
Validate namespace and local name in require

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/xml/AbstractXMLStreamReader.java
+++ b/spring-core/src/main/java/org/springframework/util/xml/AbstractXMLStreamReader.java
@@ -153,10 +153,24 @@ abstract class AbstractXMLStreamReader implements XMLStreamReader {
 	}
 
 	@Override
-	public void require(int expectedType, String namespaceURI, String localName) throws XMLStreamException {
+	public void require(int expectedType, @Nullable String namespaceURI, @Nullable String localName)
+			throws XMLStreamException {
+
 		int eventType = getEventType();
 		if (eventType != expectedType) {
 			throw new XMLStreamException("Expected [" + expectedType + "] but read [" + eventType + "]");
+		}
+		// This reader only exposes a name and namespace for START_ELEMENT and END_ELEMENT,
+		// so a non-null namespace or local name can only ever match one of those events.
+		if ((namespaceURI != null || localName != null) &&
+				eventType != XMLStreamConstants.START_ELEMENT && eventType != XMLStreamConstants.END_ELEMENT) {
+			throw new XMLStreamException("Current event is not a START_ELEMENT or END_ELEMENT");
+		}
+		if (localName != null && !localName.equals(getLocalName())) {
+			throw new XMLStreamException("Expected local name [" + localName + "] but read [" + getLocalName() + "]");
+		}
+		if (namespaceURI != null && !namespaceURI.equals(getNamespaceURI())) {
+			throw new XMLStreamException("Expected namespace [" + namespaceURI + "] but read [" + getNamespaceURI() + "]");
 		}
 	}
 

--- a/spring-core/src/test/java/org/springframework/util/xml/XMLEventStreamReaderTests.java
+++ b/spring-core/src/test/java/org/springframework/util/xml/XMLEventStreamReaderTests.java
@@ -21,6 +21,8 @@ import java.io.StringWriter;
 
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.stax.StAXSource;
@@ -34,6 +36,7 @@ import org.xmlunit.util.Predicate;
 import org.springframework.core.testfixture.xml.XmlContent;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 class XMLEventStreamReaderTests {
 
@@ -66,6 +69,27 @@ class XMLEventStreamReaderTests {
 		Predicate<Node> nodeFilter = n ->
 				n.getNodeType() != Node.DOCUMENT_TYPE_NODE && n.getNodeType() != Node.PROCESSING_INSTRUCTION_NODE;
 		assertThat(XmlContent.from(writer)).isSimilarTo(XML, nodeFilter);
+	}
+
+	@Test  // require(type, namespaceURI, localName) must validate the name and namespace
+	void requireValidatesNamespaceAndLocalName() throws Exception {
+		advanceToStartElement("root");
+
+		streamReader.require(XMLStreamConstants.START_ELEMENT, null, "root");
+		streamReader.require(XMLStreamConstants.START_ELEMENT, "namespace", "root");
+		streamReader.require(XMLStreamConstants.START_ELEMENT, "namespace", null);
+
+		assertThatExceptionOfType(XMLStreamException.class).isThrownBy(() ->
+				streamReader.require(XMLStreamConstants.START_ELEMENT, null, "wrong"));
+		assertThatExceptionOfType(XMLStreamException.class).isThrownBy(() ->
+				streamReader.require(XMLStreamConstants.START_ELEMENT, "wrong-namespace", "root"));
+	}
+
+	private void advanceToStartElement(String localName) throws Exception {
+		while (streamReader.getEventType() != XMLStreamConstants.START_ELEMENT ||
+				!streamReader.getLocalName().equals(localName)) {
+			streamReader.next();
+		}
 	}
 
 }


### PR DESCRIPTION
## Overview

`AbstractXMLStreamReader` (the base for `XMLEventStreamReader`, reachable via the public
`StaxUtils.createEventStreamReader(XMLEventReader)`) implements
`require(int expectedType, String namespaceURI, String localName)`.

## Problem

`require` only compared the event type; the `namespaceURI` and `localName` arguments were ignored
entirely:

```java
public void require(int expectedType, String namespaceURI, String localName) throws XMLStreamException {
    int eventType = getEventType();
    if (eventType != expectedType) {
        throw new XMLStreamException("Expected [" + expectedType + "] but read [" + eventType + "]");
    }
}
```

So a mismatched name or namespace passed silently, contrary to the
`XMLStreamReader#require(int, String, String)` contract: when `namespaceURI`/`localName` are
non-null they must match the current event, otherwise an `XMLStreamException` is thrown. The method
has only ever validated the event type since the class was introduced, and there are no in-tree
callers, so it went unnoticed.

## Fix

Validate `localName` and `namespaceURI` against the current event. A test is added to
`XMLEventStreamReaderTests`.

## Note on scope

This reader exposes a name and namespace only for `START_ELEMENT` and `END_ELEMENT`
(`getName()` is defined only for those states). Accordingly, a non-null name or namespace on any
other event type is treated as a mismatch and reported via `XMLStreamException`. `ENTITY_REFERENCE`
local-name validation (permitted by the spec) is intentionally not attempted, because this reader
cannot expose entity names — `getName()` throws `IllegalStateException` outside of element events.
This keeps `require` honest (it never silently accepts a non-matching name) within what the reader
can actually observe; happy to adjust the scope if maintainers prefer a different boundary.
