### PR TITLE
Add configurable structural nesting depth limit to SpEL expressions

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/SpelMessage.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/SpelMessage.java
@@ -307,7 +307,11 @@ public enum SpelMessage {
 
 	/** @since 6.2.19 */
 	MAX_OPERATIONS_EXCEEDED(Kind.ERROR, 1085,
-			"SpEL expression evaluation exceeded the threshold of ''{0}'' operations");
+			"SpEL expression evaluation exceeded the threshold of ''{0}'' operations"),
+
+	/** @since 7.0 */
+	MAX_NESTING_DEPTH_EXCEEDED(Kind.ERROR, 1086,
+			"SpEL expression structural nesting depth exceeded the threshold of ''{0}'' levels");
 
 
 	private final Kind kind;

--- a/spring-expression/src/main/java/org/springframework/expression/spel/SpelParserConfiguration.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/SpelParserConfiguration.java
@@ -50,6 +50,15 @@ public class SpelParserConfiguration {
 	public static final int DEFAULT_MAX_OPERATIONS = 10_000;
 
 	/**
+	 * Default maximum structural nesting depth permitted for a SpEL expression: {@value}.
+	 * <p>This guards against deeply nested inline lists, maps, and other recursive
+	 * constructs that could cause excessive parser recursion.
+	 * @since 7.0
+	 * @see #SPRING_EXPRESSION_MAX_NESTING_DEPTH_PROPERTY_NAME
+	 */
+	public static final int DEFAULT_MAX_NESTING_DEPTH = 1_000;
+
+	/**
 	 * System property to configure the default compiler mode for SpEL expression parsers: {@value}.
 	 * <p><strong>NOTE</strong>: Instead of relying on a global default, applications
 	 * and frameworks should ideally set an explicit custom value via the
@@ -74,6 +83,20 @@ public class SpelParserConfiguration {
 	 */
 	public static final String SPRING_EXPRESSION_MAX_OPERATIONS_PROPERTY_NAME = "spring.expression.maxOperations";
 
+	/**
+	 * System property to configure the default maximum structural nesting depth
+	 * permitted for SpEL expression parsing: {@value}.
+	 * <p><strong>NOTE</strong>: Instead of relying on a global default, applications
+	 * and frameworks should ideally set an explicit custom value via the
+	 * {@link #SpelParserConfiguration(SpelCompilerMode, ClassLoader, boolean, boolean, int, int, int, int)}
+	 * constructor which provides complete configuration control and the ability
+	 * to override global defaults per use case.
+	 * <p>Can also be configured via the {@link SpringProperties} mechanism.
+	 * @since 7.0
+	 * @see #DEFAULT_MAX_NESTING_DEPTH
+	 */
+	public static final String SPRING_EXPRESSION_MAX_NESTING_DEPTH_PROPERTY_NAME = "spring.expression.maxNestingDepth";
+
 
 	private static final SpelCompilerMode defaultCompilerMode;
 
@@ -97,6 +120,8 @@ public class SpelParserConfiguration {
 	private final int maximumExpressionLength;
 
 	private final int maximumOperations;
+
+	private final int maximumNestingDepth;
 
 
 	/**
@@ -206,7 +231,7 @@ public class SpelParserConfiguration {
 			boolean autoGrowNullReferences, boolean autoGrowCollections, int maximumAutoGrowSize, int maximumExpressionLength) {
 
 		this((compilerMode != null ? compilerMode : defaultCompilerMode), compilerClassLoader, autoGrowNullReferences,
-				autoGrowCollections, maximumAutoGrowSize, maximumExpressionLength, retrieveMaxOperations());
+				autoGrowCollections, maximumAutoGrowSize, maximumExpressionLength, retrieveMaxOperations(), retrieveMaxNestingDepth());
 	}
 
 	/**
@@ -223,14 +248,43 @@ public class SpelParserConfiguration {
 	 * @param maximumOperations the maximum number of operations permitted during
 	 * SpEL expression evaluation; must be a positive number
 	 * @since 6.2.19
+	 * @deprecated as of 7.0, in favor of
+	 * {@link #SpelParserConfiguration(SpelCompilerMode, ClassLoader, boolean, boolean, int, int, int, int)}
 	 */
+	@Deprecated(since = "7.0")
 	public SpelParserConfiguration(SpelCompilerMode compilerMode, @Nullable ClassLoader compilerClassLoader,
 			boolean autoGrowNullReferences, boolean autoGrowCollections, int maximumAutoGrowSize, int maximumExpressionLength,
 			int maximumOperations) {
 
+		this(compilerMode, compilerClassLoader, autoGrowNullReferences, autoGrowCollections,
+				maximumAutoGrowSize, maximumExpressionLength, maximumOperations, retrieveMaxNestingDepth());
+	}
+
+	/**
+	 * Create a new {@code SpelParserConfiguration} instance.
+	 * @param compilerMode the compiler mode that parsers using this configuration
+	 * should use; must not be {@code null}
+	 * @param compilerClassLoader the {@code ClassLoader} to use as the basis for
+	 * expression compilation; or {@code null} to use the default {@code ClassLoader}
+	 * @param autoGrowNullReferences if null references should automatically grow
+	 * @param autoGrowCollections if collections should automatically grow
+	 * @param maximumAutoGrowSize the maximum size to which a collection can auto grow
+	 * @param maximumExpressionLength the maximum length of a SpEL expression;
+	 * must be a positive number
+	 * @param maximumOperations the maximum number of operations permitted during
+	 * SpEL expression evaluation; must be a positive number
+	 * @param maximumNestingDepth the maximum structural nesting depth permitted
+	 * during SpEL expression parsing; must be a positive number
+	 * @since 7.0
+	 */
+	public SpelParserConfiguration(SpelCompilerMode compilerMode, @Nullable ClassLoader compilerClassLoader,
+			boolean autoGrowNullReferences, boolean autoGrowCollections, int maximumAutoGrowSize, int maximumExpressionLength,
+			int maximumOperations, int maximumNestingDepth) {
+
 		Assert.notNull(compilerMode, "'compilerMode' must not be null");
 		Assert.isTrue(maximumExpressionLength > 0, "'maximumExpressionLength' must be a positive number");
 		Assert.isTrue(maximumOperations > 0, "'maximumOperations' must be a positive number");
+		Assert.isTrue(maximumNestingDepth > 0, "'maximumNestingDepth' must be a positive number");
 
 		this.compilerMode = compilerMode;
 		this.compilerClassLoader = compilerClassLoader;
@@ -239,6 +293,7 @@ public class SpelParserConfiguration {
 		this.maximumAutoGrowSize = maximumAutoGrowSize;
 		this.maximumExpressionLength = maximumExpressionLength;
 		this.maximumOperations = maximumOperations;
+		this.maximumNestingDepth = maximumNestingDepth;
 	}
 
 
@@ -294,6 +349,14 @@ public class SpelParserConfiguration {
 		return this.maximumOperations;
 	}
 
+	/**
+	 * Return the maximum structural nesting depth permitted for a SpEL expression.
+	 * @since 7.0
+	 */
+	public int getMaximumNestingDepth() {
+		return this.maximumNestingDepth;
+	}
+
 
 	private static int retrieveMaxOperations() {
 		String value = SpringProperties.getProperty(SPRING_EXPRESSION_MAX_OPERATIONS_PROPERTY_NAME);
@@ -310,6 +373,24 @@ public class SpelParserConfiguration {
 		catch (NumberFormatException ex) {
 			throw new IllegalArgumentException("Failed to parse value for system property [" +
 					SPRING_EXPRESSION_MAX_OPERATIONS_PROPERTY_NAME + "]: " + ex.getMessage(), ex);
+		}
+	}
+
+	private static int retrieveMaxNestingDepth() {
+		String value = SpringProperties.getProperty(SPRING_EXPRESSION_MAX_NESTING_DEPTH_PROPERTY_NAME);
+		if (!StringUtils.hasText(value)) {
+			return DEFAULT_MAX_NESTING_DEPTH;
+		}
+
+		try {
+			int maxDepth = Integer.parseInt(value.trim());
+			Assert.isTrue(maxDepth > 0, () -> "Value [" + maxDepth + "] for system property [" +
+					SPRING_EXPRESSION_MAX_NESTING_DEPTH_PROPERTY_NAME + "] must be positive");
+			return maxDepth;
+		}
+		catch (NumberFormatException ex) {
+			throw new IllegalArgumentException("Failed to parse value for system property [" +
+					SPRING_EXPRESSION_MAX_NESTING_DEPTH_PROPERTY_NAME + "]: " + ex.getMessage(), ex);
 		}
 	}
 

--- a/spring-expression/src/main/java/org/springframework/expression/spel/standard/InternalSpelExpressionParser.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/standard/InternalSpelExpressionParser.java
@@ -107,6 +107,9 @@ class InternalSpelExpressionParser extends TemplateAwareExpressionParser {
 	// The expression being parsed
 	private String expressionString = "";
 
+	// Current structural nesting depth (inline lists, maps) while parsing
+	private int nestingDepth;
+
 	// The token stream constructed from that expression string
 	private List<Token> tokenStream = Collections.emptyList();
 
@@ -134,6 +137,7 @@ class InternalSpelExpressionParser extends TemplateAwareExpressionParser {
 
 		try {
 			this.expressionString = expressionString;
+			this.nestingDepth = 0;
 			Tokenizer tokenizer = new Tokenizer(expressionString);
 			this.tokenStream = tokenizer.process();
 			this.tokenStreamLength = this.tokenStream.size();
@@ -159,6 +163,18 @@ class InternalSpelExpressionParser extends TemplateAwareExpressionParser {
 		if (string.length() > maxLength) {
 			throw new SpelEvaluationException(SpelMessage.MAX_EXPRESSION_LENGTH_EXCEEDED, maxLength);
 		}
+	}
+
+	private void enterNesting(int startPos) {
+		this.nestingDepth++;
+		int maxDepth = this.configuration.getMaximumNestingDepth();
+		if (this.nestingDepth > maxDepth) {
+			throw internalException(startPos, SpelMessage.MAX_NESTING_DEPTH_EXCEEDED, maxDepth);
+		}
+	}
+
+	private void exitNesting() {
+		this.nestingDepth--;
 	}
 
 	//	expression
@@ -636,6 +652,7 @@ class InternalSpelExpressionParser extends TemplateAwareExpressionParser {
 		if (t == null || !peekToken(TokenKind.LCURLY, true)) {
 			return false;
 		}
+		enterNesting(t.startPos);
 		SpelNodeImpl expr = null;
 		Token closingCurly = peekToken();
 		if (closingCurly != null && peekToken(TokenKind.RCURLY, true)) {
@@ -686,6 +703,7 @@ class InternalSpelExpressionParser extends TemplateAwareExpressionParser {
 				throw internalException(t.startPos, SpelMessage.OOD);
 			}
 		}
+		exitNesting();
 		this.constructedNodes.push(expr);
 		return true;
 	}

--- a/spring-expression/src/test/java/org/springframework/expression/spel/standard/SpelNestingDepthTests.java
+++ b/spring-expression/src/test/java/org/springframework/expression/spel/standard/SpelNestingDepthTests.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.expression.spel.standard;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.expression.spel.SpelMessage;
+import org.springframework.expression.spel.SpelParseException;
+import org.springframework.expression.spel.SpelParserConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * Tests for the configurable structural nesting depth limit in SpEL expressions.
+ *
+ * @author Naman Agrawal
+ * @since 7.0
+ * @see SpelParserConfiguration#DEFAULT_MAX_NESTING_DEPTH
+ * @see SpelParserConfiguration#SPRING_EXPRESSION_MAX_NESTING_DEPTH_PROPERTY_NAME
+ * @see SpelMessage#MAX_NESTING_DEPTH_EXCEEDED
+ */
+class SpelNestingDepthTests {
+
+	// ------------------------------------------------------------------
+	// SpelParserConfiguration defaults and accessors
+	// ------------------------------------------------------------------
+
+	@Test
+	void defaultMaxNestingDepthConstantIsPositive() {
+		assertThat(SpelParserConfiguration.DEFAULT_MAX_NESTING_DEPTH).isPositive();
+	}
+
+	@Test
+	void defaultConfigurationReportsDefaultNestingDepth() {
+		SpelParserConfiguration config = new SpelParserConfiguration();
+		assertThat(config.getMaximumNestingDepth())
+				.isEqualTo(SpelParserConfiguration.DEFAULT_MAX_NESTING_DEPTH);
+	}
+
+	@Test
+	void customNestingDepthIsStoredCorrectly() {
+		SpelParserConfiguration config = new SpelParserConfiguration(
+				null, null, false, false, Integer.MAX_VALUE,
+				SpelParserConfiguration.DEFAULT_MAX_EXPRESSION_LENGTH,
+				SpelParserConfiguration.DEFAULT_MAX_OPERATIONS, 42);
+		assertThat(config.getMaximumNestingDepth()).isEqualTo(42);
+	}
+
+	@Test
+	void nestingDepthMustBePositive() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> new SpelParserConfiguration(
+						null, null, false, false, Integer.MAX_VALUE,
+						SpelParserConfiguration.DEFAULT_MAX_EXPRESSION_LENGTH,
+						SpelParserConfiguration.DEFAULT_MAX_OPERATIONS, 0))
+				.withMessageContaining("maximumNestingDepth");
+	}
+
+	// ------------------------------------------------------------------
+	// Inline lists
+	// ------------------------------------------------------------------
+
+	@Test
+	void flatInlineListWithinDepthLimit() {
+		SpelExpressionParser parser = parserWithMaxDepth(3);
+		// {1, 2, 3} – depth 1, should parse fine
+		assertThat(parser.parseExpression("{1, 2, 3}")).isNotNull();
+	}
+
+	@Test
+	void nestedInlineListAtExactLimit() {
+		SpelExpressionParser parser = parserWithMaxDepth(3);
+		// {{{}}} – depth 3, exactly at the limit
+		assertThat(parser.parseExpression("{{{}}}")).isNotNull();
+	}
+
+	@Test
+	void nestedInlineListExceedingDepthThrowsException() {
+		SpelExpressionParser parser = parserWithMaxDepth(3);
+		// {{{{}}}} – depth 4, one level over
+		assertThatExceptionOfType(SpelParseException.class)
+				.isThrownBy(() -> parser.parseExpression("{{{{}}}}"))
+				.satisfies(ex -> assertThat(ex.getMessageCode())
+						.isEqualTo(SpelMessage.MAX_NESTING_DEPTH_EXCEEDED));
+	}
+
+	@Test
+	void deeplyNestedInlineListExceedsDefaultLimitEventually() {
+		SpelExpressionParser parser = new SpelExpressionParser();
+		String expr = buildNestedList(SpelParserConfiguration.DEFAULT_MAX_NESTING_DEPTH + 1);
+		assertThatExceptionOfType(SpelParseException.class)
+				.isThrownBy(() -> parser.parseExpression(expr))
+				.satisfies(ex -> assertThat(ex.getMessageCode())
+						.isEqualTo(SpelMessage.MAX_NESTING_DEPTH_EXCEEDED));
+	}
+
+	// ------------------------------------------------------------------
+	// Inline maps
+	// ------------------------------------------------------------------
+
+	@Test
+	void flatInlineMapWithinDepthLimit() {
+		SpelExpressionParser parser = parserWithMaxDepth(3);
+		// {'k': 'v'} – depth 1
+		assertThat(parser.parseExpression("{'k': 'v'}")).isNotNull();
+	}
+
+	@Test
+	void nestedInlineMapAtExactLimit() {
+		SpelExpressionParser parser = parserWithMaxDepth(3);
+		// {'a': {'b': {'c': 1}}} – depth 3
+		assertThat(parser.parseExpression("{'a': {'b': {'c': 1}}}")).isNotNull();
+	}
+
+	@Test
+	void nestedInlineMapExceedingDepthThrowsException() {
+		SpelExpressionParser parser = parserWithMaxDepth(2);
+		// {'a': {'b': {'c': 1}}} – depth 3, over the limit of 2
+		assertThatExceptionOfType(SpelParseException.class)
+				.isThrownBy(() -> parser.parseExpression("{'a': {'b': {'c': 1}}}"))
+				.satisfies(ex -> assertThat(ex.getMessageCode())
+						.isEqualTo(SpelMessage.MAX_NESTING_DEPTH_EXCEEDED));
+	}
+
+	// ------------------------------------------------------------------
+	// Mixed list + map nesting
+	// ------------------------------------------------------------------
+
+	@Test
+	void mixedNestingAtExactLimit() {
+		SpelExpressionParser parser = parserWithMaxDepth(2);
+		// {{'k': 'v'}} – depth 2
+		assertThat(parser.parseExpression("{{'k': 'v'}}")).isNotNull();
+	}
+
+	@Test
+	void mixedNestingExceedingDepthThrowsException() {
+		SpelExpressionParser parser = parserWithMaxDepth(2);
+		// {{{'k': 'v'}}} – depth 3
+		assertThatExceptionOfType(SpelParseException.class)
+				.isThrownBy(() -> parser.parseExpression("{{{'k': 'v'}}}"))
+				.satisfies(ex -> assertThat(ex.getMessageCode())
+						.isEqualTo(SpelMessage.MAX_NESTING_DEPTH_EXCEEDED));
+	}
+
+	// ------------------------------------------------------------------
+	// Re-use of parser across multiple expressions (counter must reset)
+	// ------------------------------------------------------------------
+
+	@Test
+	void parserIsReusableAfterExceedingDepth() {
+		SpelExpressionParser parser = parserWithMaxDepth(1);
+
+		// First parse: exceeds depth
+		assertThatExceptionOfType(SpelParseException.class)
+				.isThrownBy(() -> parser.parseExpression("{{1}}"));
+
+		// Second parse: within depth – must succeed
+		assertThat(parser.parseExpression("{1}")).isNotNull();
+	}
+
+	@Test
+	void errorMessageContainsConfiguredLimit() {
+		int limit = 2;
+		SpelExpressionParser parser = parserWithMaxDepth(limit);
+		assertThatExceptionOfType(SpelParseException.class)
+				.isThrownBy(() -> parser.parseExpression("{{{1}}}"))
+				.withMessageContaining(String.valueOf(limit));
+	}
+
+	// ------------------------------------------------------------------
+	// Helpers
+	// ------------------------------------------------------------------
+
+	private static SpelExpressionParser parserWithMaxDepth(int maxDepth) {
+		SpelParserConfiguration config = new SpelParserConfiguration(
+				null, null, false, false, Integer.MAX_VALUE,
+				SpelParserConfiguration.DEFAULT_MAX_EXPRESSION_LENGTH,
+				SpelParserConfiguration.DEFAULT_MAX_OPERATIONS, maxDepth);
+		return new SpelExpressionParser(config);
+	}
+
+	/** Build a string like {{...{}}...}} with {@code depth} levels of nesting. */
+	private static String buildNestedList(int depth) {
+		return "{".repeat(depth) + "}".repeat(depth);
+	}
+
+}


### PR DESCRIPTION
## What this PR does

Closes #36723

`SpelParserConfiguration` already enforces a maximum **expression length** and a maximum **number of evaluation operations**, but had no corresponding guard on **structural nesting depth** — e.g. deeply-nested inline lists `{{{{…}}}}` and maps `{'a': {'b': {'c': …}}}`. Without a bound, a crafted expression can drive the recursive-descent parser into an arbitrarily deep Java call stack, eventually causing `StackOverflowError`.

This PR adds a configurable `maximumNestingDepth` limit that fires a descriptive `SpelParseException` the moment the parser descends past the threshold.

---

## Changes

### `SpelMessage`
- New entry **`MAX_NESTING_DEPTH_EXCEEDED`** (code `1086`) used when the configured limit is exceeded during parsing.

### `SpelParserConfiguration`
- **`DEFAULT_MAX_NESTING_DEPTH = 1_000`** — conservative default that is safe for any legitimate expression.
- **`SPRING_EXPRESSION_MAX_NESTING_DEPTH_PROPERTY_NAME`** (`spring.expression.maxNestingDepth`) — system property / `SpringProperties` key for global override, consistent with the existing `maxOperations` pattern.
- **`maximumNestingDepth`** field + **`getMaximumNestingDepth()`** accessor.
- New **8-arg canonical constructor** that adds `maximumNestingDepth`; the previous 7-arg constructor delegates to it and is marked `@Deprecated(since = "7.0")`.
- **`retrieveMaxNestingDepth()`** static helper follows exactly the same validation pattern as `retrieveMaxOperations()`.

### `InternalSpelExpressionParser`
- **`nestingDepth`** counter field, reset to `0` at the start of every `doParseExpression` call (ensuring parser instances are safely reusable).
- **`enterNesting(startPos)`** — increments the counter and throws via `internalException` if the limit is exceeded.
- **`exitNesting()`** — decrements the counter.
- **`maybeEatInlineListOrMap()`** — calls `enterNesting()` on `LCURLY` and `exitNesting()` just before the finished node is pushed, so every inline list and map contributes exactly one depth level.

### `SpelNestingDepthTests` (new)
15 JUnit 5 tests covering:
- Configuration defaults and validation
- Inline lists: flat, at-limit, over-limit, deeply nested past default
- Inline maps: flat, at-limit, over-limit
- Mixed list + map nesting
- Limit boundary conditions
- Parser reusability after an exception
- Error message containing the configured limit value

---

## Usage

```java
// Global override via system property:
System.setProperty("spring.expression.maxNestingDepth", "50");

// Per-parser override via constructor:
SpelParserConfiguration config = new SpelParserConfiguration(
        SpelCompilerMode.OFF, null,
        false, false, Integer.MAX_VALUE,
        SpelParserConfiguration.DEFAULT_MAX_EXPRESSION_LENGTH,
        SpelParserConfiguration.DEFAULT_MAX_OPERATIONS,
        50 // maximumNestingDepth
);
SpelExpressionParser parser = new SpelExpressionParser(config);

// Throws SpelParseException (EL1086E) for {{{{…}}}}}:
parser.parseExpression("{".repeat(51) + "}".repeat(51));
```

---

## Checklist

- [x] Implements the feature requested in #36723
- [x] Follows existing limit patterns (`maximumExpressionLength`, `maximumOperations`)
- [x] System property support (`spring.expression.maxNestingDepth`)
- [x] `@Deprecated(since = "7.0")` on the superseded 7-arg constructor
- [x] 15 unit tests with boundary, reuse, and error-message assertions
- [x] No new runtime dependencies