### PR TITLE
Fix type-variable resolution across sibling generic interfaces

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/GenericTypeResolver.java
+++ b/spring-core/src/main/java/org/springframework/core/GenericTypeResolver.java
@@ -209,7 +209,7 @@ public final class GenericTypeResolver {
 
 	private static ResolvableType resolveVariable(TypeVariable<?> typeVariable, ResolvableType contextType) {
 		ResolvableType resolvedType;
-		if (contextType.hasGenerics()) {
+		if (contextType.hasGenerics() && declaresTypeVariable(typeVariable, contextType)) {
 			ResolvableType.VariableResolver variableResolver = contextType.asVariableResolver();
 			if (variableResolver == null) {
 				return ResolvableType.NONE;
@@ -237,6 +237,11 @@ public final class GenericTypeResolver {
 			}
 		}
 		return ResolvableType.NONE;
+	}
+
+	private static boolean declaresTypeVariable(TypeVariable<?> typeVariable, ResolvableType contextType) {
+		TypeVariable<?> variableToCompare = SerializableTypeWrapper.unwrap(typeVariable);
+		return (variableToCompare.getGenericDeclaration() == contextType.resolve());
 	}
 
 	/**

--- a/spring-core/src/test/java/org/springframework/core/GenericTypeResolverTests.java
+++ b/spring-core/src/test/java/org/springframework/core/GenericTypeResolverTests.java
@@ -251,6 +251,14 @@ class GenericTypeResolverTests {
 		assertThat(resolvedType).isEqualTo(InheritsDefaultMethod.ConcreteType.class);
 	}
 
+	@Test  // gh-36890
+	void resolveTypeVariableCollisionAcrossInterfaces() {
+		Type type = method(Create.class, "create", Object.class).getGenericParameterTypes()[0];
+		Type resolvedType = resolveType(type, Controller.class);
+
+		assertThat(resolvedType).isEqualTo(Long.class);
+	}
+
 	@Test
 	void resolveTypeFromNestedParameterizedType() {
 		Type resolvedType = resolveType(method(MyInterfaceType.class, "get").getGenericReturnType(), MyCollectionInterfaceType.class);
@@ -502,6 +510,19 @@ class GenericTypeResolverTests {
 
 		static class ConcreteType implements InterfaceWithDefaultMethod.AbstractType {
 		}
+	}
+
+	interface Search<I, O> {
+	}
+
+	interface Create<I, O> {
+
+		default O create(I body) {
+			return null;
+		}
+	}
+
+	static class Controller implements Search<String, Long>, Create<Long, Long> {
 	}
 
 }


### PR DESCRIPTION
## Summary

- Ensure `GenericTypeResolver.resolveType(Type, Class)` only resolves a `TypeVariable` against a parameterized context that declares that same variable.
- Prevent a sibling generic interface with the same type-variable name from supplying an unrelated binding.
- Add regression coverage for a controller implementing `Search<String, Long>` and `Create<Long, Long>`, where `Create`'s input variable must resolve to `Long`.

## Testing

- Confirmed the new regression test failed before the fix with `expected: java.lang.Long but was: java.lang.String`.
- `./gradlew :spring-core:test --tests org.springframework.core.GenericTypeResolverTests.resolveTypeVariableCollisionAcrossInterfaces`
- `./gradlew :spring-core:test --tests org.springframework.core.GenericTypeResolverTests`
- `./gradlew :spring-core:test`
- `./gradlew :spring-core:check`
- `git diff --check`

Closes gh-36890