### PR TITLE
Balance throttle permits in SimpleAsyncTaskExecutor

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/task/SimpleAsyncTaskExecutor.java
+++ b/spring-core/src/main/java/org/springframework/core/task/SimpleAsyncTaskExecutor.java
@@ -471,27 +471,27 @@ public class SimpleAsyncTaskExecutor extends CustomizableThreadCreator
 
 		private final @Nullable Future<?> future;
 
-		private final boolean throttled;
+		private final boolean releaseThrottle;
 
-		public TaskTrackingRunnable(Runnable task, @Nullable Future<?> future, boolean throttled) {
+		public TaskTrackingRunnable(Runnable task, @Nullable Future<?> future, boolean releaseThrottle) {
 			Assert.notNull(task, "Task must not be null");
 			this.task = task;
 			this.future = future;
-			this.throttled = throttled;
+			this.releaseThrottle = releaseThrottle;
 		}
 
 		@Override
 		public void run() {
 			Set<Thread> threads = activeThreads;
 			Thread thread = null;
-			if (threads != null) {
-				thread = Thread.currentThread();
-				synchronized (threads) {
-					checkCancelled(this.future);
-					threads.add(thread);
-				}
-			}
 			try {
+				if (threads != null) {
+					thread = Thread.currentThread();
+					synchronized (threads) {
+						checkCancelled(this.future);
+						threads.add(thread);
+					}
+				}
 				this.task.run();
 			}
 			finally {
@@ -505,7 +505,9 @@ public class SimpleAsyncTaskExecutor extends CustomizableThreadCreator
 						}
 					}
 				}
-				if (this.throttled) {
+				// Release the throttle permit only if one was acquired (see execute),
+				// and always release it once acquired -- even if checkCancelled() above threw.
+				if (this.releaseThrottle) {
 					concurrencyThrottle.afterAccess();
 				}
 			}

--- a/spring-core/src/main/java/org/springframework/core/task/SimpleAsyncTaskExecutor.java
+++ b/spring-core/src/main/java/org/springframework/core/task/SimpleAsyncTaskExecutor.java
@@ -319,7 +319,7 @@ public class SimpleAsyncTaskExecutor extends CustomizableThreadCreator
 		if (isThrottleActive() && startTimeout > TIMEOUT_IMMEDIATE) {
 			this.concurrencyThrottle.beforeAccess();
 			try {
-				doExecute(new TaskTrackingRunnable(taskToUse, future));
+				doExecute(new TaskTrackingRunnable(taskToUse, future, true));
 			}
 			catch (Throwable ex) {
 				// Release concurrency permit if thread creation fails
@@ -328,7 +328,7 @@ public class SimpleAsyncTaskExecutor extends CustomizableThreadCreator
 			}
 		}
 		else if (this.activeThreads != null) {
-			doExecute(new TaskTrackingRunnable(taskToUse, future));
+			doExecute(new TaskTrackingRunnable(taskToUse, future, false));
 		}
 		else {
 			doExecute(taskToUse);
@@ -471,10 +471,13 @@ public class SimpleAsyncTaskExecutor extends CustomizableThreadCreator
 
 		private final @Nullable Future<?> future;
 
-		public TaskTrackingRunnable(Runnable task, @Nullable Future<?> future) {
+		private final boolean throttled;
+
+		public TaskTrackingRunnable(Runnable task, @Nullable Future<?> future, boolean throttled) {
 			Assert.notNull(task, "Task must not be null");
 			this.task = task;
 			this.future = future;
+			this.throttled = throttled;
 		}
 
 		@Override
@@ -502,7 +505,9 @@ public class SimpleAsyncTaskExecutor extends CustomizableThreadCreator
 						}
 					}
 				}
-				concurrencyThrottle.afterAccess();
+				if (this.throttled) {
+					concurrencyThrottle.afterAccess();
+				}
 			}
 		}
 	}

--- a/spring-core/src/test/java/org/springframework/core/task/SimpleAsyncTaskExecutorTests.java
+++ b/spring-core/src/test/java/org/springframework/core/task/SimpleAsyncTaskExecutorTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.core.task;
 
+import java.lang.reflect.Field;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
@@ -23,6 +24,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.jupiter.api.Test;
+
+import org.springframework.util.ConcurrencyThrottleSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -130,6 +133,47 @@ class SimpleAsyncTaskExecutorTests {
 		assertThat(completed)
 				.withFailMessage("Executor should not deadlock if concurrency permit was properly released after first failure")
 				.isTrue();
+	}
+
+	@Test  // immediate-timeout tasks bypass the throttle and must not unbalance its count
+	@SuppressWarnings("deprecation")
+	void immediateTasksDoNotCorruptConcurrencyThrottle() throws Exception {
+		try (SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor()) {
+			executor.setConcurrencyLimit(2);
+			executor.setTaskTerminationTimeout(10_000);  // enables active-thread tracking
+
+			int taskCount = 5;
+			CountDownLatch done = new CountDownLatch(taskCount);
+			for (int i = 0; i < taskCount; i++) {
+				executor.execute(done::countDown, AsyncTaskExecutor.TIMEOUT_IMMEDIATE);
+			}
+			assertThat(done.await(5, TimeUnit.SECONDS)).isTrue();
+
+			// Each worker runs afterAccess() in its finally block. With the bug, immediate tasks
+			// released a permit they never acquired, driving the count to -taskCount. Poll until
+			// the count settles; it must never drop below zero.
+			int count = 0;
+			for (int i = 0; i < 100; i++) {
+				count = concurrencyCount(executor);
+				if (count < 0) {
+					break;
+				}
+				Thread.sleep(10);
+			}
+			assertThat(count)
+					.withFailMessage("concurrencyThrottle count must stay >= 0; an immediate task " +
+							"released a permit it never acquired")
+					.isGreaterThanOrEqualTo(0);
+		}
+	}
+
+	private static int concurrencyCount(SimpleAsyncTaskExecutor executor) throws Exception {
+		Field throttleField = SimpleAsyncTaskExecutor.class.getDeclaredField("concurrencyThrottle");
+		throttleField.setAccessible(true);
+		Object throttle = throttleField.get(executor);
+		Field countField = ConcurrencyThrottleSupport.class.getDeclaredField("concurrencyCount");
+		countField.setAccessible(true);
+		return countField.getInt(throttle);
 	}
 
 	@Test

