### PR TITLE
Add batch update support to JdbcClient

### DIFF
--- a/framework-docs/modules/ROOT/pages/data-access/jdbc/core.adoc
+++ b/framework-docs/modules/ROOT/pages/data-access/jdbc/core.adoc
@@ -680,6 +680,21 @@ provides `firstName` and `lastName` properties, such as the `Actor` class from a
 			.update();
 ----
 
+For batch updates, accumulate the batch entries in a fluent fashion through `batch()`,
+binding the parameters for each entry as for a single update – either as positional
+parameters or as named parameters – and separating consecutive entries with `add()`.
+The accumulated entries are executed as a single JDBC batch by `batchUpdate()`, which
+also completes the final entry implicitly:
+
+[source,java,indent=0,subs="verbatim,quotes"]
+----
+	this.jdbcClient.sql("insert into t_actor (first_name, last_name) values (:firstName, :lastName)")
+			.batch()
+				.param("firstName", "Leonor").param("lastName", "Watling").add()
+				.param("firstName", "Christian").param("lastName", "Bale")
+			.batchUpdate();
+----
+
 The automatic `Actor` class mapping for parameters as well as the query results above is
 provided through implicit `SimplePropertySqlParameterSource` and `SimplePropertyRowMapper`
 strategies which are also available for direct use. They can serve as a common replacement
