### PR TITLE
Generate compilable code for non-finite floating-point values

### DIFF
--- a/spring-core/src/main/java/org/springframework/aot/generate/ValueCodeGeneratorDelegates.java
+++ b/spring-core/src/main/java/org/springframework/aot/generate/ValueCodeGeneratorDelegates.java
@@ -220,10 +220,28 @@ public abstract class ValueCodeGeneratorDelegates {
 			if (value instanceof Long) {
 				return CodeBlock.of("$LL", value);
 			}
-			if (value instanceof Float) {
+			if (value instanceof Float floatValue) {
+				if (Float.isNaN(floatValue)) {
+					return CodeBlock.of("$T.NaN", Float.class);
+				}
+				if (floatValue == Float.POSITIVE_INFINITY) {
+					return CodeBlock.of("$T.POSITIVE_INFINITY", Float.class);
+				}
+				if (floatValue == Float.NEGATIVE_INFINITY) {
+					return CodeBlock.of("$T.NEGATIVE_INFINITY", Float.class);
+				}
 				return CodeBlock.of("$LF", value);
 			}
-			if (value instanceof Double) {
+			if (value instanceof Double doubleValue) {
+				if (Double.isNaN(doubleValue)) {
+					return CodeBlock.of("$T.NaN", Double.class);
+				}
+				if (doubleValue == Double.POSITIVE_INFINITY) {
+					return CodeBlock.of("$T.POSITIVE_INFINITY", Double.class);
+				}
+				if (doubleValue == Double.NEGATIVE_INFINITY) {
+					return CodeBlock.of("$T.NEGATIVE_INFINITY", Double.class);
+				}
 				return CodeBlock.of("(double) $L", value);
 			}
 			if (value instanceof Character character) {

--- a/spring-core/src/test/java/org/springframework/aot/generate/ValueCodeGeneratorTests.java
+++ b/spring-core/src/test/java/org/springframework/aot/generate/ValueCodeGeneratorTests.java
@@ -158,6 +158,36 @@ class ValueCodeGeneratorTests {
 		}
 
 		@Test
+		void generateWhenFloatNaN() {
+			assertThat(generateCode(Float.NaN)).hasToString("java.lang.Float.NaN");
+		}
+
+		@Test
+		void generateWhenFloatPositiveInfinity() {
+			assertThat(generateCode(Float.POSITIVE_INFINITY)).hasToString("java.lang.Float.POSITIVE_INFINITY");
+		}
+
+		@Test
+		void generateWhenFloatNegativeInfinity() {
+			assertThat(generateCode(Float.NEGATIVE_INFINITY)).hasToString("java.lang.Float.NEGATIVE_INFINITY");
+		}
+
+		@Test
+		void generateWhenDoubleNaN() {
+			assertThat(generateCode(Double.NaN)).hasToString("java.lang.Double.NaN");
+		}
+
+		@Test
+		void generateWhenDoublePositiveInfinity() {
+			assertThat(generateCode(Double.POSITIVE_INFINITY)).hasToString("java.lang.Double.POSITIVE_INFINITY");
+		}
+
+		@Test
+		void generateWhenDoubleNegativeInfinity() {
+			assertThat(generateCode(Double.NEGATIVE_INFINITY)).hasToString("java.lang.Double.NEGATIVE_INFINITY");
+		}
+
+		@Test
 		void generateWhenChar() {
 			assertThat(generateCode('a')).hasToString("'a'");
 		}


### PR DESCRIPTION
## Overview

The AOT `ValueCodeGenerator` emitted non-compilable Java for non-finite `Float` and `Double` values (`NaN`, positive and negative infinity), so any bean property or constructor argument holding such a value broke compilation of the generated AOT sources. This change emits proper constant field references instead.

## Problem

`PrimitiveDelegate` rendered floats via `CodeBlock.of("$LF", value)` and doubles via `CodeBlock.of("(double) $L", value)`. Since `$L` emits the value's `toString()` verbatim, the non-finite values became invalid source:

| value | generated | compiles? |
|-------|-----------|-----------|
| `Float.NaN` | `NaNF` | no |
| `Float.POSITIVE_INFINITY` | `InfinityF` | no |
| `Double.NaN` | `(double) NaN` | no |
| `Double.POSITIVE_INFINITY` | `(double) Infinity` | no |

## Fix

Detect `NaN` with `isNaN()` (because `NaN == NaN` is always `false`) and the infinities with `==`, emitting the corresponding constant field references through the `$T` placeholder (`Float.NaN`, `Double.POSITIVE_INFINITY`, and so on), which are valid compile-time constants. Finite values keep their existing handling, so normal numbers are unaffected. Tests covering `Float`/`Double` × {`NaN`, `+Infinity`, `-Infinity`} are added to `ValueCodeGeneratorTests`.