### PR TITLE
Avoid divide-by-zero in `ExponentialBackOff` jitter

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/backoff/ExponentialBackOff.java
+++ b/spring-core/src/main/java/org/springframework/util/backoff/ExponentialBackOff.java
@@ -311,7 +311,7 @@ public class ExponentialBackOff implements BackOff {
 			long jitter = getJitter();
 			if (jitter > 0) {
 				long initialInterval = getInitialInterval();
-				long applicableJitter = jitter * (interval / initialInterval);
+				long applicableJitter = jitter * (initialInterval > 0 ? (interval / initialInterval) : 1);
 				long min = Math.max(interval - applicableJitter, initialInterval);
 				long max = Math.min(interval + applicableJitter, getMaxInterval());
 				return min + (long) (Math.random() * (max - min));

--- a/spring-core/src/test/java/org/springframework/util/ExponentialBackOffTests.java
+++ b/spring-core/src/test/java/org/springframework/util/ExponentialBackOffTests.java
@@ -27,6 +27,7 @@ import org.springframework.util.backoff.ExponentialBackOff;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 /**
  * Tests for {@link ExponentialBackOff}.
@@ -116,6 +117,20 @@ class ExponentialBackOffTests {
 	void invalidInterval() {
 		ExponentialBackOff backOff = new ExponentialBackOff();
 		assertThatIllegalArgumentException().isThrownBy(() -> backOff.setMultiplier(0.9));
+	}
+
+	@Test
+	void jitterWithZeroInitialInterval() {
+		// 'initialInterval = 0' and 'jitter > 0' are both individually accepted
+		// configurations, so their combination must not throw. With initialInterval
+		// of 0, the first nextBackOff() previously evaluated 'jitter * (0 / 0)',
+		// resulting in an integer division by zero.
+		ExponentialBackOff backOff = new ExponentialBackOff();
+		backOff.setInitialInterval(0);
+		backOff.setJitter(100);
+
+		BackOffExecution execution = backOff.start();
+		assertThatNoException().isThrownBy(execution::nextBackOff);
 	}
 
 	@Test


### PR DESCRIPTION
## Overview

When an `ExponentialBackOff` is configured with an `initialInterval` of `0`
and a positive `jitter`, the first `nextBackOff()` throws
`ArithmeticException: / by zero`.

Both settings are individually accepted today:

- `setJitter(...)` only rejects negative values (`Assert.isTrue(jitter >= 0, ...)`).
- There is no validation on `initialInterval`, and with `jitter = 0` an
  `initialInterval` of `0` already works and yields a delay of `0`.

So the combination `initialInterval = 0` and `jitter > 0` is an accepted
configuration, yet it crashes instead of producing a delay — an inconsistency
between the two jitter branches.

## Reproduction

```java
ExponentialBackOff backOff = new ExponentialBackOff();
backOff.setInitialInterval(0);
backOff.setJitter(100);

backOff.start().nextBackOff(); // throws ArithmeticException: / by zero
```

## Root cause

In `ExponentialBackOff.ExponentialBackOffExecution#applyJitter`:

```java
long applicableJitter = jitter * (interval / initialInterval);
```

With `initialInterval == 0`, the first interval is also `0`, so this evaluates
`jitter * (0 / 0)` — an integer division by zero.

## Fix

Guard the division so no jitter scaling is applied when `initialInterval` is `0`,
leaving behavior for positive intervals unchanged:

```java
long applicableJitter = jitter * (initialInterval > 0 ? (interval / initialInterval) : 1);
```

A regression test (`jitterWithZeroInitialInterval`) is added to
`ExponentialBackOffTests`.

---

This is a narrow runtime-crash guard and is orthogonal to the validation design
discussed in #35357 — it stays compatible whichever way that validation is
ultimately implemented.
