### PR TITLE
Fix asymmetric Observation scope propagation in Kotlin Coroutines

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/PropagationContextElement.java
+++ b/spring-core/src/main/java/org/springframework/core/PropagationContextElement.java
@@ -70,6 +70,8 @@ public final class PropagationContextElement extends AbstractCoroutineContextEle
 	private static final boolean coroutinesReactorPresent = ClassUtils.isPresent("kotlinx.coroutines.reactor.ReactorContext",
 			PropagationContextElement.class.getClassLoader());
 
+	private static final ThreadLocal<Integer> nestingDepth = ThreadLocal.withInitial(() -> 0);
+
 	private final ContextSnapshot threadLocalContextSnapshot;
 
 
@@ -85,6 +87,11 @@ public final class PropagationContextElement extends AbstractCoroutineContextEle
 
 	@Override
 	public ContextSnapshot.Scope updateThreadContext(CoroutineContext context) {
+		int depth = nestingDepth.get();
+		nestingDepth.set(depth + 1);
+		if (depth > 0) {
+			return new NoOpScope();
+		}
 		ContextSnapshot contextSnapshot;
 		if (coroutinesReactorPresent) {
 			contextSnapshot = ReactorDelegate.captureFrom(context);
@@ -95,7 +102,7 @@ public final class PropagationContextElement extends AbstractCoroutineContextEle
 		else {
 			contextSnapshot = this.threadLocalContextSnapshot;
 		}
-		return contextSnapshot.setThreadLocals();
+		return new WrapperScope(contextSnapshot.setThreadLocals());
 	}
 
 	public static final class Key implements CoroutineContext.Key<PropagationContextElement> {
@@ -113,6 +120,33 @@ public final class PropagationContextElement extends AbstractCoroutineContextEle
 			else {
 				return null;
 			}
+		}
+	}
+
+	private static final class WrapperScope implements ContextSnapshot.Scope {
+
+		private final ContextSnapshot.Scope delegate;
+
+		WrapperScope(ContextSnapshot.Scope delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		public void close() {
+			try {
+				this.delegate.close();
+			}
+			finally {
+				nestingDepth.set(0);
+			}
+		}
+	}
+
+	private static final class NoOpScope implements ContextSnapshot.Scope {
+
+		@Override
+		public void close() {
+			// No-op
 		}
 	}
 }

--- a/spring-core/src/test/kotlin/org/springframework/core/PropagationContextElementTests.kt
+++ b/spring-core/src/test/kotlin/org/springframework/core/PropagationContextElementTests.kt
@@ -68,6 +68,25 @@ class PropagationContextElementTests {
 		Hooks.disableAutomaticContextPropagation()
 	}
 
+	@Test
+	fun nestedInvocations() {
+		val observation = Observation.createNotStarted("coroutine", observationRegistry)
+		observation.observe {
+			val element = PropagationContextElement()
+			val scope1 = element.updateThreadContext(kotlin.coroutines.EmptyCoroutineContext)
+			assertThat(observationRegistry.currentObservation).isEqualTo(observation)
+
+			val scope2 = element.updateThreadContext(kotlin.coroutines.EmptyCoroutineContext)
+			assertThat(observationRegistry.currentObservation).isEqualTo(observation)
+
+			element.restoreThreadContext(kotlin.coroutines.EmptyCoroutineContext, scope1)
+			assertThat(observationRegistry.currentObservation).isEqualTo(observation)
+
+			element.restoreThreadContext(kotlin.coroutines.EmptyCoroutineContext, scope2)
+			assertThat(observationRegistry.currentObservation).isEqualTo(observation)
+		}
+	}
+
 	suspend fun suspendingFunction(value: String): String? {
 		delay(1)
 		val currentObservation = observationRegistry.currentObservation


### PR DESCRIPTION
### Summary
This PR addresses issue #36929 where Kotlin flow-to-flux subscriptions using `PropagationContextElement` open Observation scopes asymmetrically, causing `AssertionError` crashes in `ObservationThreadLocalAccessor.restore`.

### Cause of the Issue
During undispatched coroutine context modifications (e.g., from `ChannelFlowKt.withContextUndispatched` nested inside the flow's execution path), `updateThreadContext` is called nestedly on the same thread. When a coroutine suspends within the nested block:
1. The execution pauses, meaning the `finally` block of the nested block (which calls `restoreThreadContext` to close the nested scope) is NOT executed.
2. The outer coroutine dispatcher's suspension cleanup runs and executes the outer `restoreThreadContext`.
3. Because the nested scope was never closed, the outer `restoreThreadContext` attempts to close the outer scope but finds a dirty thread-local observation stack (with the nested scope still on top), causing Micrometer's assertion to trip.

### Solution
We introduce a static `ThreadLocal<Integer> nestingDepth` tracker inside `PropagationContextElement`:
- When `updateThreadContext` is called, we increment `nestingDepth`.
- If the depth is greater than 1 (meaning propagation is already active on the current thread), we return a no-op `Scope` implementation, avoiding nested/asymmetric thread-local scope pushes.
- For the outermost update (depth = 1), we return a `WrapperScope` that delegates to the original snapshot scope and resets the `nestingDepth` to 0 when closed.

### Verification
Added a unit test `nestedInvocations` in `PropagationContextElementTests` which simulates nested context updates and outer/nested restorations, verifying that no assertion errors are thrown and the Observation stack remains balanced. All tests in `spring-core` compiled and passed.