### PR TITLE
Avoid redundant registration of legacy date converters

### DIFF
--- a/spring-context/src/main/java/org/springframework/format/datetime/standard/DateTimeConverters.java
+++ b/spring-context/src/main/java/org/springframework/format/datetime/standard/DateTimeConverters.java
@@ -27,7 +27,6 @@ import java.util.GregorianCalendar;
 
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.convert.converter.ConverterRegistry;
-import org.springframework.format.datetime.DateFormatterRegistrar;
 
 /**
  * Installs lower-level type converters required to integrate
@@ -52,8 +51,6 @@ final class DateTimeConverters {
 	 * @param registry the converter registry
 	 */
 	public static void registerConverters(ConverterRegistry registry) {
-		DateFormatterRegistrar.addDateConverters(registry);
-
 		registry.addConverter(new LocalDateTimeToLocalDateConverter());
 		registry.addConverter(new LocalDateTimeToLocalTimeConverter());
 		registry.addConverter(new ZonedDateTimeToLocalDateConverter());

--- a/spring-context/src/test/java/org/springframework/format/support/FormattingConversionServiceTests.java
+++ b/spring-context/src/test/java/org/springframework/format/support/FormattingConversionServiceTests.java
@@ -176,6 +176,24 @@ class FormattingConversionServiceTests {
 		assertThat(formattingService.convert("1", Integer.class)).isEqualTo(Integer.valueOf(1));
 	}
 
+	@Test
+	void defaultFormattingConversionServiceHasNoDuplicateDateConverters() {
+		DefaultFormattingConversionService service = new DefaultFormattingConversionService();
+		String serviceString = service.toString();
+		int count = countOccurrences(serviceString, "DateFormatterRegistrar$DateToLongConverter");
+		assertThat(count).isEqualTo(1);
+	}
+
+	private int countOccurrences(String str, String subStr) {
+		int count = 0;
+		int idx = 0;
+		while ((idx = str.indexOf(subStr, idx)) != -1) {
+			count++;
+			idx += subStr.length();
+		}
+		return count;
+	}
+
 
 	static class NullReturningFormatter implements Formatter<Integer> {
 


### PR DESCRIPTION
Prior to this commit, DateTimeFormatterRegistrar registered legacy date converters via DateTimeConverters.registerConverters, which in turn called DateFormatterRegistrar.addDateConverters.

Since DefaultFormattingConversionService registers both DateTimeFormatterRegistrar and DateFormatterRegistrar, this resulted in redundant double registration of legacy converters (such as DateToLongConverter, CalendarToDateConverter, etc.).

This commit removes the redundant call to addDateConverters from DateTimeConverters.registerConverters, ensuring legacy date converters are only registered by DateFormatterRegistrar.

Closes gh-36951