### PR TITLE
Improve nullability in DefaultResponseCreator

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/client/response/DefaultResponseCreator.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/response/DefaultResponseCreator.java
@@ -106,7 +106,7 @@ public class DefaultResponseCreator implements ResponseCreator {
 	/**
 	 * Set the {@code Content-Type} header.
 	 */
-	public DefaultResponseCreator contentType(MediaType mediaType) {
+	public DefaultResponseCreator contentType(@Nullable MediaType mediaType) {
 		this.headers.setContentType(mediaType);
 		return this;
 	}
@@ -114,7 +114,7 @@ public class DefaultResponseCreator implements ResponseCreator {
 	/**
 	 * Set the {@code Location} header.
 	 */
-	public DefaultResponseCreator location(URI location) {
+	public DefaultResponseCreator location(@Nullable URI location) {
 		this.headers.setLocation(location);
 		return this;
 	}
@@ -123,7 +123,7 @@ public class DefaultResponseCreator implements ResponseCreator {
 	 * Add a response header with one or more values.
 	 * @since 6.0
 	 */
-	public DefaultResponseCreator header(String name, String ... headerValues) {
+	public DefaultResponseCreator header(String name, @Nullable String... headerValues) {
 		for (String headerValue : headerValues) {
 			this.headers.add(name, headerValue);
 		}

--- a/spring-test/src/main/java/org/springframework/test/web/client/response/MockRestResponseCreators.java
+++ b/spring-test/src/main/java/org/springframework/test/web/client/response/MockRestResponseCreators.java
@@ -54,8 +54,7 @@ public abstract class MockRestResponseCreators {
 	 * @param contentType the type of the content (may be {@code null})
 	 */
 	public static DefaultResponseCreator withSuccess(String body, @Nullable MediaType contentType) {
-		DefaultResponseCreator creator = new DefaultResponseCreator(HttpStatus.OK).body(body);
-		return (contentType != null ? creator.contentType(contentType) : creator);
+		return new DefaultResponseCreator(HttpStatus.OK).body(body).contentType(contentType);
 	}
 
 	/**
@@ -64,8 +63,7 @@ public abstract class MockRestResponseCreators {
 	 * @param contentType the type of the content (may be {@code null})
 	 */
 	public static DefaultResponseCreator withSuccess(byte[] body, @Nullable MediaType contentType) {
-		DefaultResponseCreator creator = new DefaultResponseCreator(HttpStatus.OK).body(body);
-		return (contentType != null ? creator.contentType(contentType) : creator);
+		return new DefaultResponseCreator(HttpStatus.OK).body(body).contentType(contentType);
 	}
 
 	/**
@@ -74,8 +72,7 @@ public abstract class MockRestResponseCreators {
 	 * @param contentType the type of the content (may be {@code null})
 	 */
 	public static DefaultResponseCreator withSuccess(Resource body, @Nullable MediaType contentType) {
-		DefaultResponseCreator creator = new DefaultResponseCreator(HttpStatus.OK).body(body);
-		return (contentType != null ? creator.contentType(contentType) : creator);
+		return new DefaultResponseCreator(HttpStatus.OK).body(body).contentType(contentType);
 	}
 
 	/**


### PR DESCRIPTION
In response to the call for improvements to Spring code regarding Jspecify [Nulls are dead - Moritz Halbritter | IntelliJ IDEA Tech Talks](https://www.youtube.com/watch?v=tpz-FSs6oO4) here is an enhancement for DefaultResponseCreator encountered during writing tests.

The `DefaultResponseCreator` builder from spring-test unnecessarily restricts certain method parameters to non-nullable types although the nullable types are supported.
This just makes writing parameterized tests, for example, unnecessarily difficult.