### PR TITLE
Support [] request params in constructor binding

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/bind/ServletRequestDataBinder.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/ServletRequestDataBinder.java
@@ -16,7 +16,7 @@
 
 package org.springframework.web.bind;
 
-import java.lang.reflect.Array;
+import java.util.Collection;
 import java.util.Enumeration;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -31,7 +31,6 @@ import org.springframework.beans.MutablePropertyValues;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.BindException;
 import org.springframework.web.multipart.MultipartFile;
@@ -240,8 +239,15 @@ public class ServletRequestDataBinder extends WebDataBinder {
 		}
 
 		protected @Nullable Object getRequestParameter(String name, Class<?> type) {
-			Object value = this.request.getParameterValues(name);
-			return (ObjectUtils.isArray(value) && Array.getLength(value) == 1 ? Array.get(value, 0) : value);
+			String[] values = this.request.getParameterValues(name);
+			if (values == null && !name.endsWith("[]") && isCollectionOrArray(type)) {
+				values = this.request.getParameterValues(name + "[]");
+			}
+			return (values != null && values.length == 1 ? values[0] : values);
+		}
+
+		private static boolean isCollectionOrArray(Class<?> type) {
+			return (type.isArray() || Collection.class.isAssignableFrom(type));
 		}
 
 		private @Nullable Object getMultipartValue(String name) {

--- a/spring-web/src/test/java/org/springframework/web/bind/ServletRequestDataBinderTests.java
+++ b/spring-web/src/test/java/org/springframework/web/bind/ServletRequestDataBinderTests.java
@@ -19,6 +19,7 @@ package org.springframework.web.bind;
 import java.beans.PropertyEditorSupport;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import org.springframework.beans.PropertyValue;
 import org.springframework.beans.PropertyValues;
 import org.springframework.beans.testfixture.beans.ITestBean;
 import org.springframework.beans.testfixture.beans.TestBean;
+import org.springframework.core.ResolvableType;
 import org.springframework.web.testfixture.servlet.MockHttpServletRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -165,6 +167,19 @@ class ServletRequestDataBinderTests {
 	}
 
 	@Test
+	void constructWithEmptyArraySuffixParameter() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addParameter("names[]", "John", "Jane");
+
+		ServletRequestDataBinder binder = new ServletRequestDataBinder(null);
+		binder.setTargetType(ResolvableType.forClass(NamesBean.class));
+		binder.construct(request);
+
+		NamesBean target = (NamesBean) binder.getTarget();
+		assertThat(target.names()).containsExactly("John", "Jane");
+	}
+
+	@Test
 	void bindingWithNestedObjectCreationAndWrongOrder() {
 		TestBean tb = new TestBean();
 
@@ -254,6 +269,9 @@ class ServletRequestDataBinderTests {
 			m.remove(element.getName());
 		}
 		assertThat(m.size()).as("Map size is 0").isEqualTo(0);
+	}
+
+	private record NamesBean(List<String> names) {
 	}
 
 }


### PR DESCRIPTION
This updates servlet constructor binding so collection and array constructor arguments can resolve request parameters sent with an empty array suffix, for example `names[]` for the logical `names` parameter.

The fallback is limited to collection and array argument types, matching the existing property binding behavior without changing scalar binding.

Tests:
- `./gradlew :spring-web:test --tests org.springframework.web.bind.ServletRequestDataBinderTests.constructWithEmptyArraySuffixParameter`

Closes gh-35734