@@ -687,9 +702,9 @@ for `BeanPropertySqlParameterSource` and `BeanPropertyRowMapper`/`DataClassRowMa
 also with `JdbcTemplate` and `NamedParameterJdbcTemplate` themselves.
 
 NOTE: `JdbcClient` is a flexible but simplified facade for JDBC query/update statements.
-Advanced capabilities such as batch inserts and stored procedure calls typically require
-extra customization: consider Spring's `SimpleJdbcInsert` and `SimpleJdbcCall` classes or
-plain direct `JdbcTemplate` usage for any such capabilities not available in `JdbcClient`.
+Advanced capabilities such as stored procedure calls typically require extra customization:
+consider Spring's `SimpleJdbcInsert` and `SimpleJdbcCall` classes or plain direct
+`JdbcTemplate` usage for any such capabilities not available in `JdbcClient`.
 
 
 [[jdbc-SQLExceptionTranslator]]

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/DefaultJdbcClient.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/DefaultJdbcClient.java
@@ -296,6 +296,11 @@ final class DefaultJdbcClient implements JdbcClient {
 					this.classicOps.update(statementCreatorForIndexedParamsWithKeys(keyColumnNames), generatedKeyHolder));
 		}
 
+		@Override
+		public BatchSpec batch() {
+			return new DefaultBatchSpec();
+		}
+
 		private boolean useNamedParams() {
 			boolean hasNamedParams = (this.namedParams.hasValues() || this.namedParamSource != this.namedParams);
 			if (hasNamedParams && !this.indexedParams.isEmpty()) {
@@ -321,6 +326,114 @@ final class DefaultJdbcClient implements JdbcClient {
 				pscf.setReturnGeneratedKeys(true);
 			}
 			return pscf.newPreparedStatementCreator(this.indexedParams);
+		}
+
+
+		private class DefaultBatchSpec implements BatchSpec {
+
+			private final List<Object[]> indexedBatch = new ArrayList<>();
+
+			private final List<SqlParameterSource> namedBatch = new ArrayList<>();
+
+			private @Nullable Boolean usingNamedParams;
+
+			private List<@Nullable Object> currentIndexedParams = new ArrayList<>();
+
+			private MapSqlParameterSource currentNamedParams = new MapSqlParameterSource();
+
+			private SqlParameterSource currentNamedParamSource = this.currentNamedParams;
+
+			@Override
+			public BatchSpec param(@Nullable Object value) {
+				validateIndexedParamValue(value);
+				this.currentIndexedParams.add(value);
+				return this;
+			}
+
+			@Override
+			public BatchSpec param(String name, @Nullable Object value) {
+				this.currentNamedParams.addValue(name, value);
+				return this;
+			}
+
+			@Override
+			public BatchSpec params(Object... values) {
+				Collections.addAll(this.currentIndexedParams, values);
+				return this;
+			}
+
+			@Override
+			public BatchSpec params(List<?> values) {
+				this.currentIndexedParams.addAll(values);
+				return this;
+			}
+
+			@Override
+			public BatchSpec params(Map<String, ?> paramMap) {
+				this.currentNamedParams.addValues(paramMap);
+				return this;
+			}
+
+			@SuppressWarnings({"rawtypes", "unchecked"})
+			@Override
+			public BatchSpec paramSource(Object namedParamObject) {
+				this.currentNamedParamSource = (namedParamObject instanceof Map map ?
+						new MapSqlParameterSource(map) :
+						new SimplePropertySqlParameterSource(namedParamObject));
+				return this;
+			}
+
+			@Override
+			public BatchSpec paramSource(SqlParameterSource namedParamSource) {
+				this.currentNamedParamSource = namedParamSource;
+				return this;
+			}
+
+			@Override
+			public BatchSpec add() {
+				completeEntry();
+				return this;
+			}
+
+			@Override
+			public int[] batchUpdate() {
+				completeEntry();
+				return (Boolean.TRUE.equals(this.usingNamedParams) ?
+						namedParamOps.batchUpdate(sql, this.namedBatch.toArray(new SqlParameterSource[0])) :
+						classicOps.batchUpdate(sql, this.indexedBatch));
+			}
+
+			private void completeEntry() {
+				boolean hasIndexed = !this.currentIndexedParams.isEmpty();
+				boolean hasNamed = (this.currentNamedParams.hasValues() ||
+						this.currentNamedParamSource != this.currentNamedParams);
+				if (hasIndexed && hasNamed) {
+					throw new IllegalStateException("Configure either named or indexed parameters, not both");
+				}
+				if (this.currentNamedParams.hasValues() && this.currentNamedParamSource != this.currentNamedParams) {
+					throw new IllegalStateException(
+							"Configure either individual named parameters or a SqlParameterSource, not both");
+				}
+				if (!hasIndexed && !hasNamed) {
+					return;
+				}
+				if (this.usingNamedParams == null) {
+					this.usingNamedParams = hasNamed;
+				}
+				else if (this.usingNamedParams != hasNamed) {
+					throw new IllegalStateException(
+							"Configure either named or indexed parameters for all batch entries, not both");
+				}
+				if (hasNamed) {
+					this.namedBatch.add(this.currentNamedParamSource);
+					this.currentNamedParams = new MapSqlParameterSource();
+					this.currentNamedParamSource = this.currentNamedParams;
+				}
+				else {
+					this.indexedBatch.add(this.currentIndexedParams.toArray());
+					this.currentIndexedParams = new ArrayList<>();
+				}
+			}
 		}
 
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/JdbcClient.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/simple/JdbcClient.java
@@ -55,9 +55,10 @@ import org.springframework.jdbc.support.rowset.SqlRowSet;
  *
  * <p>Delegates to {@link org.springframework.jdbc.core.JdbcTemplate} and
  * {@link org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate}.
- * For complex JDBC operations &mdash; for example, batch inserts and stored
- * procedure calls &mdash; you may use those lower-level template classes directly,
- * or alternatively {@link SimpleJdbcInsert} and {@link SimpleJdbcCall}.
+ * Batch updates are supported in a fluent fashion through {@link StatementSpec#batch()};
+ * for other complex JDBC operations &mdash; for example, stored procedure calls &mdash;
+ * you may use those lower-level template classes directly, or alternatively
+ * {@link SimpleJdbcInsert} and {@link SimpleJdbcCall}.
  *
  * @author Juergen Hoeller
  * @author Sam Brannen
@@ -344,6 +345,122 @@ public interface JdbcClient {
 		 * @see java.sql.DatabaseMetaData#supportsGetGeneratedKeys()
 		 */
 		int update(KeyHolder generatedKeyHolder, String... keyColumnNames);
+
+		/**
+		 * Begin a batch update for the provided SQL statement, accumulating several
+		 * sets of parameters with each set representing the parameters for one
+		 * statement execution within the batch.
+		 * <p>Bind the parameters for each batch entry through the returned
+		 * {@link BatchSpec} in the same fashion as for a single update, separating
+		 * consecutive entries with {@link BatchSpec#add()}, and finally trigger
+		 * execution through {@link BatchSpec#batchUpdate()}:
+		 * <pre class="code">
+		 * int[] rowsAffected = client.sql("INSERT INTO user (first_name, last_name) VALUES (:first, :last)")
+		 *     .batch()
+		 *         .param("first", "Jane").param("last", "Smith").add()
+		 *         .param("first", "John").param("last", "Doe")
+		 *     .batchUpdate();
+		 * </pre>
+		 * <p>The final batch entry does not need to be marked with {@code add()};
+		 * {@link BatchSpec#batchUpdate()} completes it implicitly.
+		 * @return a batch specification for accumulating sets of parameters
+		 * @since 7.1
+		 * @see java.sql.PreparedStatement#executeBatch()
+		 */
+		BatchSpec batch();
+	}
+
+
+	/**
+	 * A specification for accumulating several sets of parameters for a batch
+	 * update, with each set representing the parameters for one statement
+	 * execution within the batch.
+	 *
+	 * <p>Parameters are bound in the same fashion as for a single {@link StatementSpec},
+	 * either as JDBC-style positional parameters or as Spring-style named parameters
+	 * (but not both within the same batch). A batch entry is completed and a new one
+	 * started through {@link #add()}; the final entry is completed implicitly by
+	 * {@link #batchUpdate()}.
+	 *
+	 * @since 7.1
+	 * @see StatementSpec#batch()
+	 */
+	interface BatchSpec {
+
+		/**
+		 * Bind a positional parameter for the current batch entry.
+		 * @param value the parameter value to bind
+		 * @return this batch specification (for chaining)
+		 * @see StatementSpec#param(Object)
+		 */
+		BatchSpec param(@Nullable Object value);
+
+		/**
+		 * Bind a named parameter for the current batch entry.
+		 * @param name the parameter name
+		 * @param value the parameter value to bind
+		 * @return this batch specification (for chaining)
+		 * @see StatementSpec#param(String, Object)
+		 */
+		BatchSpec param(String name, @Nullable Object value);
+
+		/**
+		 * Bind a var-args list of positional parameters for the current batch entry.
+		 * @param values the parameter values to bind
+		 * @return this batch specification (for chaining)
+		 * @see StatementSpec#params(Object...)
+		 */
+		BatchSpec params(Object... values);
+
+		/**
+		 * Bind a list of positional parameters for the current batch entry.
+		 * @param values the parameter values to bind
+		 * @return this batch specification (for chaining)
+		 * @see StatementSpec#params(List)
+		 */
+		BatchSpec params(List<?> values);
+
+		/**
+		 * Bind named parameters for the current batch entry.
+		 * @param paramMap a map of names and parameter values to bind
+		 * @return this batch specification (for chaining)
+		 * @see StatementSpec#params(Map)
+		 */
+		BatchSpec params(Map<String, ?> paramMap);
+
+		/**
+		 * Provide all named parameters for the current batch entry based on the
+		 * properties, record components, or fields of the given parameter object.
+		 * @param namedParamObject a custom parameter object
+		 * @return this batch specification (for chaining)
+		 * @see StatementSpec#paramSource(Object)
+		 */
+		BatchSpec paramSource(Object namedParamObject);
+
+		/**
+		 * Provide all named parameters for the current batch entry through the
+		 * given parameter source.
+		 * @param namedParamSource a custom {@link SqlParameterSource} instance
+		 * @return this batch specification (for chaining)
+		 * @see StatementSpec#paramSource(SqlParameterSource)
+		 */
+		BatchSpec paramSource(SqlParameterSource namedParamSource);
+
+		/**
+		 * Complete the current set of parameters as one batch entry and start a
+		 * new one for the subsequent parameter bindings.
+		 * @return this batch specification (for chaining)
+		 */
+		BatchSpec add();
+
+		/**
+		 * Execute the accumulated sets of parameters as a batch update, completing
+		 * the current (final) set as the last batch entry.
+		 * @return an array containing the numbers of rows affected by each
+		 * execution in the batch
+		 * @see java.sql.PreparedStatement#executeBatch()
+		 */
+		int[] batchUpdate();
 	}
 
 

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/simple/JdbcClientIntegrationTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/simple/JdbcClientIntegrationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.jdbc.core.simple;
 
 import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -24,6 +25,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.core.io.ClassRelativeResourceLoader;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.init.DatabasePopulator;
@@ -31,6 +33,7 @@ import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType.H2;
 
 /**
@@ -144,6 +147,155 @@ class JdbcClientIntegrationTests {
 		assertThat(generatedKeyHolder.getKey()).isEqualTo(expectedId);
 		assertNumUsers(2);
 		assertUser(expectedId, firstName, lastName);
+	}
+
+	@Test
+	void batchUpdateWithIndexedParameters() {
+		int[] rowsAffected = this.jdbcClient.sql(INSERT_WITH_JDBC_PARAMS)
+				.batch()
+					.params("Jane", "Smith").add()
+					.params("John", "Doe")
+				.batchUpdate();
+
+		assertThat(rowsAffected).containsExactly(1, 1);
+		assertNumUsers(3);
+		assertUser(1, "Jane", "Smith");
+		assertUser(2, "John", "Doe");
+	}
+
+	@Test
+	void batchUpdateWithNamedParameters() {
+		int[] rowsAffected = this.jdbcClient.sql(INSERT_WITH_NAMED_PARAMS)
+				.batch()
+					.param("firstName", "Jane").param("lastName", "Smith").add()
+					.param("firstName", "John").param("lastName", "Doe")
+				.batchUpdate();
+
+		assertThat(rowsAffected).containsExactly(1, 1);
+		assertNumUsers(3);
+		assertUser(1, "Jane", "Smith");
+		assertUser(2, "John", "Doe");
+	}
+
+	@Test
+	void batchUpdateWithIndividualIndexedParameters() {
+		int[] rowsAffected = this.jdbcClient.sql(INSERT_WITH_JDBC_PARAMS)
+				.batch()
+					.param("Jane").param("Smith").add()
+					.param("John").param("Doe")
+				.batchUpdate();
+
+		assertThat(rowsAffected).containsExactly(1, 1);
+		assertNumUsers(3);
+		assertUser(1, "Jane", "Smith");
+		assertUser(2, "John", "Doe");
+	}
+
+	@Test
+	void batchUpdateWithIndexedParameterList() {
+		int[] rowsAffected = this.jdbcClient.sql(INSERT_WITH_JDBC_PARAMS)
+				.batch()
+					.params(List.of("Jane", "Smith")).add()
+					.params(List.of("John", "Doe"))
+				.batchUpdate();
+
+		assertThat(rowsAffected).containsExactly(1, 1);
+		assertNumUsers(3);
+		assertUser(1, "Jane", "Smith");
+		assertUser(2, "John", "Doe");
+	}
+
+	@Test
+	void batchUpdateWithNamedParameterMap() {
+		int[] rowsAffected = this.jdbcClient.sql(INSERT_WITH_NAMED_PARAMS)
+				.batch()
+					.params(Map.of("firstName", "Jane", "lastName", "Smith")).add()
+					.params(Map.of("firstName", "John", "lastName", "Doe"))
+				.batchUpdate();
+
+		assertThat(rowsAffected).containsExactly(1, 1);
+		assertNumUsers(3);
+		assertUser(1, "Jane", "Smith");
+		assertUser(2, "John", "Doe");
+	}
+
+	@Test
+	void batchUpdateWithParameterObjects() {
+		int[] rowsAffected = this.jdbcClient.sql(INSERT_WITH_NAMED_PARAMS)
+				.batch()
+					.paramSource(new NewUser("Jane", "Smith")).add()
+					.paramSource(new NewUser("John", "Doe"))
+				.batchUpdate();
+
+		assertThat(rowsAffected).containsExactly(1, 1);
+		assertNumUsers(3);
+		assertUser(1, "Jane", "Smith");
+		assertUser(2, "John", "Doe");
+	}
+
+	@Test
+	void batchUpdateWithParameterSources() {
+		int[] rowsAffected = this.jdbcClient.sql(INSERT_WITH_NAMED_PARAMS)
+				.batch()
+					.paramSource(new MapSqlParameterSource("firstName", "Jane").addValue("lastName", "Smith")).add()
+					.paramSource(new MapSqlParameterSource("firstName", "John").addValue("lastName", "Doe"))
+				.batchUpdate();
+
+		assertThat(rowsAffected).containsExactly(1, 1);
+		assertNumUsers(3);
+		assertUser(1, "Jane", "Smith");
+		assertUser(2, "John", "Doe");
+	}
+
+	@Test
+	void batchUpdateWithTrailingAdd() {
+		int[] rowsAffected = this.jdbcClient.sql(INSERT_WITH_NAMED_PARAMS)
+				.batch()
+					.param("firstName", "Jane").param("lastName", "Smith").add()
+					.param("firstName", "John").param("lastName", "Doe").add()
+				.batchUpdate();
+
+		assertThat(rowsAffected).containsExactly(1, 1);
+		assertNumUsers(3);
+		assertUser(1, "Jane", "Smith");
+		assertUser(2, "John", "Doe");
+	}
+
+	@Test
+	void emptyBatchUpdate() {
+		int[] rowsAffected = this.jdbcClient.sql(INSERT_WITH_NAMED_PARAMS).batch().batchUpdate();
+
+		assertThat(rowsAffected).isEmpty();
+		assertNumUsers(1);
+	}
+
+	@Test
+	void batchUpdateRejectsMixedParametersWithinEntry() {
+		assertThatIllegalStateException().isThrownBy(() ->
+				this.jdbcClient.sql(INSERT_WITH_JDBC_PARAMS)
+						.batch()
+							.param("Jane").param("lastName", "Smith")
+						.batchUpdate());
+	}
+
+	@Test
+	void batchUpdateRejectsMixedParametersAcrossEntries() {
+		assertThatIllegalStateException().isThrownBy(() ->
+				this.jdbcClient.sql(INSERT_WITH_NAMED_PARAMS)
+						.batch()
+							.param("firstName", "Jane").param("lastName", "Smith").add()
+							.params("John", "Doe")
+						.batchUpdate());
+	}
+
+	@Test
+	void batchUpdateRejectsIndividualNamedParametersWithParameterSource() {
+		assertThatIllegalStateException().isThrownBy(() ->
+				this.jdbcClient.sql(INSERT_WITH_NAMED_PARAMS)
+						.batch()
+							.param("firstName", "Jane")
+							.paramSource(new MapSqlParameterSource("lastName", "Smith"))
+						.batchUpdate());
 	}
 
 
@@ -268,5 +420,7 @@ class JdbcClientIntegrationTests {
 
 
 	record User(long id, String firstName, String lastName) {}
+
+	record NewUser(String firstName, String lastName) {}
 
 }


### PR DESCRIPTION
This adds batch update support to `JdbcClient`, as requested in gh-33843.

Batch entries are accumulated in a fluent way through a new `batch()` method on `StatementSpec`:

```java
int[] rowsAffected = client.sql("INSERT INTO user (first_name, last_name) VALUES (:first, :last)")
        .batch()
            .param("first", "Jane").param("last", "Smith").add()
            .param("first", "John").param("last", "Doe")
        .batchUpdate();
```

Each entry is bound with `param(...)` / `params(...)` / `paramSource(...)` exactly like a single update; `add()` separates entries and `batchUpdate()` executes them as one JDBC batch (the last entry is completed implicitly). Both positional and named parameters are supported (mixing the two in one batch is rejected). It delegates to `JdbcOperations.batchUpdate` / `NamedParameterJdbcOperations.batchUpdate`.

Reference docs and integration tests are included. The `spring-jdbc` build, Checkstyle and tests pass.

I know this is assigned to @sdeleuze — feel free to take whatever is useful here.