### PR TITLE
Parse byte/short/char/boolean/float array attributes

### DIFF
--- a/spring-core/src/main/java24/org/springframework/core/type/classreading/ClassFileAnnotationDelegate.java
+++ b/spring-core/src/main/java24/org/springframework/core/type/classreading/ClassFileAnnotationDelegate.java
@@ -122,6 +122,46 @@ abstract class ClassFileAnnotationDelegate {
 			case AnnotationValue.OfLong _ -> {
 				return stream.map(AnnotationValue.OfLong.class::cast).mapToLong(AnnotationValue.OfLong::longValue).toArray();
 			}
+			case AnnotationValue.OfByte _ -> {
+				List<AnnotationValue> values = arrayValue.values();
+				byte[] result = new byte[values.size()];
+				for (int i = 0; i < result.length; i++) {
+					result[i] = ((AnnotationValue.OfByte) values.get(i)).byteValue();
+				}
+				return result;
+			}
+			case AnnotationValue.OfShort _ -> {
+				List<AnnotationValue> values = arrayValue.values();
+				short[] result = new short[values.size()];
+				for (int i = 0; i < result.length; i++) {
+					result[i] = ((AnnotationValue.OfShort) values.get(i)).shortValue();
+				}
+				return result;
+			}
+			case AnnotationValue.OfChar _ -> {
+				List<AnnotationValue> values = arrayValue.values();
+				char[] result = new char[values.size()];
+				for (int i = 0; i < result.length; i++) {
+					result[i] = ((AnnotationValue.OfChar) values.get(i)).charValue();
+				}
+				return result;
+			}
+			case AnnotationValue.OfBoolean _ -> {
+				List<AnnotationValue> values = arrayValue.values();
+				boolean[] result = new boolean[values.size()];
+				for (int i = 0; i < result.length; i++) {
+					result[i] = ((AnnotationValue.OfBoolean) values.get(i)).booleanValue();
+				}
+				return result;
+			}
+			case AnnotationValue.OfFloat _ -> {
+				List<AnnotationValue> values = arrayValue.values();
+				float[] result = new float[values.size()];
+				for (int i = 0; i < result.length; i++) {
+					result[i] = ((AnnotationValue.OfFloat) values.get(i)).floatValue();
+				}
+				return result;
+			}
 			default -> {
 				Class<?> arrayElementType = resolveArrayElementType(arrayValue.values(), classLoader);
 				return stream

--- a/spring-core/src/test/java24/org/springframework/core/type/classreading/ClassFileAnnotationDelegatePrimitiveArrayTests.java
+++ b/spring-core/src/test/java24/org/springframework/core/type/classreading/ClassFileAnnotationDelegatePrimitiveArrayTests.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.type.classreading;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.core.annotation.MergedAnnotation;
+import org.springframework.core.io.DefaultResourceLoader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for primitive array attribute parsing by the {@code java.lang.classfile}
+ * based {@link ClassFileAnnotationDelegate}. Mirrors the ASM-based
+ * {@code MergedAnnotationMetadataVisitorTests} expectations.
+ *
+ * @author junhyeong9812
+ */
+class ClassFileAnnotationDelegatePrimitiveArrayTests {
+
+	@Test
+	void parsesNonEmptyPrimitiveArrayAttributes() throws Exception {
+		MergedAnnotation<?> annotation = readAnnotation(WithArrays.class);
+		assertThat(annotation.getValue("byteValue")).contains(new byte[] { 1 });
+		assertThat(annotation.getValue("shortValue")).contains(new short[] { 2 });
+		assertThat(annotation.getValue("intValue")).contains(new int[] { 3 });
+		assertThat(annotation.getValue("longValue")).contains(new long[] { 4 });
+		assertThat(annotation.getValue("booleanValue")).contains(new boolean[] { true });
+		assertThat(annotation.getValue("charValue")).contains(new char[] { 'c' });
+		assertThat(annotation.getValue("doubleValue")).contains(new double[] { 5.0 });
+		assertThat(annotation.getValue("floatValue")).contains(new float[] { 6.0f });
+	}
+
+	@Test
+	void parsesEmptyPrimitiveArrayAttributes() throws Exception {
+		MergedAnnotation<?> annotation = readAnnotation(WithEmptyArrays.class);
+		assertThat(annotation.getValue("byteValue")).contains(new byte[] {});
+		assertThat(annotation.getValue("floatValue")).contains(new float[] {});
+	}
+
+	private static MergedAnnotation<?> readAnnotation(Class<?> type) throws Exception {
+		ClassFileMetadataReaderFactory factory = new ClassFileMetadataReaderFactory(new DefaultResourceLoader());
+		MetadataReader reader = factory.getMetadataReader(type.getName());
+		return reader.getAnnotationMetadata().getAnnotations().get(ArrayTypesAnnotation.class);
+	}
+
+
+	@ArrayTypesAnnotation(byteValue = 1, shortValue = 2, intValue = 3, longValue = 4,
+			booleanValue = true, charValue = 'c', doubleValue = 5.0, floatValue = 6.0f)
+	static class WithArrays {
+	}
+
+	@ArrayTypesAnnotation(byteValue = {}, shortValue = {}, intValue = {}, longValue = {},
+			booleanValue = {}, charValue = {}, doubleValue = {}, floatValue = {})
+	static class WithEmptyArrays {
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface ArrayTypesAnnotation {
+
+		byte[] byteValue();
+
+		short[] shortValue();
+
+		int[] intValue();
+
+		long[] longValue();
+
+		boolean[] booleanValue();
+
+		char[] charValue();
+
+		double[] doubleValue();
+
+		float[] floatValue();
+	}
+
+}


### PR DESCRIPTION
## Overview

On JDK 24+, annotation metadata is read through the `java.lang.classfile` based
`ClassFileAnnotationDelegate` (selected by `MetadataReaderFactoryDelegate`).

## Problem

`parseArrayValue()` converted only `int`, `long` and `double` array attributes into primitive
arrays. `byte`, `short`, `char`, `boolean` and `float` arrays fell through to the default branch
and were boxed into `Byte[]`, `Short[]`, `Character[]`, `Boolean[]` and `Float[]`. When such an
attribute is later accessed, `TypeMappedAnnotation` adapts the value against the declared
attribute type (e.g. `byte[]`) and throws:

```
java.lang.IllegalStateException: Attribute 'byteValue' ... should be compatible with byte[]
but a java.lang.Byte[] value was returned
```

Empty arrays returned `Object[0]` and were handled separately, which masked the issue. The
ASM-based reader returns genuine primitive arrays (see `MergedAnnotationMetadataVisitorTests`),
confirming the intended behavior; the ClassFile reader should match.

## Fix

Add explicit cases for `OfByte`/`OfShort`/`OfChar`/`OfBoolean`/`OfFloat` that build the
corresponding primitive array. (`Stream` offers no `mapToByte`/`mapToShort`/`mapToChar`/
`mapToBoolean`/`mapToFloat`, so a small loop is used, alongside the existing `OfInt`/`OfLong`/
`OfDouble` cases.)

A regression test is added under `src/test/java24` (the `java24Test` source set); it fails on
the current code with the `IllegalStateException` above and passes with the fix.
