### PR TITLE
Introduce `ResolvableType::resolveRequiredGeneric` to return casted non-null value

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/ResolvableType.java
+++ b/spring-core/src/main/java/org/springframework/core/ResolvableType.java
@@ -867,6 +867,24 @@ public class ResolvableType implements Serializable {
 	}
 
 	/**
+	 * Convenience method that will {@link #getGeneric(int...) get} and
+	 * {@link #resolve() resolve} a specific generic parameter.
+	 * @param indexes the indexes that refer to the generic parameter
+	 * (can be omitted to return the first generic)
+	 * @return a resolved {@link Class}
+	 * @throws IllegalStateException if no generic was available
+	 * @see #resolveGeneric(int...)
+	 * @see #getGeneric(int...)
+	 * @see #resolve()
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> Class<T> resolveRequiredGeneric(int... indexes) {
+		Class<?> generic = getGeneric(indexes).resolve();
+		Assert.state(generic != null, "The generic must not be null");
+		return (Class<T>) generic;
+	}
+
+	/**
 	 * Resolve this type to a {@link java.lang.Class}, returning {@code null}
 	 * if the type cannot be resolved. This method will consider bounds of
 	 * {@link TypeVariable TypeVariables} and {@link WildcardType WildcardTypes} if

--- a/spring-core/src/test/java/org/springframework/core/ResolvableTypeTests.java
+++ b/spring-core/src/test/java/org/springframework/core/ResolvableTypeTests.java
@@ -55,6 +55,7 @@ import org.springframework.util.MultiValueMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeastOnce;
@@ -1601,6 +1602,14 @@ class ResolvableTypeTests {
 		assertThat(typeWithGenerics.isAssignableFrom(PaymentCreator.class)).isTrue();
 	}
 
+	@Test
+	void resolveRequiredGeneric() {
+		assertThat(new AbstractRepository<String>() {}.entityClass).isEqualTo(String.class);
+		assertThat(new AbstractRepository<Long>() {}.entityClass).isEqualTo(Long.class);
+		assertThat(new AbstractRepository<>() {}.entityClass).isEqualTo(Object.class);
+		assertThatIllegalStateException().isThrownBy(() -> new AbstractRepository() {});
+	}
+
 
 	private ResolvableType testSerialization(ResolvableType type) throws Exception {
 		ByteArrayOutputStream bos = new ByteArrayOutputStream();
@@ -2013,6 +2022,14 @@ class ResolvableTypeTests {
 	abstract static class Payment {
 	}
 
+	abstract class AbstractRepository<T> {
+
+		final Class<T> entityClass;
+
+		AbstractRepository() {
+			entityClass = ResolvableType.forClass(getClass()).as(AbstractRepository.class).resolveRequiredGeneric();
+		}
+	}
 
 	private static class ResolvableTypeAssert extends AbstractAssert<ResolvableTypeAssert, ResolvableType>{
 


### PR DESCRIPTION
Use case:
```java
abstract class AbstractRepository<T> {

	final Class<T> entityClass;

	AbstractRepository() {
		entityClass = ResolvableType.forClass(getClass()).as(AbstractRepository.class).resolveRequiredGeneric();
	}
}
```