### PR TITLE
Write native configuration files as UTF-8

### DIFF
--- a/spring-core/src/main/java/org/springframework/aot/nativex/FileNativeConfigurationWriter.java
+++ b/spring-core/src/main/java/org/springframework/aot/nativex/FileNativeConfigurationWriter.java
@@ -20,6 +20,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 
@@ -59,7 +60,7 @@ public class FileNativeConfigurationWriter extends NativeConfigurationWriter {
 	protected void writeTo(String fileName, Consumer<BasicJsonWriter> writer) {
 		try {
 			File file = createIfNecessary(fileName);
-			try (FileWriter out = new FileWriter(file)) {
+			try (FileWriter out = new FileWriter(file, StandardCharsets.UTF_8)) {
 				writer.accept(createJsonWriter(out));
 			}
 		}

--- a/spring-core/src/test/java/org/springframework/aot/nativex/FileNativeConfigurationWriterTests.java
+++ b/spring-core/src/test/java/org/springframework/aot/nativex/FileNativeConfigurationWriterTests.java
@@ -18,6 +18,7 @@ package org.springframework.aot.nativex;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Consumer;
@@ -174,6 +175,17 @@ class FileNativeConfigurationWriterTests {
 							{"glob": "com/example/another.properties"}
 					]
 				}""");
+	}
+
+	@Test
+	void resourceConfigWithNonAsciiPatternIsWrittenAsUtf8() throws IOException {
+		FileNativeConfigurationWriter generator = new FileNativeConfigurationWriter(tempDir);
+		RuntimeHints hints = new RuntimeHints();
+		hints.resources().registerPattern("com/example/café/**");
+		generator.write(hints);
+		Path jsonFile = tempDir.resolve("META-INF").resolve("native-image").resolve("reachability-metadata.json");
+		byte[] content = Files.readAllBytes(jsonFile);
+		assertThat(content).containsSequence("café".getBytes(StandardCharsets.UTF_8));
 	}
 
 	@Test


### PR DESCRIPTION
## Overview

A small consistency/hardening change: make `FileNativeConfigurationWriter` always write the GraalVM native-image configuration files (`reachability-metadata.json`, etc.) as UTF-8.

This is a minor edge-case fix rather than a critical bug; the trigger is narrow (see below), so please feel free to decline if you consider it not worth the change.

## Problem

`writeTo` uses a plain `FileWriter`:

```java
try (FileWriter out = new FileWriter(file)) {
    writer.accept(createJsonWriter(out));
}
```

`FileWriter` without an explicit charset encodes using the JVM platform default charset, which is not UTF-8 on every supported configuration (for example a Windows JVM, where the default is a code-page charset such as windows-1252 prior to JDK 18 / JEP 400). `BasicJsonWriter` passes non-ASCII characters through unescaped, so the on-disk encoding is decided entirely by the writer's charset. GraalVM expects these files to be UTF-8, so on a non-UTF-8 platform non-ASCII characters in resource patterns or bundle names could be written with the wrong encoding.

The conditions are narrow (a non-UTF-8 default charset combined with non-ASCII content), so this is more of a hardening/consistency improvement than a frequently hit bug.

## Fix

Specify `StandardCharsets.UTF_8` explicitly:

```java
try (FileWriter out = new FileWriter(file, StandardCharsets.UTF_8)) {
    writer.accept(createJsonWriter(out));
}
```

This is consistent with the explicit UTF-8 usage already present in the `aot.generate` package.

A test writes a resource pattern containing a non-ASCII character and asserts that the raw file bytes contain its UTF-8 byte sequence. Note that on a JVM whose default charset is already UTF-8 (such as the CI environment) the test passes both before and after the change; it serves as a guard on non-UTF-8 platforms and documents the intended encoding. The correctness of the fix itself rests on the `FileWriter(File, Charset)` contract rather than on reproducing a non-UTF-8 default in CI.