--- a/spring-core/src/test/java/org/springframework/core/task/SimpleAsyncTaskExecutorTests.java
+++ b/spring-core/src/test/java/org/springframework/core/task/SimpleAsyncTaskExecutorTests.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 
@@ -135,36 +136,49 @@ class SimpleAsyncTaskExecutorTests {
 				.isTrue();
 	}
 
-	@Test  // immediate-timeout tasks bypass the throttle and must not unbalance its count
+	@Test  // immediate-timeout tasks bypass the throttle: no permit acquired, so none released
 	@SuppressWarnings("deprecation")
-	void immediateTasksDoNotCorruptConcurrencyThrottle() throws Exception {
-		try (SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor()) {
-			executor.setConcurrencyLimit(2);
-			executor.setTaskTerminationTimeout(10_000);  // enables active-thread tracking
-
-			int taskCount = 5;
-			CountDownLatch done = new CountDownLatch(taskCount);
-			for (int i = 0; i < taskCount; i++) {
-				executor.execute(done::countDown, AsyncTaskExecutor.TIMEOUT_IMMEDIATE);
+	void immediateTaskDoesNotReleaseThrottlePermit() throws Exception {
+		// doExecute runs the wrapper inline so the throttle accounting is observed deterministically
+		SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor() {
+			@Override
+			protected void doExecute(Runnable task) {
+				task.run();
 			}
-			assertThat(done.await(5, TimeUnit.SECONDS)).isTrue();
+		};
+		executor.setConcurrencyLimit(2);
+		executor.setTaskTerminationTimeout(10_000);  // enables active-thread tracking
 
-			// Each worker runs afterAccess() in its finally block. With the bug, immediate tasks
-			// released a permit they never acquired, driving the count to -taskCount. Poll until
-			// the count settles; it must never drop below zero.
-			int count = 0;
-			for (int i = 0; i < 100; i++) {
-				count = concurrencyCount(executor);
-				if (count < 0) {
-					break;
-				}
-				Thread.sleep(10);
+		executor.execute(() -> {}, AsyncTaskExecutor.TIMEOUT_IMMEDIATE);
+
+		// The task never acquired a permit, so afterAccess() must not have been called.
+		assertThat(concurrencyCount(executor)).isZero();
+	}
+
+	@Test  // a throttled task cancelled before it runs must still release its acquired permit
+	@SuppressWarnings("deprecation")
+	void cancelledThrottledTaskReleasesPermit() throws Exception {
+		AtomicReference<Runnable> captured = new AtomicReference<>();
+		// capture the wrapper without running it, to control the cancellation timing
+		SimpleAsyncTaskExecutor executor = new SimpleAsyncTaskExecutor() {
+			@Override
+			protected void doExecute(Runnable task) {
+				captured.set(task);
 			}
-			assertThat(count)
-					.withFailMessage("concurrencyThrottle count must stay >= 0; an immediate task " +
-							"released a permit it never acquired")
-					.isGreaterThanOrEqualTo(0);
-		}
+		};
+		executor.setConcurrencyLimit(1);
+		executor.setCancelRemainingTasksOnClose(true);  // close() marks remaining tasks cancelled
+
+		executor.execute(() -> {}, AsyncTaskExecutor.TIMEOUT_INDEFINITE);  // acquires a permit
+		assertThat(concurrencyCount(executor)).isOne();
+
+		executor.close();  // sets the cancelled flag
+
+		// The wrapper hits checkCancelled() and throws before running the task, but the
+		// acquired permit must still be released.
+		assertThatExceptionOfType(CancellationException.class)
+				.isThrownBy(() -> captured.get().run());
+		assertThat(concurrencyCount(executor)).isZero();
 	}
 
 	private static int concurrencyCount(SimpleAsyncTaskExecutor executor) throws Exception {


### PR DESCRIPTION
## Overview

`SimpleAsyncTaskExecutor` acquires a concurrency throttle permit (`beforeAccess()`) only on the
throttled execution branch, but `TaskTrackingRunnable.run()` released one (`afterAccess()`)
unconditionally. This unbalanced the throttle's concurrency count in two ways.

## Problem

1. **Immediate-timeout task** — with the throttle active and active-thread tracking enabled
   (`taskTerminationTimeout > 0` or `cancelRemainingTasksOnClose`), an immediate-timeout task takes
   the active-thread tracking branch without acquiring a permit, yet `run()` still released one,
   driving the count below zero and progressively defeating the configured concurrency limit. This
   is reachable through the deprecated `execute(Runnable, long)` overload; the regular
   `execute(Runnable)` / `submit(...)` paths use `TIMEOUT_INDEFINITE` and are unaffected.
2. **Cancelled-before-run task** — a throttled task cancelled before it ran (`checkCancelled()`
   threw ahead of the `try/finally` in `run()`) never released its acquired permit.

## Fix

Track whether a permit was acquired and release it in `run()`'s `finally` only in that case, with
the `finally` now also covering `checkCancelled()`, so an acquired permit is always released
exactly once. Deterministic regression tests are added to `SimpleAsyncTaskExecutorTests`.
