### PR TITLE
Update Javadoc for `@ActiveProfiles` ordering

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/context/MergedContextConfiguration.java
+++ b/spring-test/src/main/java/org/springframework/test/context/MergedContextConfiguration.java
@@ -190,8 +190,8 @@ public class MergedContextConfiguration implements Serializable {
 	 * or {@code propertySourceProperties} an empty array will be stored instead.
 	 * If a {@code null} value is supplied for the
 	 * {@code contextInitializerClasses} an empty set will be stored instead.
-	 * Furthermore, active profiles will be sorted, and duplicate profiles
-	 * will be removed.
+	 * Furthermore, duplicate active profiles will be removed while preserving
+	 * registration order.
 	 * @param testClass the test class for which the configuration was merged
 	 * @param locations the merged context resource locations
 	 * @param classes the merged annotated classes
@@ -229,8 +229,8 @@ public class MergedContextConfiguration implements Serializable {
 	 * or {@code propertySourceProperties} an empty array will be stored instead.
 	 * If a {@code null} value is supplied for {@code contextInitializerClasses}
 	 * or {@code contextCustomizers}, an empty set will be stored instead.
-	 * Furthermore, active profiles will be sorted, and duplicate profiles
-	 * will be removed.
+	 * Furthermore, duplicate active profiles will be removed while preserving
+	 * registration order.
 	 * @param testClass the test class for which the configuration was merged
 	 * @param locations the merged context resource locations
 	 * @param classes the merged annotated classes
@@ -268,8 +268,8 @@ public class MergedContextConfiguration implements Serializable {
 	 * {@code activeProfiles}, or {@code propertySourceProperties} an empty array
 	 * will be stored instead. If a {@code null} value is supplied for
 	 * {@code contextInitializerClasses} or {@code contextCustomizers}, an empty
-	 * set will be stored instead. Furthermore, active profiles will be sorted,
-	 * and duplicate profiles will be removed.
+	 * set will be stored instead. Furthermore, duplicate active profiles
+	 * will be removed while preserving registration order.
 	 * @param testClass the test class for which the configuration was merged
 	 * @param locations the merged context resource locations
 	 * @param classes the merged annotated classes

--- a/spring-test/src/main/java/org/springframework/test/context/web/WebMergedContextConfiguration.java
+++ b/spring-test/src/main/java/org/springframework/test/context/web/WebMergedContextConfiguration.java
@@ -87,8 +87,8 @@ public class WebMergedContextConfiguration extends MergedContextConfiguration {
 	 * If a {@code null} value is supplied for the
 	 * {@code contextInitializerClasses} an empty set will be stored instead.
 	 * If an <em>empty</em> value is supplied for the {@code resourceBasePath}
-	 * an empty string will be used. Furthermore, active profiles will be sorted,
-	 * and duplicate profiles will be removed.
+	 * an empty string will be used. Furthermore, duplicate active profiles
+	 * will be removed while preserving registration order.
 	 * @param testClass the test class for which the configuration was merged
 	 * @param locations the merged resource locations
 	 * @param classes the merged annotated classes
@@ -125,8 +125,8 @@ public class WebMergedContextConfiguration extends MergedContextConfiguration {
 	 * If a {@code null} value is supplied for {@code contextInitializerClasses}
 	 * or {@code contextCustomizers}, an empty set will be stored instead.
 	 * If an <em>empty</em> value is supplied for the {@code resourceBasePath}
-	 * an empty string will be used. Furthermore, active profiles will be sorted,
-	 * and duplicate profiles will be removed.
+	 * an empty string will be used. Furthermore, duplicate active profiles
+	 * will be removed while preserving registration order.
 	 * @param testClass the test class for which the configuration was merged
 	 * @param locations the merged context resource locations
 	 * @param classes the merged annotated classes
@@ -164,8 +164,8 @@ public class WebMergedContextConfiguration extends MergedContextConfiguration {
 	 * {@code activeProfiles}, or {@code propertySourceProperties} an empty array
 	 * will be stored instead. If a {@code null} value is supplied for
 	 * {@code contextInitializerClasses} or {@code contextCustomizers}, an empty
-	 * set will be stored instead. Furthermore, active profiles will be sorted,
-	 * and duplicate profiles will be removed.
+	 * set will be stored instead. Furthermore, duplicate active profiles
+	 * will be removed while preserving registration order.
 	 * @param testClass the test class for which the configuration was merged
 	 * @param locations the merged context resource locations
 	 * @param classes the merged annotated classes


### PR DESCRIPTION
## Overview

In gh-26004, `TreeSet` was replaced by `LinkedHashSet` so that the registration order of active profiles in `@ActiveProfiles` is preserved.

However, the Javadoc in MergedContextConfiguration and WebMergedContextConfiguration still described the old sorting behavior. This PR aligns it with the actual behavior.

Active profiles are part of `MergedContextConfiguration` `equals()`and `hashCode()`, so their order participates in the test context cache key. The previous Javadoc could mislead readers reasoning about why two configurations do or do not share a cached `ApplicationContext`.

I did not find any other occurrences of the outdated doc elsewhere, including in the reference documentation.

## Related Issues

- #26004
