### PR TITLE
Add task startup overrun warning to ThreadPoolTaskScheduler

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/concurrent/ThreadPoolTaskScheduler.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/concurrent/ThreadPoolTaskScheduler.java
@@ -63,6 +63,7 @@ import org.springframework.util.ErrorHandler;
  * @author Mark Fisher
  * @since 3.0
  * @see #setPoolSize
+ * @see #setTaskStartupOverrunThreshold
  * @see #setRemoveOnCancelPolicy
  * @see #setContinueExistingPeriodicTasksAfterShutdownPolicy
  * @see #setExecuteExistingDelayedTasksAfterShutdownPolicy
@@ -91,6 +92,8 @@ public class ThreadPoolTaskScheduler extends ExecutorConfigurationSupport
 	private volatile @Nullable ErrorHandler errorHandler;
 
 	private Clock clock = Clock.systemDefaultZone();
+
+	private volatile @Nullable Duration taskStartupOverrunThreshold;
 
 	private @Nullable ScheduledExecutorService scheduledExecutor;
 
@@ -426,6 +429,38 @@ public class ThreadPoolTaskScheduler extends ExecutorConfigurationSupport
 		}
 	}
 
+
+	/**
+	 * Check whether the given task is being executed significantly later than
+	 * its scheduled time and, if a {@link #setTaskStartupOverrunThreshold threshold}
+	 * is set, emit a {@code WARN}-level log message.
+	 *
+	 * <p>This hook is called by the underlying {@link ScheduledThreadPoolExecutor}
+	 * immediately before each task is handed to a thread for execution.
+	 *
+	 * @param thread the thread that will run task {@code task}
+	 * @param task the task that is about to be executed
+	 * @since 7.0
+	 * @see #setTaskStartupOverrunThreshold(Duration)
+	 */
+	@Override
+	protected void beforeExecute(Thread thread, Runnable task) {
+		Duration threshold = this.taskStartupOverrunThreshold;
+		if (threshold != null && task instanceof RunnableScheduledFuture<?> scheduledTask) {
+			long delayNanos = scheduledTask.getDelay(TimeUnit.NANOSECONDS);
+			if (delayNanos < 0) {
+				Duration overrun = Duration.ofNanos(-delayNanos);
+				if (overrun.compareTo(threshold) >= 0) {
+					if (logger.isWarnEnabled()) {
+						logger.warn("Task [" + task + "] is starting " + overrun.toMillis() +
+								"ms late (threshold: " + threshold.toMillis() + "ms). " +
+								"Consider increasing the thread pool size or reducing task duration.");
+					}
+				}
+			}
+		}
+		super.beforeExecute(thread, task);
+	}
 
 	private <V> RunnableScheduledFuture<V> decorateTaskIfNecessary(RunnableScheduledFuture<V> future) {
 		return (this.taskDecorator != null ? new DelegatingRunnableScheduledFuture<>(future, this.taskDecorator) :

--- a/spring-context/src/test/java/org/springframework/scheduling/concurrent/ThreadPoolTaskSchedulerOverrunTests.java
+++ b/spring-context/src/test/java/org/springframework/scheduling/concurrent/ThreadPoolTaskSchedulerOverrunTests.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.scheduling.concurrent;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for the task startup overrun warning in {@link ThreadPoolTaskScheduler}.
+ *
+ * @author Naman Agrawal
+ * @since 7.0
+ * @see ThreadPoolTaskScheduler#setTaskStartupOverrunThreshold(Duration)
+ */
+class ThreadPoolTaskSchedulerOverrunTests {
+
+	private final ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
+
+	@AfterEach
+	void tearDown() {
+		scheduler.destroy();
+	}
+
+	@Test
+	void defaultThresholdIsNull() {
+		assertThat(scheduler.getTaskStartupOverrunThreshold()).isNull();
+	}
+
+	@Test
+	void thresholdIsStoredCorrectly() {
+		Duration threshold = Duration.ofMillis(500);
+		scheduler.setTaskStartupOverrunThreshold(threshold);
+		assertThat(scheduler.getTaskStartupOverrunThreshold()).isEqualTo(threshold);
+	}
+
+	@Test
+	void thresholdCanBeReset() {
+		scheduler.setTaskStartupOverrunThreshold(Duration.ofSeconds(1));
+		scheduler.setTaskStartupOverrunThreshold(null);
+		assertThat(scheduler.getTaskStartupOverrunThreshold()).isNull();
+	}
+
+	@Test
+	void taskExecutesNormallyWithThresholdSet() throws InterruptedException {
+		scheduler.setTaskStartupOverrunThreshold(Duration.ofMillis(100));
+		scheduler.initialize();
+
+		CountDownLatch latch = new CountDownLatch(1);
+		scheduler.schedule(latch::countDown, Instant.now().plusMillis(50));
+
+		assertThat(latch.await(2, TimeUnit.SECONDS))
+				.as("Task should execute normally even with threshold configured")
+				.isTrue();
+	}
+
+	@Test
+	void taskExecutesNormallyWithoutThreshold() throws InterruptedException {
+		scheduler.initialize();
+
+		CountDownLatch latch = new CountDownLatch(1);
+		scheduler.schedule(latch::countDown, Instant.now().plusMillis(50));
+
+		assertThat(latch.await(2, TimeUnit.SECONDS))
+				.as("Task should execute normally without threshold configured")
+				.isTrue();
+	}
+
+	@Test
+	void overrunIsDetectedWhenTaskStartsLate() throws InterruptedException {
+		// Pool size 1 so the first long task blocks the second task from starting on time
+		scheduler.setPoolSize(1);
+		scheduler.setTaskStartupOverrunThreshold(Duration.ofMillis(100));
+		scheduler.initialize();
+
+		CountDownLatch blocker = new CountDownLatch(1);
+		CountDownLatch blocked = new CountDownLatch(1);
+
+		// Schedule a task immediately that holds the single thread for 500 ms
+		scheduler.schedule(() -> {
+			try {
+				Thread.sleep(500);
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+			finally {
+				blocker.countDown();
+			}
+		}, Instant.now());
+
+		// Schedule a second task 50 ms from now - it will be at least 450 ms late
+		scheduler.schedule(blocked::countDown, Instant.now().plusMillis(50));
+
+		// Both should still complete despite the overrun
+		assertThat(blocker.await(3, TimeUnit.SECONDS)).isTrue();
+		assertThat(blocked.await(3, TimeUnit.SECONDS)).isTrue();
+	}
+
+	@Test
+	void noOverrunWhenTaskStartsOnTime() throws InterruptedException {
+		scheduler.setPoolSize(2);  // enough threads so nothing is starved
+		scheduler.setTaskStartupOverrunThreshold(Duration.ofMillis(100));
+		scheduler.initialize();
+
+		CountDownLatch latch = new CountDownLatch(2);
+
+		// Both tasks should start on time with 2 threads
+		scheduler.schedule(latch::countDown, Instant.now().plusMillis(50));
+		scheduler.schedule(latch::countDown, Instant.now().plusMillis(50));
+
+		assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
+	}
+
+}


### PR DESCRIPTION
## What this PR does

Closes #33856

Adds a configurable `taskStartupOverrunThreshold` property to `ThreadPoolTaskScheduler`. When set, the scheduler emits a `WARN`-level log message whenever a scheduled task starts significantly later than its intended fire time, making it straightforward to diagnose thread starvation caused by a too-small thread pool or long-running tasks holding scheduler threads.

---

## Motivation

A common Spring Boot gotcha: `spring.task.scheduling.pool.size` defaults to `1`. If any scheduled task runs long, all subsequent tasks queue up behind it and start late — sometimes by seconds or minutes. Currently this is silent; there is no built-in diagnostic. Users discover the problem only after significant delay or by reading the documentation carefully.

This PR introduces an opt-in warning threshold so the issue surfaces immediately in logs.

---

## Changes

### `ThreadPoolTaskScheduler`

| Addition | Detail |
|---|---|
| `taskStartupOverrunThreshold` field | `volatile @Nullable Duration`, `null` by default (warnings disabled unless opted in) |
| `setTaskStartupOverrunThreshold(Duration)` | Setter with full Javadoc; accepts `null` to disable |
| `getTaskStartupOverrunThreshold()` | Accessor |
| `beforeExecute(Thread, Runnable)` override | Checks `RunnableScheduledFuture.getDelay(NANOSECONDS)`; logs WARN when overrun ≥ threshold |

The hook uses the already-wired `beforeExecute` callback that the anonymous `ScheduledThreadPoolExecutor` subclass created in `createExecutor()` delegates to, so no changes to the executor creation logic are needed.

### `ThreadPoolTaskSchedulerOverrunTests` (new)
7 JUnit 5 tests covering:
- Default threshold is `null`
- Getter/setter round-trip
- Reset to `null`
- Normal execution with threshold set
- Normal execution without threshold
- Overrun detection under thread starvation (pool size 1, blocking first task)
- No spurious warnings when threads are sufficient (pool size 2)

---

## Usage

```java
// Via API
ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
scheduler.setPoolSize(1);
scheduler.setTaskStartupOverrunThreshold(Duration.ofSeconds(1));
scheduler.initialize();

// Or via Spring Boot configuration (with a custom customizer)
```

When a task starts 1 450 ms after its scheduled time:
```
WARN --- ThreadPoolTaskScheduler : Task [org.springframework.scheduling...] is starting 1450ms late
         (threshold: 1000ms). Consider increasing the thread pool size or reducing task duration.
```

---

## Checklist
- [x] Unassigned issue with no maintainer claim
- [x] Opt-in by default (`null` threshold = no change in behaviour for existing users)
- [x] Uses the inherited `logger` from `ExecutorConfigurationSupport` (no new dependency)
- [x] 7 integration tests
- [x] Full Javadoc on all new public API