### PR TITLE
Write native configuration file when only lambda hints are present

### DIFF
--- a/spring-core/src/main/java/org/springframework/aot/nativex/NativeConfigurationWriter.java
+++ b/spring-core/src/main/java/org/springframework/aot/nativex/NativeConfigurationWriter.java
@@ -46,6 +46,7 @@ public abstract class NativeConfigurationWriter {
 	private boolean hasAnyHint(RuntimeHints hints) {
 		return (hints.proxies().jdkProxyHints().findAny().isPresent() ||
 				hints.reflection().typeHints().findAny().isPresent() ||
+				hints.reflection().lambdaHints().findAny().isPresent() ||
 				hints.resources().resourcePatternHints().findAny().isPresent() ||
 				hints.resources().resourceBundleHints().findAny().isPresent() ||
 				hints.jni().typeHints().findAny().isPresent() ||

--- a/spring-core/src/test/java/org/springframework/aot/nativex/FileNativeConfigurationWriterTests.java
+++ b/spring-core/src/test/java/org/springframework/aot/nativex/FileNativeConfigurationWriterTests.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -131,6 +132,34 @@ class FileNativeConfigurationWriterTests {
 							"methods": [
 								{ "name": "setDefaultCharset", "parameterTypes": [ "java.nio.charset.Charset" ] }
 							]
+						}
+					]
+				}
+				""");
+	}
+
+	@Test
+	void lambdaConfig() throws Exception {
+		FileNativeConfigurationWriter generator = new FileNativeConfigurationWriter(tempDir);
+		RuntimeHints hints = new RuntimeHints();
+		hints.reflection().registerLambda(Integer.class, builder -> builder
+				.withDeclaringMethod("getCell", Integer.class, Integer.class)
+				.withInterfaces(Supplier.class));
+		generator.write(hints);
+		assertEquals("""
+				{
+					"reflection": [
+						{
+							"type": {
+								"lambda": {
+									"declaringClass": "java.lang.Integer",
+									"declaringMethod": {
+										"name": "getCell",
+										"parameterTypes": [ "java.lang.Integer", "java.lang.Integer" ]
+									},
+									"interfaces": [ "java.util.function.Supplier" ]
+								}
+							}
 						}
 					]
 				}


### PR DESCRIPTION
## Overview

`FileNativeConfigurationWriter` fails to write `reachability-metadata.json` when a `RuntimeHints` instance contains only lambda hints, silently dropping the lambda metadata.

## Problem

`NativeConfigurationWriter.write(RuntimeHints)` only writes the configuration file when `hasAnyHint(hints)` returns `true`:

```java
public void write(RuntimeHints hints) {
	if (hasAnyHint(hints)) {
		writeTo("reachability-metadata.json",
				writer -> new RuntimeHintsWriter().write(writer, hints));
	}
}
```

However `hasAnyHint(hints)` does not check `ReflectionHints.lambdaHints()`:

```java
private boolean hasAnyHint(RuntimeHints hints) {
	return (hints.proxies().jdkProxyHints().findAny().isPresent() ||
			hints.reflection().typeHints().findAny().isPresent() ||
			hints.resources().resourcePatternHints().findAny().isPresent() ||
			hints.resources().resourceBundleHints().findAny().isPresent() ||
			hints.jni().typeHints().findAny().isPresent() ||
			hasAnyDeprecatedHint(hints));
}
```

`RuntimeHintsWriter` already serializes lambda hints (see the `oneLambda` test in `RuntimeHintsWriterTests`), so when a `RuntimeHints` holds only lambda hints registered via `ReflectionHints.registerLambda(...)`, `hasAnyHint` returns `false`, the file is never written, and the lambda metadata is lost. This is not caught on the JVM; it only surfaces as a native-image runtime failure.

## Fix

Include lambda hints in `hasAnyHint()` so the configuration file is written whenever lambda hints are present:

```java
hints.reflection().lambdaHints().findAny().isPresent() ||
```

Adds a `lambdaConfig()` test that registers only a lambda hint and asserts the file is written with the expected JSON. Without the fix the test fails with `NoSuchFileException` because no file is produced.
