### PR TITLE
doc: Add RestTestClient setup with @AutoConfigureRestTestClient

### DIFF
--- a/framework-docs/modules/ROOT/pages/testing/resttestclient.adoc
+++ b/framework-docs/modules/ROOT/pages/testing/resttestclient.adoc
@@ -77,6 +77,41 @@ Kotlin::
 ----
 ======
 
+[[resttestclient.springboottest-config]]
+=== Bind to `@SpringBootTest`
+
+When using Spring Boot, `@AutoConfigureRestTestClient` auto-configures a `RestTestClient` that connects to the embedded server started by `@SpringBootTest`.
+
+[tabs]
+======
+Java::
++
+[source,java,indent=0,subs="verbatim,quotes"]
+----
+	@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+	@AutoConfigureRestTestClient
+	class HttpRequestTest {
+
+		@Autowired
+		private RestTestClient restTestClient;
+
+		// ...
+	}
+----
+
+Kotlin::
++
+[source,kotlin,indent=0,subs="verbatim,quotes"]
+----
+	@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+	@AutoConfigureRestTestClient
+	class HttpRequestTest(@Autowired private val restTestClient: RestTestClient) {
+
+		// ...
+	}
+----
+======
+
 [[resttestclient.server-config]]
 === Bind to Server
 


### PR DESCRIPTION
When searching for how to set up the new ` RestTestClient`  for a ` @SpringBootTest`  I was writing, I missed an hint to the ` @AutoConfigureRestTestClient`  in the docs.

So I added it. ^^

I am aware that this is the spring framework doc and not the spring boot doc but since the `RestTestClient` is documentet here, I thought that this would be the best place. 

Feel free to throw away this PR if you don't want Spring Boot related stuff in it. :)