### PR TITLE
Add java.time support to MimeMessageHelper

### DIFF
--- a/spring-context-support/src/main/java/org/springframework/mail/MailMessage.java
+++ b/spring-context-support/src/main/java/org/springframework/mail/MailMessage.java
@@ -16,6 +16,7 @@
 
 package org.springframework.mail;
 
+import java.time.Instant;
 import java.util.Date;
 
 /**
@@ -52,6 +53,16 @@ public interface MailMessage {
 	void setBcc(String... bcc) throws MailParseException;
 
 	void setSentDate(Date sentDate) throws MailParseException;
+
+	/**
+	 * Set the sent-date of the message.
+	 * @param sentDate the date to set (never {@code null})
+	 * @throws MailParseException in case of errors
+	 * @since 7.1
+	 */
+	default void setSentDate(Instant sentDate) throws MailParseException {
+		setSentDate(Date.from(sentDate));
+	}
 
 	void setSubject(String subject) throws MailParseException;
 

--- a/spring-context-support/src/main/java/org/springframework/mail/javamail/MimeMailMessage.java
+++ b/spring-context-support/src/main/java/org/springframework/mail/javamail/MimeMailMessage.java
@@ -16,6 +16,7 @@
 
 package org.springframework.mail.javamail;
 
+import java.time.Instant;
 import java.util.Date;
 
 import jakarta.mail.MessagingException;
@@ -155,6 +156,16 @@ public class MimeMailMessage implements MailMessage {
 
 	@Override
 	public void setSentDate(Date sentDate) throws MailParseException {
+		try {
+			this.helper.setSentDate(sentDate);
+		}
+		catch (MessagingException ex) {
+			throw new MailParseException(ex);
+		}
+	}
+
+	@Override
+	public void setSentDate(Instant sentDate) throws MailParseException {
 		try {
 			this.helper.setSentDate(sentDate);
 		}

--- a/spring-context-support/src/main/java/org/springframework/mail/javamail/MimeMessageHelper.java
+++ b/spring-context-support/src/main/java/org/springframework/mail/javamail/MimeMessageHelper.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
+import java.time.Instant;
 import java.util.Date;
 
 import jakarta.activation.DataHandler;
@@ -761,6 +762,17 @@ public class MimeMessageHelper {
 	public void setSentDate(Date sentDate) throws MessagingException {
 		Assert.notNull(sentDate, "Sent date must not be null");
 		this.mimeMessage.setSentDate(sentDate);
+	}
+
+	/**
+	 * Set the sent-date of the message.
+	 * @param sentDate the date to set (never {@code null})
+	 * @throws MessagingException in case of errors
+	 * @since 7.1
+	 */
+	public void setSentDate(Instant sentDate) throws MessagingException {
+		Assert.notNull(sentDate, "Sent date must not be null");
+		this.mimeMessage.setSentDate(Date.from(sentDate));
 	}
 
 	/**

--- a/spring-context-support/src/test/java/org/springframework/mail/javamail/JavaMailSenderTests.java
+++ b/spring-context-support/src/test/java/org/springframework/mail/javamail/JavaMailSenderTests.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
+import java.time.Instant;
 import java.util.List;
 import java.util.Properties;
 import java.util.stream.Stream;
@@ -450,6 +451,28 @@ class JavaMailSenderTests {
 	void connectionWithFailure() {
 		sender.setHost(null);
 		assertThatExceptionOfType(MessagingException.class).isThrownBy(sender::testConnection);
+	}
+
+	@Test
+	void javaTimeSentDateSupport() throws Exception {
+		Instant sentDate = Instant.parse("2026-06-20T10:15:30.00Z");
+		Date expectedDate = Date.from(sentDate);
+
+		// Test MimeMessageHelper
+		MimeMessage mimeMessage = sender.createMimeMessage();
+		MimeMessageHelper helper = new MimeMessageHelper(mimeMessage);
+		helper.setSentDate(sentDate);
+		assertThat(mimeMessage.getSentDate()).isEqualTo(expectedDate);
+
+		// Test MimeMailMessage
+		MimeMailMessage mimeMailMessage = new MimeMailMessage(helper);
+		mimeMailMessage.setSentDate(sentDate);
+		assertThat(mimeMessage.getSentDate()).isEqualTo(expectedDate);
+
+		// Test SimpleMailMessage (via MailMessage interface default method)
+		SimpleMailMessage simpleMailMessage = new SimpleMailMessage();
+		simpleMailMessage.setSentDate(sentDate);
+		assertThat(simpleMailMessage.getSentDate()).isEqualTo(expectedDate);
 	}
 
 


### PR DESCRIPTION
This commit introduces support for setting the sent date of mail messages using 'java.time.Instant'. The 'setSentDate(Instant)' method is added as a default method on 'MailMessage' and implemented/overridden in 'MimeMessageHelper' and 'MimeMailMessage'.

This allows developers using modern Java time APIs to avoid legacy and deprecated 'java.util.Date' conversions and warnings.

Closes gh-36936