### PR TITLE
Address EditorConfig violations

### DIFF
--- a/integration-tests/src/test/resources/org/springframework/beans/factory/xml/component-config.xml
+++ b/integration-tests/src/test/resources/org/springframework/beans/factory/xml/component-config.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xmlns:foo="http://www.foo.example/schema/component"
-      xsi:schemaLocation="
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:foo="http://www.foo.example/schema/component"
+	   xsi:schemaLocation="
 http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 http://www.foo.example/schema/component http://www.foo.example/schema/component/component.xsd">
 
-   <foo:component id="bionic-family" name="Bionic-1">
-      <foo:component name="Mother-1">
-      	<foo:component name="Karate-1"/>
-  		<foo:component name="Sport-1"/>
-      </foo:component>
-      <foo:component name="Rock-1"/>
-   </foo:component>
+	<foo:component id="bionic-family" name="Bionic-1">
+		<foo:component name="Mother-1">
+			<foo:component name="Karate-1"/>
+			<foo:component name="Sport-1"/>
+		</foo:component>
+		<foo:component name="Rock-1"/>
+	</foo:component>
 
 </beans>

--- a/integration-tests/src/test/resources/org/springframework/beans/factory/xml/component.xsd
+++ b/integration-tests/src/test/resources/org/springframework/beans/factory/xml/component.xsd
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <xsd:schema xmlns="http://www.foo.example/schema/component"
-         xmlns:xsd="http://www.w3.org/2001/XMLSchema"
-         targetNamespace="http://www.foo.example/schema/component"
-         elementFormDefault="qualified"
-         attributeFormDefault="unqualified">
+			xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+			targetNamespace="http://www.foo.example/schema/component"
+			elementFormDefault="qualified"
+			attributeFormDefault="unqualified">
 
-   <xsd:element name="component">
-      <xsd:complexType>
-         <xsd:choice minOccurs="0" maxOccurs="unbounded">
-            <xsd:element ref="component"/>
-         </xsd:choice>
-         <xsd:attribute name="id" type="xsd:ID"/>
-         <xsd:attribute name="name" use="required" type="xsd:string"/>
-      </xsd:complexType>
-   </xsd:element>
+	<xsd:element name="component">
+		<xsd:complexType>
+			<xsd:choice minOccurs="0" maxOccurs="unbounded">
+				<xsd:element ref="component"/>
+			</xsd:choice>
+			<xsd:attribute name="id" type="xsd:ID"/>
+			<xsd:attribute name="name" use="required" type="xsd:string"/>
+		</xsd:complexType>
+	</xsd:element>
 
 </xsd:schema>

--- a/integration-tests/src/test/resources/org/springframework/context/annotation/ltw/ComponentScanningWithLTWTests.xml
+++ b/integration-tests/src/test/resources/org/springframework/context/annotation/ltw/ComponentScanningWithLTWTests.xml
@@ -10,7 +10,7 @@
 
 	<context:component-scan base-package="org.springframework.context.annotation">
 		<context:exclude-filter type="annotation"
-		                        expression="org.springframework.context.annotation.Configuration"/>
+								expression="org.springframework.context.annotation.Configuration"/>
 	</context:component-scan>
 
 	<context:load-time-weaver aspectj-weaving="off"/>

--- a/spring-aop/src/test/resources/org/springframework/aop/target/CommonsPool2TargetSourceProxyTests-context.xml
+++ b/spring-aop/src/test/resources/org/springframework/aop/target/CommonsPool2TargetSourceProxyTests-context.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-aspects/src/test/resources/org/springframework/aop/aspectj/autoproxy/ajcAutoproxyTests.xml
+++ b/spring-aspects/src/test/resources/org/springframework/aop/aspectj/autoproxy/ajcAutoproxyTests.xml
@@ -2,12 +2,12 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:aop="http://www.springframework.org/schema/aop"
-	    xmlns:cache="http://www.springframework.org/schema/cache"
+		xmlns:cache="http://www.springframework.org/schema/cache"
 		xmlns:context="http://www.springframework.org/schema/context"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
 				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd
 				http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache-3.1.xsd
-	   			http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<aop:aspectj-autoproxy/>
 

--- a/spring-beans/src/jmh/resources/org/springframework/beans/factory/ConcurrentBeanFactoryBenchmark-context.xml
+++ b/spring-beans/src/jmh/resources/org/springframework/beans/factory/ConcurrentBeanFactoryBenchmark-context.xml
@@ -2,14 +2,14 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
-  <bean id="bean1" class="org.springframework.beans.factory.ConcurrentBeanFactoryBenchmark$ConcurrentBean"
+	<bean id="bean1" class="org.springframework.beans.factory.ConcurrentBeanFactoryBenchmark$ConcurrentBean"
 			scope="prototype">
-    <property name="date" value="2004/08/08"/>
-  </bean>
+		<property name="date" value="2004/08/08"/>
+	</bean>
 
-  <bean id="bean2" class="org.springframework.beans.factory.ConcurrentBeanFactoryBenchmark$ConcurrentBean"
+	<bean id="bean2" class="org.springframework.beans.factory.ConcurrentBeanFactoryBenchmark$ConcurrentBean"
 			scope="prototype">
-    <property name="date" value="2000/02/02"/>
-  </bean>
+		<property name="date" value="2000/02/02"/>
+	</bean>
 
 </beans>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/BeanFactoryUtilsTests-dependentBeans.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/BeanFactoryUtilsTests-dependentBeans.xml
@@ -29,9 +29,9 @@
 	<bean id="thread" class="java.lang.Thread"/>
 
 	<bean id="field" class="org.springframework.beans.factory.config.FieldRetrievingFactoryBean">
-	   <property name="targetObject" ref="thread"/>
-   	   <property name="targetField" value="MAX_PRIORITY"/>
-	 </bean>
+		<property name="targetObject" ref="thread"/>
+		<property name="targetField" value="MAX_PRIORITY"/>
+	</bean>
 
 	<bean id="secondBuffer" class="java.lang.StringBuffer">
 		<constructor-arg ref="field"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/FactoryBeanTests-circular.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/FactoryBeanTests-circular.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-   xsi:schemaLocation="http://www.springframework.org/schema/beans
-                       https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
+						https://www.springframework.org/schema/beans/spring-beans-3.0.xsd">
 
-   <bean id="bean1" class="org.springframework.beans.factory.FactoryBeanTests$PassThroughFactoryBean" primary="true">
-      <constructor-arg value="org.springframework.beans.factory.FactoryBeanTests$BeanImpl1"/>
-      <property name="instanceName" value="beanImpl1"/>
-   </bean>
+	<bean id="bean1" class="org.springframework.beans.factory.FactoryBeanTests$PassThroughFactoryBean" primary="true">
+		<constructor-arg value="org.springframework.beans.factory.FactoryBeanTests$BeanImpl1"/>
+		<property name="instanceName" value="beanImpl1"/>
+	</bean>
 
-   <bean id="beanImpl1" class="org.springframework.beans.factory.FactoryBeanTests$BeanImpl1">
-      <property name="impl2" ref="bean2"/>
-   </bean>
+	<bean id="beanImpl1" class="org.springframework.beans.factory.FactoryBeanTests$BeanImpl1">
+		<property name="impl2" ref="bean2"/>
+	</bean>
 
-   <bean id="bean2" class="org.springframework.beans.factory.FactoryBeanTests$PassThroughFactoryBean" primary="true">
-      <constructor-arg value="org.springframework.beans.factory.FactoryBeanTests$BeanImpl2"/>
-      <property name="instanceName" value="beanImpl2"/>
-   </bean>
+	<bean id="bean2" class="org.springframework.beans.factory.FactoryBeanTests$PassThroughFactoryBean" primary="true">
+		<constructor-arg value="org.springframework.beans.factory.FactoryBeanTests$BeanImpl2"/>
+		<property name="instanceName" value="beanImpl2"/>
+	</bean>
 
-   <bean id="beanImpl2" class="org.springframework.beans.factory.FactoryBeanTests$BeanImpl2">
-      <property name="impl1" ref="bean1"/>
-   </bean>
+	<bean id="beanImpl2" class="org.springframework.beans.factory.FactoryBeanTests$BeanImpl2">
+		<property name="impl1" ref="bean1"/>
+	</bean>
 
 </beans>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/FactoryBeanTests-withAutowiring.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/FactoryBeanTests-withAutowiring.xml
@@ -12,7 +12,7 @@
 	<bean id="gamma" class="org.springframework.beans.factory.FactoryBeanTests$Gamma"/>
 
 	<bean id="betaFactory" class="org.springframework.beans.factory.FactoryBeanTests$BetaFactoryBean" autowire="constructor">
-    	<property name="beta" ref="beta"/>
+		<property name="beta" ref="beta"/>
 	</bean>
 
 	<bean id="gammaFactory" factory-bean="${gammaFactory}" factory-method="${gamma}"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/annotation/CustomAutowireConfigurerTests-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/annotation/CustomAutowireConfigurerTests-context.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.springframework.org/schema/beans
-                https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans
+						   https://www.springframework.org/schema/beans/spring-beans-2.5.xsd">
 
-    <bean id="resolver" class="org.springframework.beans.factory.annotation.CustomAutowireConfigurerTests$CustomResolver"/>
+	<bean id="resolver" class="org.springframework.beans.factory.annotation.CustomAutowireConfigurerTests$CustomResolver"/>
 
-    <bean id="number-one" class="java.lang.String">
-        <meta key="priority" value="1"/>
-        <constructor-arg value="#1!"/>
-    </bean>
+	<bean id="number-one" class="java.lang.String">
+		<meta key="priority" value="1"/>
+		<constructor-arg value="#1!"/>
+	</bean>
 
-    <bean id="one" class="java.lang.String" autowire-candidate="false">
-        <meta key="priority" value="1"/>
-        <constructor-arg value="#1"/>
-    </bean>
+	<bean id="one" class="java.lang.String" autowire-candidate="false">
+		<meta key="priority" value="1"/>
+		<constructor-arg value="#1"/>
+	</bean>
 
-    <bean id="number1" class="java.lang.String">
-        <meta key="priority" value="1"/>
-        <constructor-arg value="#1"/>
-    </bean>
+	<bean id="number1" class="java.lang.String">
+		<meta key="priority" value="1"/>
+		<constructor-arg value="#1"/>
+	</bean>
 
-    <bean id="number-two" class="java.lang.String">
-        <meta key="priority" value="2"/>
-        <constructor-arg value="#2"/>
-    </bean>
+	<bean id="number-two" class="java.lang.String">
+		<meta key="priority" value="2"/>
+		<constructor-arg value="#2"/>
+	</bean>
 
-    <bean id="testBean"
-          class="org.springframework.beans.factory.annotation.CustomAutowireConfigurerTests$TestBean"
-          autowire="constructor"/>
+	<bean id="testBean"
+		  class="org.springframework.beans.factory.annotation.CustomAutowireConfigurerTests$TestBean"
+		  autowire="constructor"/>
 
 </beans>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/config/PropertyPathFactoryBeanTests-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/config/PropertyPathFactoryBeanTests-context.xml
@@ -10,7 +10,7 @@
 				<property name="age"><value>11</value></property>
 			</bean>
 		</property>
-  </bean>
+	</bean>
 
 	<bean id="otb" class="org.springframework.beans.testfixture.beans.TestBean">
 		<property name="age"><value>98</value></property>
@@ -19,7 +19,7 @@
 				<property name="age"><value>99</value></property>
 			</bean>
 		</property>
-  </bean>
+	</bean>
 
 	<bean id="propertyPath1" class="org.springframework.beans.factory.config.PropertyPathFactoryBean">
 		<property name="targetObject">

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/parsing/CustomProblemReporterTests-context.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/parsing/CustomProblemReporterTests-context.xml
@@ -18,9 +18,9 @@
 		<property name="spouse">
 			<bean class="org.springframework.beans.testfixture.beans.TestBean">
 				<property name="someMap">
-				    <map>
-				        <entry/>
-				    </map>
+					<map>
+						<entry/>
+					</map>
 				</property>
 			</bean>
 		</property>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/autowire-constructor-with-exclusion.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/autowire-constructor-with-exclusion.xml
@@ -8,15 +8,15 @@
 	<bean id="sally" class="org.springframework.beans.testfixture.beans.TestBean" scope="prototype"/>
 
 	<bean id="props1" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
-	  <property name="properties">
+		<property name="properties">
 			<value>name=props1</value>
-	  </property>
+		</property>
 	</bean>
 
 	<bean id="props2" class="org.springframework.beans.factory.config.PropertiesFactoryBean" autowire-candidate="false">
-	  <property name="properties">
+		<property name="properties">
 			<value>name=props2</value>
-	  </property>
+		</property>
 	</bean>
 
 </beans>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/autowire-with-exclusion.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/autowire-with-exclusion.xml
@@ -8,15 +8,15 @@
 	<bean id="sally" class="org.springframework.beans.testfixture.beans.TestBean"/>
 
 	<bean id="props1" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
-	  <property name="properties">
+		<property name="properties">
 			<value>name=props1</value>
-	  </property>
+		</property>
 	</bean>
 
 	<bean id="props2" class="org.springframework.beans.factory.config.PropertiesFactoryBean" autowire-candidate="false">
-	  <property name="properties">
+		<property name="properties">
 			<value>name=props2</value>
-	  </property>
+		</property>
 	</bean>
 
 	<bean class="org.springframework.beans.factory.xml.CountingFactory">

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/autowire-with-inclusion.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/autowire-with-inclusion.xml
@@ -9,15 +9,15 @@
 	<bean id="sally" class="org.springframework.beans.testfixture.beans.TestBean" autowire-candidate="true"/>
 
 	<bean id="props1" class="org.springframework.beans.factory.config.PropertiesFactoryBean" autowire-candidate="true">
-	  <property name="properties">
+		<property name="properties">
 			<value>name=props1</value>
-	  </property>
+		</property>
 	</bean>
 
 	<bean id="props2" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
-	  <property name="properties">
+		<property name="properties">
 			<value>name=props2</value>
-	  </property>
+		</property>
 	</bean>
 
 	<bean class="org.springframework.beans.factory.xml.CountingFactory">

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/autowire-with-selective-inclusion.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/autowire-with-selective-inclusion.xml
@@ -9,21 +9,21 @@
 	<bean id="sally" class="org.springframework.beans.testfixture.beans.TestBean"/>
 
 	<bean id="props1" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
-	  <property name="properties">
+		<property name="properties">
 			<value>name=props1</value>
-	  </property>
+		</property>
 	</bean>
 
 	<bean id="props2" class="org.springframework.beans.factory.config.PropertiesFactoryBean" autowire-candidate="false">
-	  <property name="properties">
+		<property name="properties">
 			<value>name=props2</value>
-	  </property>
+		</property>
 	</bean>
 
 	<bean id="someProps" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
-	  <property name="properties">
+		<property name="properties">
 			<value>name=someProps</value>
-	  </property>
+		</property>
 	</bean>
 
 	<bean class="org.springframework.beans.factory.xml.CountingFactory">

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/collections.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/collections.xml
@@ -137,15 +137,15 @@
 					<value type="java.lang.Integer">10</value>
 				</entry>
 				<entry>
- 					<key>
+					<key>
 						<ref bean="jennyKey"/>
 					</key>
 					<ref bean="jenny"/>
 				</entry>
 				<entry>
- 					<key>
- 						<bean class="java.lang.Integer">
- 							<constructor-arg value="5"/>
+					<key>
+						<bean class="java.lang.Integer">
+							<constructor-arg value="5"/>
 						</bean>
 					</key>
 					<idref bean="david"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/simpleConstructorNamespaceHandlerTests.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/simpleConstructorNamespaceHandlerTests.xml
@@ -4,18 +4,18 @@
 		xmlns:c="http://www.springframework.org/schema/c"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd">
 
- <!--
+<!--
 	<bean id="simple1" class="org.springframework.beans.testfixture.beans.DummyBean">
 		<constructor-arg value="name"/>
 	</bean>
- -->
+-->
 	<bean id="simple" class="org.springframework.beans.testfixture.beans.DummyBean" c:_="simple"/>
 
 <!--
 	<bean id="simple1-ref" class="org.springframework.beans.testfixture.beans.DummyBean">
 		<constructor-arg ref="name"/>
 	</bean>
- -->
+-->
 	<bean id="simple-ref" class="org.springframework.beans.testfixture.beans.DummyBean" c:_-ref="name"/>
 
 	<bean id="name" class="java.lang.String">
@@ -27,7 +27,7 @@
 		<constructor-arg name="name" value="foo"/>
 		<constructor-arg name="age" value="10"/>
 	</bean>
- -->
+-->
 	<bean id="name-value" class="org.springframework.beans.testfixture.beans.TestBean" c:age="10" c:name="name-value"/>
 
 <!-- 
@@ -35,7 +35,7 @@
 		<constructor-arg name="name" ref="name"/>
 		<constructor-arg name="spouse" ref="name-value"/>
 	</bean>
- -->
+-->
 	<bean id="name-ref" class="org.springframework.beans.testfixture.beans.DummyBean" c:name-ref="name" c:spouse-ref="name-value"/>
 
 	<bean id="indexed-value" class="org.springframework.beans.testfixture.beans.DummyBean" c:_1="austria" c:_0="at" c:_2="10"/>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/test.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/test.xml
@@ -121,7 +121,7 @@
 	<bean id="validEmpty" class="org.springframework.beans.testfixture.beans.TestBean"/>
 
 	<bean id="commentsInValue" class="org.springframework.beans.testfixture.beans.TestBean">
-	  <property name="name"><value>this is<!-- don't mind me --> a <![CDATA[<!--comment-->]]></value></property>
+		<property name="name"><value>this is<!-- don't mind me --> a <![CDATA[<!--comment-->]]></value></property>
 	</bean>
 
 </beans>

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/testUtilNamespace.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/testUtilNamespace.xml
@@ -112,14 +112,14 @@
 				<util:constant static-field="java.lang.Thread.State.RUNNABLE"/>
 			</set>
 		</property>
-	  <property name="someMap">
+		<property name="someMap">
 			<map>
 				<entry>
 					<key><value>min</value></key>
 					<util:constant static-field="org.springframework.beans.testfixture.beans.CustomEnum.VALUE_1"/>
 				</entry>
 			</map>
-	  </property>
+		</property>
 	</bean>
 
 	<bean id="circularCollectionsBean" class="org.springframework.beans.testfixture.beans.TestBean">

--- a/spring-beans/src/test/resources/org/springframework/beans/factory/xml/withMeta.xml
+++ b/spring-beans/src/test/resources/org/springframework/beans/factory/xml/withMeta.xml
@@ -13,7 +13,7 @@
 	</spring:bean>
 
 	<spring:bean id="testBean3" class="org.springframework.beans.testfixture.beans.TestBean">
-	  <spring:property name="name" value="Rob">
+		<spring:property name="name" value="Rob">
 			<spring:meta key="surname" value="Harrop"/>
 		</spring:property>
 	</spring:bean>

--- a/spring-context-support/src/test/resources/org/springframework/cache/ehcache/testEhcache.xml
+++ b/spring-context-support/src/test/resources/org/springframework/cache/ehcache/testEhcache.xml
@@ -1,50 +1,50 @@
 <ehcache>
 
-    <!-- Sets the path to the directory where cache .data files are created.
+	<!-- Sets the path to the directory where cache .data files are created.
 
-         If the path is a Java System Property it is replaced by
-         its value in the running VM.
+		 If the path is a Java System Property it is replaced by
+		 its value in the running VM.
 
-         The following properties are translated:
-         user.home - User's home directory
-         user.dir - User's current working directory
-         java.io.tmpdir - Default temp file path -->
-    <diskStore path="java.io.tmpdir"/>
+		 The following properties are translated:
+		 user.home - User's home directory
+		 user.dir - User's current working directory
+		 java.io.tmpdir - Default temp file path -->
+	<diskStore path="java.io.tmpdir"/>
 
 
-    <!--Default Cache configuration. These will applied to caches programmatically created through
-        the CacheManager.
+	<!--Default Cache configuration. These will applied to caches programmatically created through
+		the CacheManager.
 
-        The following attributes are required for defaultCache:
+		The following attributes are required for defaultCache:
 
-        maxInMemory       - Sets the maximum number of objects that will be created in memory
-        eternal           - Sets whether elements are eternal. If eternal,  timeouts are ignored and the element
-                            is never expired.
-        timeToIdleSeconds - Sets the time to idle for an element before it expires.
-                            i.e. The maximum amount of time between accesses before an element expires
-                            Is only used if the element is not eternal.
-                            Optional attribute. A value of 0 means that an Element can idle for infinity
-        timeToLiveSeconds - Sets the time to live for an element before it expires.
-                            i.e. The maximum time between creation time and when an element expires.
-                            Is only used if the element is not eternal.
-        overflowToDisk    - Sets whether elements can overflow to disk when the in-memory cache
-                            has reached the maxInMemory limit.
+		maxInMemory       - Sets the maximum number of objects that will be created in memory
+		eternal           - Sets whether elements are eternal. If eternal,  timeouts are ignored and the element
+							is never expired.
+		timeToIdleSeconds - Sets the time to idle for an element before it expires.
+							i.e. The maximum amount of time between accesses before an element expires
+							Is only used if the element is not eternal.
+							Optional attribute. A value of 0 means that an Element can idle for infinity
+		timeToLiveSeconds - Sets the time to live for an element before it expires.
+							i.e. The maximum time between creation time and when an element expires.
+							Is only used if the element is not eternal.
+		overflowToDisk    - Sets whether elements can overflow to disk when the in-memory cache
+							has reached the maxInMemory limit.
 
-        -->
-    <defaultCache
-        maxElementsInMemory="10000"
-        eternal="false"
-        timeToIdleSeconds="120"
-        timeToLiveSeconds="120"
-        overflowToDisk="true"
-        />
+		-->
+	<defaultCache
+		maxElementsInMemory="10000"
+		eternal="false"
+		timeToIdleSeconds="120"
+		timeToLiveSeconds="120"
+		overflowToDisk="true"
+	/>
        
-    <cache name="myCache1"
-        maxElementsInMemory="300"
-        eternal="false"
-        timeToIdleSeconds="500"
-        timeToLiveSeconds="500"
-        overflowToDisk="true"
-        />
+	<cache name="myCache1"
+		maxElementsInMemory="300"
+		eternal="false"
+		timeToIdleSeconds="500"
+		timeToLiveSeconds="500"
+		overflowToDisk="true"
+		/>
        
 </ehcache>

--- a/spring-context-support/src/test/resources/org/springframework/cache/jcache/config/jCacheNamespaceDriven-resolver.xml
+++ b/spring-context-support/src/test/resources/org/springframework/cache/jcache/config/jCacheNamespaceDriven-resolver.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   		https://www.springframework.org/schema/beans/spring-beans.xsd
-       		http://www.springframework.org/schema/cache
-       		https://www.springframework.org/schema/cache/spring-cache.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd
+			http://www.springframework.org/schema/cache
+			https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<cache:annotation-driven cache-manager="cacheManager" cache-resolver="cacheResolver"/>
 

--- a/spring-context-support/src/test/resources/org/springframework/cache/jcache/config/jCacheNamespaceDriven.xml
+++ b/spring-context-support/src/test/resources/org/springframework/cache/jcache/config/jCacheNamespaceDriven.xml
@@ -3,9 +3,9 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   		https://www.springframework.org/schema/beans/spring-beans.xsd
-       		http://www.springframework.org/schema/cache
-       		https://www.springframework.org/schema/cache/spring-cache.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd
+			http://www.springframework.org/schema/cache
+			https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<cache:annotation-driven proxy-target-class="false" order="0" error-handler="errorHandler"/>
 

--- a/spring-context-support/src/test/resources/org/springframework/cache/jcache/config/jCacheStandaloneConfig.xml
+++ b/spring-context-support/src/test/resources/org/springframework/cache/jcache/config/jCacheStandaloneConfig.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   		https://www.springframework.org/schema/beans/spring-beans.xsd">
+			https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean class="org.springframework.aop.framework.autoproxy.DefaultAdvisorAutoProxyCreator"/>
 

--- a/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/quartzSchedulerLifecycleTests.xml
+++ b/spring-context-support/src/test/resources/org/springframework/scheduling/quartz/quartzSchedulerLifecycleTests.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans
-        https://www.springframework.org/schema/beans/spring-beans.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
+		https://www.springframework.org/schema/beans/spring-beans.xsd">
 
 	<bean id="otherSchedulerWithDefaultShutdownOrder" class="org.springframework.scheduling.quartz.SchedulerFactoryBean">
 		<property name="autoStartup" value="false"/>

--- a/spring-context/src/main/resources/org/springframework/cache/config/spring-cache.xsd
+++ b/spring-context/src/main/resources/org/springframework/cache/config/spring-cache.xsd
@@ -214,12 +214,12 @@
 	The SpEL expression used for computing the cache key, mutually exclusive with the key-generator parameter.]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
-        <xsd:attribute name="key-generator" type="xsd:string" use="optional">
-            <xsd:annotation>
-                <xsd:documentation><![CDATA[
+		<xsd:attribute name="key-generator" type="xsd:string" use="optional">
+			<xsd:annotation>
+				<xsd:documentation><![CDATA[
 	The name of the KeyGenerator bean responsible to compute the key, mutually exclusive with the key parameter.]]></xsd:documentation>
-            </xsd:annotation>
-        </xsd:attribute>
+			</xsd:annotation>
+		</xsd:attribute>
 		<xsd:attribute name="cache-manager" type="xsd:string" use="optional">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
@@ -247,64 +247,64 @@
 		<xsd:complexContent>
 			<xsd:extension base="basedefinitionType">
 				<xsd:sequence>
-				  <xsd:choice minOccurs="0" maxOccurs="unbounded">
-					<xsd:element name="cacheable" minOccurs="0" maxOccurs="unbounded">
-						<xsd:complexType>
-							<xsd:complexContent>
-								<xsd:extension base="basedefinitionType">
-									<xsd:attribute name="unless" type="xsd:string" use="optional">
-										<xsd:annotation>
-											<xsd:documentation><![CDATA[
+					<xsd:choice minOccurs="0" maxOccurs="unbounded">
+						<xsd:element name="cacheable" minOccurs="0" maxOccurs="unbounded">
+							<xsd:complexType>
+								<xsd:complexContent>
+									<xsd:extension base="basedefinitionType">
+										<xsd:attribute name="unless" type="xsd:string" use="optional">
+											<xsd:annotation>
+												<xsd:documentation><![CDATA[
 	The SpEL expression used to veto the method caching.]]></xsd:documentation>
-										</xsd:annotation>
-									</xsd:attribute>
-									<xsd:attribute name="sync" type="xsd:boolean" use="optional" default="false">
-										<xsd:annotation>
-											<xsd:documentation><![CDATA[
+											</xsd:annotation>
+										</xsd:attribute>
+										<xsd:attribute name="sync" type="xsd:boolean" use="optional" default="false">
+											<xsd:annotation>
+												<xsd:documentation><![CDATA[
 	Synchronize the invocation of the underlying method if several threads
 	are attempting to load a value for the same key]]></xsd:documentation>
-										</xsd:annotation>
-									</xsd:attribute>
-								</xsd:extension>
-							</xsd:complexContent>
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="cache-put" minOccurs="0" maxOccurs="unbounded">
-						<xsd:complexType>
-							<xsd:complexContent>
-								<xsd:extension base="basedefinitionType">
-									<xsd:attribute name="unless" type="xsd:string" use="optional">
-										<xsd:annotation>
-											<xsd:documentation><![CDATA[
+											</xsd:annotation>
+										</xsd:attribute>
+									</xsd:extension>
+								</xsd:complexContent>
+							</xsd:complexType>
+						</xsd:element>
+						<xsd:element name="cache-put" minOccurs="0" maxOccurs="unbounded">
+							<xsd:complexType>
+								<xsd:complexContent>
+									<xsd:extension base="basedefinitionType">
+										<xsd:attribute name="unless" type="xsd:string" use="optional">
+											<xsd:annotation>
+												<xsd:documentation><![CDATA[
 	The SpEL expression used to veto the method caching.]]></xsd:documentation>
-										</xsd:annotation>
-									</xsd:attribute>
-								</xsd:extension>
-							</xsd:complexContent>
-						</xsd:complexType>
-					</xsd:element>
-					<xsd:element name="cache-evict" minOccurs="0" maxOccurs="unbounded">
-						<xsd:complexType>
-							<xsd:complexContent>
-								<xsd:extension base="basedefinitionType">
-									<xsd:attribute name="all-entries" type="xsd:boolean" use="optional">
-										<xsd:annotation>
-											<xsd:documentation><![CDATA[
+											</xsd:annotation>
+										</xsd:attribute>
+									</xsd:extension>
+								</xsd:complexContent>
+							</xsd:complexType>
+						</xsd:element>
+						<xsd:element name="cache-evict" minOccurs="0" maxOccurs="unbounded">
+							<xsd:complexType>
+								<xsd:complexContent>
+									<xsd:extension base="basedefinitionType">
+										<xsd:attribute name="all-entries" type="xsd:boolean" use="optional">
+											<xsd:annotation>
+												<xsd:documentation><![CDATA[
 	Whether all the entries should be evicted.]]></xsd:documentation>
-										</xsd:annotation>
-									</xsd:attribute>
-									<xsd:attribute name="before-invocation" type="xsd:boolean" use="optional">
-										<xsd:annotation>
-											<xsd:documentation><![CDATA[
+											</xsd:annotation>
+										</xsd:attribute>
+										<xsd:attribute name="before-invocation" type="xsd:boolean" use="optional">
+											<xsd:annotation>
+												<xsd:documentation><![CDATA[
 	Whether the eviction should occur after the method is successfully
 	invoked (default) or before.]]></xsd:documentation>
-										</xsd:annotation>
-									</xsd:attribute>
-								</xsd:extension>
-							</xsd:complexContent>
-						</xsd:complexType>
-					</xsd:element>
-				  </xsd:choice>
+											</xsd:annotation>
+										</xsd:attribute>
+									</xsd:extension>
+								</xsd:complexContent>
+							</xsd:complexType>
+						</xsd:element>
+					</xsd:choice>
 				</xsd:sequence>
 			</xsd:extension>
 		</xsd:complexContent>

--- a/spring-context/src/main/resources/org/springframework/context/config/spring-context.xsd
+++ b/spring-context/src/main/resources/org/springframework/context/config/spring-context.xsd
@@ -506,17 +506,17 @@
 		<xsd:attribute name="type" use="required">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-    Controls the type of filtering to apply to the expression.
+	Controls the type of filtering to apply to the expression.
 
-    "annotation" indicates an annotation to be present or meta-present at the type level in target components;
-    "assignable" indicates a class (or interface) that the target components are assignable to (extend/implement);
-    "aspectj" indicates an AspectJ type pattern expression to be matched by the target components;
-    "regex" indicates a regex pattern to be matched by the target components' class names;
-    "custom" indicates a custom implementation of the org.springframework.core.type.TypeFilter interface.
+	"annotation" indicates an annotation to be present or meta-present at the type level in target components;
+	"assignable" indicates a class (or interface) that the target components are assignable to (extend/implement);
+	"aspectj" indicates an AspectJ type pattern expression to be matched by the target components;
+	"regex" indicates a regex pattern to be matched by the target components' class names;
+	"custom" indicates a custom implementation of the org.springframework.core.type.TypeFilter interface.
 
-    Note: This attribute will not be inherited by child bean definitions.
-    Hence, it needs to be specified per concrete bean definition.
-                ]]></xsd:documentation>
+	Note: This attribute will not be inherited by child bean definitions.
+	Hence, it needs to be specified per concrete bean definition.
+				]]></xsd:documentation>
 			</xsd:annotation>
 			<xsd:simpleType>
 				<xsd:restriction base="xsd:string">
@@ -531,8 +531,8 @@
 		<xsd:attribute name="expression" type="xsd:string" use="required">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-    Indicates the filter expression, the type of which is indicated by "type".
-                ]]></xsd:documentation>
+	Indicates the filter expression, the type of which is indicated by "type".
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>

--- a/spring-context/src/main/resources/org/springframework/ejb/config/spring-jee.xsd
+++ b/spring-context/src/main/resources/org/springframework/ejb/config/spring-jee.xsd
@@ -217,7 +217,7 @@
 	
 	Note: This attribute will not be inherited by child bean definitions.
 	Hence, it needs to be specified per concrete bean definition.
-	    				]]></xsd:documentation>
+						]]></xsd:documentation>
 					</xsd:annotation>
 				</xsd:attribute>
 			</xsd:extension>

--- a/spring-context/src/main/resources/org/springframework/scheduling/config/spring-task.xsd
+++ b/spring-context/src/main/resources/org/springframework/scheduling/config/spring-task.xsd
@@ -268,7 +268,7 @@
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 	A reference to a bean that implements the Trigger interface.
- 				]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="initial-delay" type="xsd:string" use="optional">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/AfterThrowingAdviceBindingTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/AfterThrowingAdviceBindingTests.xml
@@ -3,14 +3,14 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 
 	<aop:config>
 		<aop:aspect id="afterThrowingAdviceBindingTests" ref="testAspect">
 			<aop:after-throwing
-			    method="noArgs"
-			    pointcut="execution(* exceptional(..))"
+				method="noArgs"
+				pointcut="execution(* exceptional(..))"
 			/>
 			<aop:after-throwing
 				method="oneThrowable"

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/AspectAndAdvicePrecedenceTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/AspectAndAdvicePrecedenceTests.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-			 xmlns:aop="http://www.springframework.org/schema/aop"
-			 xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aop="http://www.springframework.org/schema/aop"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+			http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/BeanNamePointcutAtAspectTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/BeanNamePointcutAtAspectTests.xml
@@ -3,7 +3,7 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:aspectj-autoproxy/>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/DeclarationOrderIndependenceTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/DeclarationOrderIndependenceTests.xml
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-     xmlns:aop="http://www.springframework.org/schema/aop"
-     xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:aop="http://www.springframework.org/schema/aop"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+			http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
-  <bean id="topsyTurvyAspect" class="org.springframework.aop.aspectj.TopsyTurvyAspect"/>
+	<bean id="topsyTurvyAspect" class="org.springframework.aop.aspectj.TopsyTurvyAspect"/>
  
-  <bean id="topsyTurvyTarget" class="org.springframework.aop.aspectj.TopsyTurvyTargetImpl"/>
+	<bean id="topsyTurvyTarget" class="org.springframework.aop.aspectj.TopsyTurvyTargetImpl"/>
 
-  <aop:config>
-    <aop:aspect id="myAspect" ref="topsyTurvyAspect">
-      <aop:before pointcut-ref="pc1"
-                  method="before"/>
-      <aop:declare-parents
-        types-matching="*..TopsyTurvyTarget+"
-        implement-interface="java.io.Serializable"
-        default-impl="org.springframework.aop.aspectj.DeclarationOrderIndependenceTests$SerializableMixin"/>
-      <aop:after-returning pointcut-ref="pc2" method="afterReturning"/>
-      <aop:pointcut id="pc1" expression="execution(* *..do*(..))"/>
-      <aop:around pointcut-ref="pc2"
-                  method="around"/>
-      <aop:pointcut id="pc2" expression="execution(* *..TopsyTurvyTarget+.get*(..))"/>
-      <aop:declare-parents
-        types-matching="*..TopsyTurvyTarget+"
-        implement-interface="org.springframework.beans.factory.BeanNameAware"
-        default-impl="org.springframework.aop.aspectj.DeclarationOrderIndependenceTests$BeanNameAwareMixin"/>         
-    </aop:aspect>
-  </aop:config>
+	<aop:config>
+		<aop:aspect id="myAspect" ref="topsyTurvyAspect">
+			<aop:before pointcut-ref="pc1"
+						method="before"/>
+			<aop:declare-parents
+				types-matching="*..TopsyTurvyTarget+"
+				implement-interface="java.io.Serializable"
+				default-impl="org.springframework.aop.aspectj.DeclarationOrderIndependenceTests$SerializableMixin"/>
+			<aop:after-returning pointcut-ref="pc2" method="afterReturning"/>
+			<aop:pointcut id="pc1" expression="execution(* *..do*(..))"/>
+			<aop:around pointcut-ref="pc2"
+						method="around"/>
+			<aop:pointcut id="pc2" expression="execution(* *..TopsyTurvyTarget+.get*(..))"/>
+			<aop:declare-parents
+				types-matching="*..TopsyTurvyTarget+"
+				implement-interface="org.springframework.beans.factory.BeanNameAware"
+				default-impl="org.springframework.aop.aspectj.DeclarationOrderIndependenceTests$BeanNameAwareMixin"/>         
+		</aop:aspect>
+	</aop:config>
  
 </beans>

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/ImplicitJPArgumentMatchingAtAspectJTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/ImplicitJPArgumentMatchingAtAspectJTests.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<bean id="testBean" class="org.springframework.beans.testfixture.beans.TestBean">
 		<property name="name" value="aTestBean"/>

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/ImplicitJPArgumentMatchingTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/ImplicitJPArgumentMatchingTests.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config proxy-target-class="true">
 		<aop:aspect ref="counterAspect">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/OverloadedAdviceTests-ambiguous.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/OverloadedAdviceTests-ambiguous.xml
@@ -3,7 +3,7 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 
 	<aop:config>

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/OverloadedAdviceTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/OverloadedAdviceTests.xml
@@ -3,7 +3,7 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 
 	<aop:config>

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/ProceedTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/ProceedTests.xml
@@ -22,11 +22,11 @@
 	<bean id="testBean" class="org.springframework.aop.aspectj.SimpleBeanImpl"/>
 
 	<bean id="firstTestAspect"  class="org.springframework.aop.aspectj.ProceedTestingAspect">
-	   <property name="order" value="1"/>
+		<property name="order" value="1"/>
 	</bean>
 
 	<bean id="secondTestAspect" class="org.springframework.aop.aspectj.ProceedTestingAspect">
-	   <property name="order" value="2"/>
+		<property name="order" value="2"/>
 	</bean>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/PropertyDependentAspectTests-after.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/PropertyDependentAspectTests-after.xml
@@ -4,7 +4,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect ref="monitoringAspect">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/PropertyDependentAspectTests-atAspectJ-after.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/PropertyDependentAspectTests-atAspectJ-after.xml
@@ -4,7 +4,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<bean id="counter" class="org.springframework.aop.aspectj.Counter"/>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/PropertyDependentAspectTests-atAspectJ-before.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/PropertyDependentAspectTests-atAspectJ-before.xml
@@ -4,7 +4,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:aspectj-autoproxy/>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/PropertyDependentAspectTests-before.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/PropertyDependentAspectTests-before.xml
@@ -4,7 +4,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<bean id="counter" class="org.springframework.aop.aspectj.Counter"/>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/SharedPointcutWithArgsMismatchTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/SharedPointcutWithArgsMismatchTests.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:aop="http://www.springframework.org/schema/aop"
-        xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-        http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xmlns:aop="http://www.springframework.org/schema/aop"
+		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="beforeAdviceBindingTests" ref="testAspect">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/SubtypeSensitiveMatchingTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/SubtypeSensitiveMatchingTests.xml
@@ -3,18 +3,18 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 
 	<aop:config>
 		<aop:aspect id="thisMatcher" ref="testAspect">
-		  <aop:before pointcut="execution(* *(..)) and this(java.io.Serializable)" method="toString"/>
+			<aop:before pointcut="execution(* *(..)) and this(java.io.Serializable)" method="toString"/>
 		</aop:aspect>
 		<aop:aspect id="targetMatcher" ref="testAspect">
-		  <aop:before pointcut="execution(* *(..)) and target(java.io.Serializable)" method="toString"/>
+			<aop:before pointcut="execution(* *(..)) and target(java.io.Serializable)" method="toString"/>
 		</aop:aspect>
 		<aop:aspect id="argsMatcher" ref="testAspect">
-		  <aop:before pointcut="execution(* bar(..)) and args(java.io.Serializable)" method="toString"/>
+			<aop:before pointcut="execution(* bar(..)) and args(java.io.Serializable)" method="toString"/>
 		</aop:aspect>
 	</aop:config>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/TargetPointcutSelectionTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/TargetPointcutSelectionTests.xml
@@ -8,16 +8,16 @@
 	<aop:config>
 
 		<aop:advisor pointcut="target(org.springframework.aop.aspectj.TargetPointcutSelectionTests$TestImpl1)"
-        advice-ref="testInterceptor"/>
+					 advice-ref="testInterceptor"/>
 
 		<aop:aspect ref="testAspectForTestImpl1">
 			<aop:before pointcut="target(org.springframework.aop.aspectj.TargetPointcutSelectionTests$TestImpl1)"
-          method="increment"/>
+						method="increment"/>
 		</aop:aspect>
 
 		<aop:aspect ref="testAspectForAbstractTestImpl">
 			<aop:before pointcut="target(org.springframework.aop.aspectj.TargetPointcutSelectionTests$AbstractTestImpl)"
-          method="increment"/>
+						method="increment"/>
 		</aop:aspect>
 
 	</aop:config>

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/ThisAndTargetSelectionOnlyPointcutsAtAspectJTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/ThisAndTargetSelectionOnlyPointcutsAtAspectJTests.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:aspectj-autoproxy proxy-target-class="false"/>
 

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/ThisAndTargetSelectionOnlyPointcutsTests.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/ThisAndTargetSelectionOnlyPointcutsTests.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 
 	<aop:config>

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AnnotationBindingTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AnnotationBindingTests-context.xml
@@ -3,7 +3,7 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect id="annotationBindingAspect" ref="testAspect">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectImplementingInterfaceTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectImplementingInterfaceTests-context.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:aop="http://www.springframework.org/schema/aop"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:config>
 		<aop:aspect ref="interfaceExtendingAspect">

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-aspectsWithCGLIB.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-aspectsWithCGLIB.xml
@@ -3,10 +3,10 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-3.0.xsd">
+	   http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-3.0.xsd">
 
     
-    <!--
+	<!--
 	<bean
 		class="org.springframework.aop.aspectj.annotation.AnnotationAwareAspectJAutoProxyCreator" />
 	-->

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-aspectsWithOrdering.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-aspectsWithOrdering.xml
@@ -3,7 +3,7 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<!--
 	<bean class="org.springframework.aop.aspectj.annotation.AnnotationAwareAspectJAutoProxyCreator" />

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-usesInclude.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/AspectJAutoProxyCreatorTests-usesInclude.xml
@@ -6,7 +6,7 @@
 				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
 	<aop:aspectj-autoproxy>
-	  <aop:include name="aspectOne"/>
+		<aop:include name="aspectOne"/>
 	</aop:aspectj-autoproxy>
 
 	<bean id="aspectOne" class="org.springframework.aop.aspectj.autoproxy.MultiplyReturnValue" >

--- a/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/benchmark/BenchmarkTests-aspectj.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/aspectj/autoproxy/benchmark/BenchmarkTests-aspectj.xml
@@ -3,10 +3,10 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:aop="http://www.springframework.org/schema/aop"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
+	   http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd">
 
     
-    <!--
+	<!--
 	<bean
 		class="org.springframework.aop.aspectj.annotation.AnnotationAwareAspectJAutoProxyCreator" />
 	-->

--- a/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-context.xml
@@ -26,7 +26,7 @@
 		<!--
 			Aspect interfaces don't need to be included here.
 			They may, for example, be added by global interceptors.
-		 -->
+		-->
 		<property name="interfaces"><value>org.springframework.beans.testfixture.beans.ITestBean</value></property>
 
 		<!--

--- a/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-notlast-targetsource.xml
+++ b/spring-context/src/test/resources/org/springframework/aop/framework/ProxyFactoryBeanTests-notlast-targetsource.xml
@@ -18,9 +18,9 @@
 	/>
 
 	<!--
-       An error, as the target source or non-advice object
-       must be last
-    -->
+		An error, as the target source or non-advice object
+		must be last
+	-->
 	<bean id="targetSourceNotLast"
 		class="org.springframework.aop.framework.ProxyFactoryBean">
 		<property name="proxyInterfaces"><value>org.springframework.beans.testfixture.beans.ITestBean</value></property>

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/QualifierAnnotationTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/QualifierAnnotationTests-context.xml
@@ -55,8 +55,8 @@
 
 	<bean id="thetaClient" class="org.springframework.beans.factory.xml.QualifierAnnotationTests$MultiQualifierClient"/>
 
-    <bean id="thetaFactory" class="org.springframework.beans.factory.xml.QualifierAnnotationTests$QualifiedFactoryBean"/>
+	<bean id="thetaFactory" class="org.springframework.beans.factory.xml.QualifierAnnotationTests$QualifiedFactoryBean"/>
 
-    <bean id="thetaImpl" class="org.springframework.beans.factory.xml.QualifierAnnotationTests$ThetaImpl"/>
+	<bean id="thetaImpl" class="org.springframework.beans.factory.xml.QualifierAnnotationTests$ThetaImpl"/>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-collections.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-collections.xml
@@ -133,15 +133,15 @@
 					<value type="java.lang.Integer">10</value>
 				</entry>
 				<entry>
- 					<key>
+					<key>
 						<ref bean="jennyKey"/>
 					</key>
 					<ref bean="jenny"/>
 				</entry>
 				<entry>
- 					<key>
- 						<bean class="java.lang.Integer">
- 							<constructor-arg value="5"/>
+					<key>
+						<bean class="java.lang.Integer">
+							<constructor-arg value="5"/>
 						</bean>
 					</key>
 					<idref bean="david"/>

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-localCollectionsUsingXsd.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/XmlBeanFactoryTests-localCollectionsUsingXsd.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-	     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	     xmlns:util="http://www.springframework.org/schema/util"
-	     xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-           http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-2.0.xsd">
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xmlns:util="http://www.springframework.org/schema/util"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+			http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-2.0.xsd">
 
 	<!-- just ensures that one can use <ref bean=""/> to refer to the various <util:collections/> types -->
 

--- a/spring-context/src/test/resources/org/springframework/beans/factory/xml/support/CustomNamespaceHandlerTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/beans/factory/xml/support/CustomNamespaceHandlerTests-context.xml
@@ -4,8 +4,8 @@
 	   xmlns:test="http://www.springframework.org/schema/beans/test"
 	   xmlns:util="http://www.springframework.org/schema/util"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-       http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-2.0.xsd
-       http://www.springframework.org/schema/beans/test https://www.springframework.org/schema/beans/factory/xml/support/CustomNamespaceHandlerTests.xsd"
+	   http://www.springframework.org/schema/util https://www.springframework.org/schema/util/spring-util-2.0.xsd
+	   http://www.springframework.org/schema/beans/test https://www.springframework.org/schema/beans/factory/xml/support/CustomNamespaceHandlerTests.xsd"
 	default-lazy-init="true">
 
 	<test:testBean id="testBean" name="Rob Harrop" age="23"/>

--- a/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheConfig.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheConfig.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:aop="http://www.springframework.org/schema/aop"
-       xmlns:p="http://www.springframework.org/schema/p"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-       		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd">
+	   xmlns:aop="http://www.springframework.org/schema/aop"
+	   xmlns:p="http://www.springframework.org/schema/p"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+			http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd">
 
 	<bean id="apc" class="org.springframework.aop.framework.autoproxy.InfrastructureAdvisorAutoProxyCreator"/>
 

--- a/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheNamespace-manager-resolver.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheNamespace-manager-resolver.xml
@@ -3,7 +3,7 @@
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xmlns:p="http://www.springframework.org/schema/p"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-       		http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
+			http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<cache:annotation-driven cache-manager="customCacheManager"
 							 cache-resolver="cacheResolver"/>

--- a/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheNamespace-resolver.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheNamespace-resolver.xml
@@ -3,7 +3,7 @@
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xmlns:p="http://www.springframework.org/schema/p"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-       		http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
+			http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<cache:annotation-driven cache-resolver="cacheResolver"/>
 

--- a/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheNamespace.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/annotationDrivenCacheNamespace.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:aop="http://www.springframework.org/schema/aop"
-       xmlns:cache="http://www.springframework.org/schema/cache"
-       xmlns:p="http://www.springframework.org/schema/p"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-       		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd
-       		http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
+	   xmlns:aop="http://www.springframework.org/schema/aop"
+	   xmlns:cache="http://www.springframework.org/schema/cache"
+	   xmlns:p="http://www.springframework.org/schema/p"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+			http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd
+			http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<cache:annotation-driven proxy-target-class="false" order="0"
 							 key-generator="keyGenerator" error-handler="errorHandler"/>

--- a/spring-context/src/test/resources/org/springframework/cache/config/cache-advice-invalid.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/cache-advice-invalid.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-       		http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
+			http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<import resource="cache-advice.xml"/>
 

--- a/spring-context/src/test/resources/org/springframework/cache/config/cache-advice.xml
+++ b/spring-context/src/test/resources/org/springframework/cache/config/cache-advice.xml
@@ -4,8 +4,8 @@
 	   xmlns:cache="http://www.springframework.org/schema/cache"
 	   xmlns:p="http://www.springframework.org/schema/p"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-       		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd
-       		http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
+			http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop.xsd
+			http://www.springframework.org/schema/cache https://www.springframework.org/schema/cache/spring-cache.xsd">
 
 	<cache:advice id="cacheAdviceInterface" cache-manager="cacheManager">
 		<cache:caching cache="testCache">
@@ -116,7 +116,7 @@
 
 	<bean id="keyGenerator" class="org.springframework.context.testfixture.cache.SomeKeyGenerator"/>
 
-    <bean id="customKeyGenerator" class="org.springframework.context.testfixture.cache.SomeCustomKeyGenerator"/>
+	<bean id="customKeyGenerator" class="org.springframework.context.testfixture.cache.SomeCustomKeyGenerator"/>
 
 	<bean id="customCacheManager" class="org.springframework.cache.support.SimpleCacheManager">
 		<property name="caches">

--- a/spring-context/src/test/resources/org/springframework/context/access/ContextJndiBeanFactoryLocatorTests-collections.xml
+++ b/spring-context/src/test/resources/org/springframework/context/access/ContextJndiBeanFactoryLocatorTests-collections.xml
@@ -133,15 +133,15 @@
 					<value type="java.lang.Integer">10</value>
 				</entry>
 				<entry>
- 					<key>
+					<key>
 						<ref bean="jennyKey"/>
 					</key>
 					<ref bean="jenny"/>
 				</entry>
 				<entry>
- 					<key>
- 						<bean class="java.lang.Integer">
- 							<constructor-arg value="5"/>
+					<key>
+						<bean class="java.lang.Integer">
+							<constructor-arg value="5"/>
 						</bean>
 					</key>
 					<idref bean="david"/>

--- a/spring-context/src/test/resources/org/springframework/context/access/ContextSingletonBeanFactoryLocatorTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/context/access/ContextSingletonBeanFactoryLocatorTests-context.xml
@@ -8,20 +8,20 @@
 
 <beans>
 
-  <!-- this definition could be inside one beanRefFactory.xml file -->
-  <bean id="a.qualified.name.of.some.sort"
-      class="org.springframework.context.support.ClassPathXmlApplicationContext">
-    <property name="configLocation" value="org/springframework/beans/factory/access/beans1.xml"/>
-  </bean>
+	<!-- this definition could be inside one beanRefFactory.xml file -->
+	<bean id="a.qualified.name.of.some.sort"
+			class="org.springframework.context.support.ClassPathXmlApplicationContext">
+		<property name="configLocation" value="org/springframework/beans/factory/access/beans1.xml"/>
+	</bean>
 
-  <!-- while the following two could be inside another, also on the classpath,
+	<!-- while the following two could be inside another, also on the classpath,
 	perhaps coming from another component jar -->
-  <bean id="another.qualified.name"
-      class="org.springframework.context.support.ClassPathXmlApplicationContext">
-    <property name="configLocation" value="org/springframework/beans/factory/access/beans1.xml"/>
-    <property name="parent" ref="a.qualified.name.of.some.sort"/>
-  </bean>
+	<bean id="another.qualified.name"
+			class="org.springframework.context.support.ClassPathXmlApplicationContext">
+		<property name="configLocation" value="org/springframework/beans/factory/access/beans1.xml"/>
+		<property name="parent" ref="a.qualified.name.of.some.sort"/>
+	</bean>
 
-  <alias name="another.qualified.name" alias="a.qualified.name.which.is.an.alias"/>
+	<alias name="another.qualified.name" alias="a.qualified.name.which.is.an.alias"/>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/DestroyMethodInferenceTests-context.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/DestroyMethodInferenceTests-context.xml
@@ -2,14 +2,14 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	                    https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
+						https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
 	<bean id="x1"
-	      class="org.springframework.context.annotation.DestroyMethodInferenceTests$WithLocalCloseMethod"/>
+		  class="org.springframework.context.annotation.DestroyMethodInferenceTests$WithLocalCloseMethod"/>
 
 	<bean id="x2"
-	      class="org.springframework.context.annotation.DestroyMethodInferenceTests$WithLocalCloseMethod"
-	      destroy-method="(inferred)"/>
+		  class="org.springframework.context.annotation.DestroyMethodInferenceTests$WithLocalCloseMethod"
+		  destroy-method="(inferred)"/>
 
 	<bean id="x8"
 		  class="org.springframework.context.annotation.DestroyMethodInferenceTests.WithInheritedCloseMethod"
@@ -24,9 +24,9 @@
 
 	<beans default-destroy-method="(inferred)">
 		<bean id="x3"
-		      class="org.springframework.context.annotation.DestroyMethodInferenceTests$WithLocalCloseMethod"/>
+			  class="org.springframework.context.annotation.DestroyMethodInferenceTests$WithLocalCloseMethod"/>
 		<bean id="x4"
-		      class="org.springframework.context.annotation.DestroyMethodInferenceTests$WithNoCloseMethod"/>
+			  class="org.springframework.context.annotation.DestroyMethodInferenceTests$WithNoCloseMethod"/>
 	</beans>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/aspectjTypeFilterTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/aspectjTypeFilterTests.xml
@@ -6,9 +6,9 @@
 				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="example.scannable" use-default-filters="false" annotation-config="false">
-        <context:include-filter type="aspectj" expression="example.scannable.Stub*"/>
-        <context:include-filter type="aspectj" expression="example.scannable.FooService+"/>
-        <context:exclude-filter type="aspectj" expression="example..Scoped*Test*"/>
-    </context:component-scan>
+		<context:include-filter type="aspectj" expression="example.scannable.Stub*"/>
+		<context:include-filter type="aspectj" expression="example.scannable.FooService+"/>
+		<context:exclude-filter type="aspectj" expression="example..Scoped*Test*"/>
+	</context:component-scan>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/aspectjTypeFilterTestsWithPlaceholders.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/aspectjTypeFilterTestsWithPlaceholders.xml
@@ -6,9 +6,9 @@
 				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="${basePackage}" use-default-filters="false" annotation-config="false">
-        <context:include-filter type="aspectj" expression="example.scannable.Stub*"/>
-        <context:include-filter type="aspectj" expression="${scanInclude}"/>
-        <context:exclude-filter type="aspectj" expression="${scanExclude}"/>
-    </context:component-scan>
+		<context:include-filter type="aspectj" expression="example.scannable.Stub*"/>
+		<context:include-filter type="aspectj" expression="${scanInclude}"/>
+		<context:exclude-filter type="aspectj" expression="${scanExclude}"/>
+	</context:component-scan>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/customNameGeneratorTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/customNameGeneratorTests.xml
@@ -6,6 +6,6 @@
 				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="test, example.scannable"
-	    name-generator="org.springframework.context.annotation.TestBeanNameGenerator"/>
+		name-generator="org.springframework.context.annotation.TestBeanNameGenerator"/>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/customScopeResolverTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/customScopeResolverTests.xml
@@ -6,6 +6,6 @@
 				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="example.scannable"
-	    scope-resolver="org.springframework.context.annotation.TestScopeMetadataResolver"/>
+		scope-resolver="org.springframework.context.annotation.TestScopeMetadataResolver"/>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/defaultAutowireByNameTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/defaultAutowireByNameTests.xml
@@ -3,27 +3,27 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				            http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
-        default-autowire="byName">
+							http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
+		default-autowire="byName">
 
 	<context:component-scan base-package="org.springframework.context.annotation"
-            use-default-filters="false"
-            annotation-config="false">
-        <context:include-filter type="assignable"
-                expression="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$DefaultsTestBean"/>
-    </context:component-scan>
+			use-default-filters="false"
+			annotation-config="false">
+		<context:include-filter type="assignable"
+				expression="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$DefaultsTestBean"/>
+	</context:component-scan>
 
-    <bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$ConstructorDependencyTestBean">
-        <constructor-arg value="cd"/>
-    </bean>
+	<bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$ConstructorDependencyTestBean">
+		<constructor-arg value="cd"/>
+	</bean>
 
-    <bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
-        <constructor-arg value="pd1"/>
-    </bean>
+	<bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
+		<constructor-arg value="pd1"/>
+	</bean>
 
-    <bean id="propertyDependency2"
-          class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
-        <constructor-arg value="pd2"/>
-    </bean>
+	<bean id="propertyDependency2"
+		  class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
+		<constructor-arg value="pd2"/>
+	</bean>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/defaultAutowireByTypeTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/defaultAutowireByTypeTests.xml
@@ -3,27 +3,27 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				            http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
-        default-autowire="byType">
+							http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
+		default-autowire="byType">
 
 	<context:component-scan base-package="org.springframework.context.annotation"
-            use-default-filters="false"
-            annotation-config="false">
-        <context:include-filter type="assignable"
-                expression="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$DefaultsTestBean"/>
-    </context:component-scan>
+			use-default-filters="false"
+			annotation-config="false">
+		<context:include-filter type="assignable"
+				expression="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$DefaultsTestBean"/>
+	</context:component-scan>
 
-    <bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$ConstructorDependencyTestBean">
-        <constructor-arg value="cd"/>
-    </bean>
+	<bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$ConstructorDependencyTestBean">
+		<constructor-arg value="cd"/>
+	</bean>
 
-    <bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
-        <constructor-arg value="pd1"/>
-    </bean>
+	<bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
+		<constructor-arg value="pd1"/>
+	</bean>
 
-    <bean id="propertyDependency2"
-          class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
-        <constructor-arg value="pd2"/>
-    </bean>
+	<bean id="propertyDependency2"
+		  class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
+		<constructor-arg value="pd2"/>
+	</bean>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/defaultAutowireConstructorTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/defaultAutowireConstructorTests.xml
@@ -3,27 +3,27 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				            http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
-        default-autowire="constructor">
+							http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
+		default-autowire="constructor">
 
 	<context:component-scan base-package="org.springframework.context.annotation"
-            use-default-filters="false"
-            annotation-config="false">
-        <context:include-filter type="assignable"
-                expression="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$DefaultsTestBean"/>
-    </context:component-scan>
+			use-default-filters="false"
+			annotation-config="false">
+		<context:include-filter type="assignable"
+				expression="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$DefaultsTestBean"/>
+	</context:component-scan>
 
-    <bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$ConstructorDependencyTestBean">
-        <constructor-arg value="cd"/>
-    </bean>
+	<bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$ConstructorDependencyTestBean">
+		<constructor-arg value="cd"/>
+	</bean>
 
-    <bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
-        <constructor-arg value="pd1"/>
-    </bean>
+	<bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
+		<constructor-arg value="pd1"/>
+	</bean>
 
-    <bean id="propertyDependency2"
-          class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
-        <constructor-arg value="pd2"/>
-    </bean>
+	<bean id="propertyDependency2"
+		  class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
+		<constructor-arg value="pd2"/>
+	</bean>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/defaultAutowireNoTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/defaultAutowireNoTests.xml
@@ -3,27 +3,27 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				            http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
-        default-autowire="no">
+							http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
+		default-autowire="no">
 
 	<context:component-scan base-package="org.springframework.context.annotation"
-            use-default-filters="false"
-            annotation-config="false">
-        <context:include-filter type="assignable"
-                expression="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$DefaultsTestBean"/>
-    </context:component-scan>
+			use-default-filters="false"
+			annotation-config="false">
+		<context:include-filter type="assignable"
+				expression="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$DefaultsTestBean"/>
+	</context:component-scan>
 
-    <bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$ConstructorDependencyTestBean">
-        <constructor-arg value="cd"/>
-    </bean>
+	<bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$ConstructorDependencyTestBean">
+		<constructor-arg value="cd"/>
+	</bean>
 
-    <bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
-        <constructor-arg value="pd1"/>
-    </bean>
+	<bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
+		<constructor-arg value="pd1"/>
+	</bean>
 
-    <bean id="propertyDependency2"
-          class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
-        <constructor-arg value="pd2"/>
-    </bean>
+	<bean id="propertyDependency2"
+		  class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
+		<constructor-arg value="pd2"/>
+	</bean>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/defaultInitAndDestroyMethodsTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/defaultInitAndDestroyMethodsTests.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:context="http://www.springframework.org/schema/context"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
-    default-init-method="init" default-destroy-method="destroy">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
+	default-init-method="init" default-destroy-method="destroy">
 
 	<context:component-scan base-package="org.springframework.context.annotation"
-      use-default-filters="false" annotation-config="false">
-    <context:include-filter type="assignable"
-        expression="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$DefaultsTestBean"/>
-    </context:component-scan>
+			use-default-filters="false" annotation-config="false">
+		<context:include-filter type="assignable"
+				expression="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$DefaultsTestBean"/>
+	</context:component-scan>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/defaultLazyInitFalseTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/defaultLazyInitFalseTests.xml
@@ -3,14 +3,14 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				            http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
-        default-lazy-init="false">
+							http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
+		default-lazy-init="false">
 
 	<context:component-scan base-package="org.springframework.context.annotation"
-            use-default-filters="false"
-            annotation-config="false">
-        <context:include-filter type="assignable"
-                expression="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$DefaultsTestBean"/>
-    </context:component-scan>
+			use-default-filters="false"
+			annotation-config="false">
+		<context:include-filter type="assignable"
+				expression="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$DefaultsTestBean"/>
+	</context:component-scan>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/defaultLazyInitTrueTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/defaultLazyInitTrueTests.xml
@@ -3,14 +3,14 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				            http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
-        default-lazy-init="true">
+							http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
+		default-lazy-init="true">
 
 	<context:component-scan base-package="org.springframework.context.annotation"
-            use-default-filters="false"
-            annotation-config="false">
-        <context:include-filter type="assignable"
-                expression="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$DefaultsTestBean"/>
-    </context:component-scan>
+			use-default-filters="false"
+			annotation-config="false">
+		<context:include-filter type="assignable"
+				expression="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$DefaultsTestBean"/>
+	</context:component-scan>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/defaultNonExistingInitAndDestroyMethodsTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/defaultNonExistingInitAndDestroyMethodsTests.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns:context="http://www.springframework.org/schema/context"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-        http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
-    default-init-method="myInit" default-destroy-method="myDestroy">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:context="http://www.springframework.org/schema/context"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd"
+	default-init-method="myInit" default-destroy-method="myDestroy">
 
 	<context:component-scan base-package="org.springframework.context.annotation"
-      use-default-filters="false" annotation-config="false">
-    <context:include-filter type="assignable"
-        expression="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$DefaultsTestBean"/>
-    </context:component-scan>
+			use-default-filters="false" annotation-config="false">
+		<context:include-filter type="assignable"
+				expression="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$DefaultsTestBean"/>
+	</context:component-scan>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/defaultWithNoOverridesTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/defaultWithNoOverridesTests.xml
@@ -3,26 +3,26 @@
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xmlns:context="http://www.springframework.org/schema/context"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-				            http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
+							http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="org.springframework.context.annotation"
-            use-default-filters="false"
-            annotation-config="false">
-        <context:include-filter type="assignable"
-                expression="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$DefaultsTestBean"/>
-    </context:component-scan>
+			use-default-filters="false"
+			annotation-config="false">
+		<context:include-filter type="assignable"
+				expression="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$DefaultsTestBean"/>
+	</context:component-scan>
 
-    <bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$ConstructorDependencyTestBean">
-        <constructor-arg value="cd"/>
-    </bean>
+	<bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$ConstructorDependencyTestBean">
+		<constructor-arg value="cd"/>
+	</bean>
 
-    <bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
-        <constructor-arg value="pd1"/>
-    </bean>
+	<bean class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
+		<constructor-arg value="pd1"/>
+	</bean>
 
-    <bean id="propertyDependency2"
-          class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
-        <constructor-arg value="pd2"/>
-    </bean>
+	<bean id="propertyDependency2"
+		  class="org.springframework.context.annotation.ComponentScanParserBeanDefinitionDefaultsTests$PropertyDependencyTestBean">
+		<constructor-arg value="pd2"/>
+	</bean>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/invalidClassNameScopeResolverTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/invalidClassNameScopeResolverTests.xml
@@ -6,6 +6,6 @@
 				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="org.springframework.context.annotation"
-	    scope-resolver="not.a.valid.classname"/>
+		scope-resolver="not.a.valid.classname"/>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/invalidConstructorNameGeneratorTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/invalidConstructorNameGeneratorTests.xml
@@ -6,6 +6,6 @@
 				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="org.springframework.context.annotation"
-	    name-generator="org.springframework.context.annotation.InvalidConstructorBeanNameGenerator"/>
+		name-generator="org.springframework.context.annotation.InvalidConstructorBeanNameGenerator"/>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/matchingResourcePatternTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/matchingResourcePatternTests.xml
@@ -6,10 +6,10 @@
 				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="example."
-                            resource-pattern="**/scannable/*.class"
-                            use-default-filters="false"
-                            annotation-config="false">
-        <context:include-filter type="aspectj" expression="example.scannable.FooService+"/>
-    </context:component-scan>
+							resource-pattern="**/scannable/*.class"
+							use-default-filters="false"
+							annotation-config="false">
+		<context:include-filter type="aspectj" expression="example.scannable.FooService+"/>
+	</context:component-scan>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/annotation/nonMatchingResourcePatternTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/annotation/nonMatchingResourcePatternTests.xml
@@ -6,10 +6,10 @@
 				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd">
 
 	<context:component-scan base-package="org.springframework."
-                            resource-pattern="**/thispackagedoesnotexist/*.class"
-                            use-default-filters="false"
-                            annotation-config="false">
-        <context:include-filter type="aspectj" expression="example.scannable.FooService+"/>
-    </context:component-scan>
+							resource-pattern="**/thispackagedoesnotexist/*.class"
+							use-default-filters="false"
+							annotation-config="false">
+		<context:include-filter type="aspectj" expression="example.scannable.FooService+"/>
+	</context:component-scan>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/support/conversionService.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/conversionService.xml
@@ -8,11 +8,11 @@
 	<bean id="resourceTestBean" class="org.springframework.tests.sample.beans.ResourceTestBean">
 		<property name="resource" value="org/springframework/context/support/conversionService.xml"/>
 		<property name="resourceArray" value="org/springframework/context/support/conversionService.xml"/>
- 		<property name="resourceMap">
- 			<map>
- 				<entry key="key1" value="org/springframework/context/support/conversionService.xml"/>
- 			</map>
- 		</property>
+		<property name="resourceMap">
+			<map>
+				<entry key="key1" value="org/springframework/context/support/conversionService.xml"/>
+			</map>
+		</property>
 		<property name="resourceArrayMap">
 			<map>
 				<entry key="key1" value="org/springframework/context/support/conversionService.xml"/>

--- a/spring-context/src/test/resources/org/springframework/context/support/conversionServiceWithResourceOverriding.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/conversionServiceWithResourceOverriding.xml
@@ -12,11 +12,11 @@
 	<bean id="resourceTestBean" class="org.springframework.tests.sample.beans.ResourceTestBean">
 		<property name="resource" value="org/springframework/context/support/conversionService.xml"/>
 		<property name="resourceArray" value="org/springframework/context/support/conversionService.xml"/>
- 		<property name="resourceMap">
- 			<map>
- 				<entry key="key1" value="org/springframework/context/support/conversionService.xml"/>
- 			</map>
- 		</property>
+		<property name="resourceMap">
+			<map>
+				<entry key="key1" value="org/springframework/context/support/conversionService.xml"/>
+			</map>
+		</property>
 		<property name="resourceArrayMap">
 			<map>
 				<entry key="key1" value="org/springframework/context/support/conversionService.xml"/>

--- a/spring-context/src/test/resources/org/springframework/context/support/lifecycleTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/lifecycleTests.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans
-        https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
+		https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
-  <bean id="bean4" class="org.springframework.context.support.LifecycleTestBean" depends-on="bean2"/>
+	<bean id="bean4" class="org.springframework.context.support.LifecycleTestBean" depends-on="bean2"/>
 
-  <bean id="bean3" class="org.springframework.context.support.LifecycleTestBean" depends-on="bean2"/>
+	<bean id="bean3" class="org.springframework.context.support.LifecycleTestBean" depends-on="bean2"/>
 
-  <bean id="bean1" class="org.springframework.context.support.LifecycleTestBean"/>
+	<bean id="bean1" class="org.springframework.context.support.LifecycleTestBean"/>
 
-  <bean id="bean2" class="org.springframework.context.support.LifecycleTestBean" depends-on="bean1"/>
+	<bean id="bean2" class="org.springframework.context.support.LifecycleTestBean" depends-on="bean1"/>
 
-  <bean id="bean2Proxy" class="org.springframework.aop.framework.ProxyFactoryBean">
-    <property name="target" ref="bean2"/>
-  </bean>
+	<bean id="bean2Proxy" class="org.springframework.aop.framework.ProxyFactoryBean">
+		<property name="target" ref="bean2"/>
+	</bean>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/support/simpleThreadScopeTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/simpleThreadScopeTests.xml
@@ -19,7 +19,7 @@
 		default initial capacity.
 
 		For details see: https://github.com/spring-projects/spring-framework/issues/25801
-	 -->
+	-->
 	<bean id="removeNodeStatusScreen" class="org.springframework.beans.testfixture.beans.TestBean" scope="thread">
 		<property name="spouse" ref="removeNodeStatusPresenter" />
 	</bean>

--- a/spring-context/src/test/resources/org/springframework/context/support/smartLifecycleTests.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/smartLifecycleTests.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans
-        https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans
+		https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
-  <bean id="bean4" class="org.springframework.context.support.SmartLifecycleTestBean" depends-on="bean2"/>
+	<bean id="bean4" class="org.springframework.context.support.SmartLifecycleTestBean" depends-on="bean2"/>
 
-  <bean id="bean3" class="org.springframework.context.support.SmartLifecycleTestBean" depends-on="bean2"/>
+	<bean id="bean3" class="org.springframework.context.support.SmartLifecycleTestBean" depends-on="bean2"/>
 
-  <bean id="bean1" class="org.springframework.context.support.SmartLifecycleTestBean"/>
+	<bean id="bean1" class="org.springframework.context.support.SmartLifecycleTestBean"/>
 
-  <bean id="bean2" class="org.springframework.context.support.SmartLifecycleTestBean" depends-on="bean1"/>
+	<bean id="bean2" class="org.springframework.context.support.SmartLifecycleTestBean" depends-on="bean1"/>
 
-  <bean id="bean2Proxy" class="org.springframework.aop.framework.ProxyFactoryBean">
-    <property name="target" ref="bean2"/>
-  </bean>
+	<bean id="bean2Proxy" class="org.springframework.aop.framework.ProxyFactoryBean">
+		<property name="target" ref="bean2"/>
+	</bean>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/support/spr7283.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/spr7283.xml
@@ -8,7 +8,7 @@
 
 	<bean id="conversionService" class="org.springframework.context.support.ConversionServiceFactoryBean"/>
 
-    <util:list id="list">
+	<util:list id="list">
 		<bean class="org.springframework.context.support.Spr7283Tests$A"/>
 		<bean class="org.springframework.context.support.Spr7283Tests$B"/>
 	</util:list>

--- a/spring-context/src/test/resources/org/springframework/context/support/test/contextA.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/test/contextA.xml
@@ -38,7 +38,7 @@
 	</bean>
 
 	<bean name="wrappedAssemblerTwo" class="org.springframework.context.support.TestProxyFactoryBean">
-	    <property name="target" ref="assemblerTwo"/>
+		<property name="target" ref="assemblerTwo"/>
 	</bean>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/context/support/test/contextC.xml
+++ b/spring-context/src/test/resources/org/springframework/context/support/test/contextC.xml
@@ -7,7 +7,7 @@
 
 	<context:property-placeholder location="org/springframework/context/support/placeholder.properties"/>
 
-  <context:property-placeholder/>
+	<context:property-placeholder/>
 
 	<bean name="logicTwo" class="org.springframework.context.support.Logic">
 		<!--<property name="assembler"><ref bean="assemblerOne"/></property>-->

--- a/spring-context/src/test/resources/org/springframework/ejb/config/jeeNamespaceHandlerTests.xml
+++ b/spring-context/src/test/resources/org/springframework/ejb/config/jeeNamespaceHandlerTests.xml
@@ -64,7 +64,7 @@
 			resource-ref="true"
 			home-interface="org.springframework.beans.testfixture.beans.ITestBean"
 			refresh-home-on-connect-failure="true"
-      		cache-session-bean="true">
+			cache-session-bean="true">
 		<jee:environment>foo=bar</jee:environment>
 	</jee:remote-slsb>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/annotation/lazyAssembling.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/annotation/lazyAssembling.xml
@@ -7,9 +7,9 @@
 
 	<context:mbean-export server="server" registration="replaceExisting"/>
 
-    <context:property-placeholder/>
+	<context:property-placeholder/>
 
-    <bean id="server" class="org.springframework.jmx.support.MBeanServerFactoryBean"/>
+	<bean id="server" class="org.springframework.jmx.support.MBeanServerFactoryBean"/>
 
 	<bean name="testBean4" class="org.springframework.jmx.export.annotation.AnnotationTestBean" lazy-init="true">
 		<property name="name" value="TEST"/>

--- a/spring-context/src/test/resources/org/springframework/jmx/export/assembler/interfaceAssemblerMapped.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/assembler/interfaceAssemblerMapped.xml
@@ -16,9 +16,9 @@
 				<property name="interfaceMappings">
 					<props>
 						<prop key="bean:name=testBean4">
- 							org.springframework.jmx.export.assembler.IAdditionalTestMethods,
+							org.springframework.jmx.export.assembler.IAdditionalTestMethods,
 							org.springframework.jmx.export.assembler.ICustomJmxBean
- 						</prop>
+						</prop>
 					</props>
 				</property>
 				<property name="notificationInfos">

--- a/spring-context/src/test/resources/org/springframework/jmx/export/autodetectLazyMBeans.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/autodetectLazyMBeans.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/autodetectMBeans.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/autodetectMBeans.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/autodetectNoMBeans.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/autodetectNoMBeans.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/customConfigurer.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/customConfigurer.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/excludedBeans.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/excludedBeans.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
- <!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
+<!DOCTYPE beans PUBLIC "-//SPRING//DTD BEAN 2.0//EN" "https://www.springframework.org/dtd/spring-beans-2.0.dtd">
 
 <beans>
 

--- a/spring-context/src/test/resources/org/springframework/jmx/export/notificationPublisherLazyTests.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/notificationPublisherLazyTests.xml
@@ -11,7 +11,7 @@
 				<entry key="spring:type=Publisher" value="publisher"/>
 			</map>
 		</property>
-    <property name="server" ref="server"/>
-  </bean>
+		<property name="server" ref="server"/>
+	</bean>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/jmx/export/notificationPublisherTests.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/notificationPublisherTests.xml
@@ -17,7 +17,7 @@
 				<entry key="spring:type=PublisherStandardMBean" value-ref="publisherStandardMBean"/>
 			</map>
 		</property>
-    	<property name="server" ref="server"/>
+		<property name="server" ref="server"/>
 	</bean>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/jmx/export/propertyPlaceholderConfigurer.xml
+++ b/spring-context/src/test/resources/org/springframework/jmx/export/propertyPlaceholderConfigurer.xml
@@ -31,7 +31,7 @@
 				</entry>
 			</map>
 		</property>
-    <property name="server" ref="server"/>
+		<property name="server" ref="server"/>
 	</bean>
 
 	<bean id="testBean" class="org.springframework.jmx.JmxTestBean" scope="myScope">

--- a/spring-context/src/test/resources/org/springframework/scheduling/config/annotationDrivenContext.xml
+++ b/spring-context/src/test/resources/org/springframework/scheduling/config/annotationDrivenContext.xml
@@ -3,7 +3,7 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:task="http://www.springframework.org/schema/task"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   			https://www.springframework.org/schema/beans/spring-beans.xsd
+				https://www.springframework.org/schema/beans/spring-beans.xsd
 				http://www.springframework.org/schema/task
 				https://www.springframework.org/schema/task/spring-task.xsd">
 

--- a/spring-context/src/test/resources/org/springframework/scheduling/config/scheduledTasksContext.xml
+++ b/spring-context/src/test/resources/org/springframework/scheduling/config/scheduledTasksContext.xml
@@ -3,7 +3,7 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:task="http://www.springframework.org/schema/task"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   			https://www.springframework.org/schema/beans/spring-beans.xsd
+				https://www.springframework.org/schema/beans/spring-beans.xsd
 				http://www.springframework.org/schema/task
 				https://www.springframework.org/schema/task/spring-task.xsd">
 

--- a/spring-context/src/test/resources/org/springframework/scheduling/config/schedulerContext.xml
+++ b/spring-context/src/test/resources/org/springframework/scheduling/config/schedulerContext.xml
@@ -3,7 +3,7 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:task="http://www.springframework.org/schema/task"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans
-	   			https://www.springframework.org/schema/beans/spring-beans.xsd
+				https://www.springframework.org/schema/beans/spring-beans.xsd
 				http://www.springframework.org/schema/task
 				https://www.springframework.org/schema/task/spring-task.xsd">
 

--- a/spring-context/src/test/resources/org/springframework/scripting/bsh/bsh-with-xsd.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/bsh/bsh-with-xsd.xml
@@ -51,12 +51,12 @@
 		<lang:property name="message" value="Hello World!"/>
 	</lang:bsh>
 
-    <lang:bsh id="eventListener" script-interfaces="org.springframework.context.ApplicationListener,org.springframework.scripting.Messenger" >
-        <lang:inline-script><![CDATA[
-            int count;
-            void onApplicationEvent (org.springframework.context.ApplicationEvent event) { count++; System.out.println(event); }
-            String getMessage() { return "count=" + count; }
-        ]]></lang:inline-script>
-    </lang:bsh>
+	<lang:bsh id="eventListener" script-interfaces="org.springframework.context.ApplicationListener,org.springframework.scripting.Messenger" >
+		<lang:inline-script><![CDATA[
+			int count;
+			void onApplicationEvent (org.springframework.context.ApplicationEvent event) { count++; System.out.println(event); }
+			String getMessage() { return "count=" + count; }
+		]]></lang:inline-script>
+	</lang:bsh>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/scripting/bsh/bshContext.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/bsh/bshContext.xml
@@ -9,10 +9,10 @@
 		<constructor-arg>
 			<value>inline:
 int add(int x, int y) {
-  return x + y;
+	return x + y;
 }
 			</value>
- 		</constructor-arg>
+		</constructor-arg>
 		<constructor-arg value="org.springframework.scripting.Calculator"/>
 	</bean>
 
@@ -63,7 +63,7 @@ int add(int x, int y) {
 	</bean>
 
 	<bean id="messengerPrototype" class="org.springframework.scripting.bsh.BshScriptFactory" scope="prototype"
-			 init-method="init">
+		  init-method="init">
 		<constructor-arg value="classpath:org/springframework/scripting/bsh/MessengerImpl.bsh"/>
 		<property name="message" value="Hello World!"/>
 	</bean>

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/GroovyAspectIntegrationTests-groovy-dynamic-context.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/GroovyAspectIntegrationTests-groovy-dynamic-context.xml
@@ -7,13 +7,13 @@
 						http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd
 						http://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang-3.1.xsd">
 
-    <aop:config >
-       <aop:advisor id="logUserAdvisor" pointcut="@within(org.springframework.scripting.groovy.Log)" advice-ref="logUserAdvice"/>
-    </aop:config>
+	<aop:config >
+		<aop:advisor id="logUserAdvisor" pointcut="@within(org.springframework.scripting.groovy.Log)" advice-ref="logUserAdvice"/>
+	</aop:config>
 
-    <bean id="logUserAdvice" class="org.springframework.scripting.groovy.LogUserAdvice" />
+	<bean id="logUserAdvice" class="org.springframework.scripting.groovy.LogUserAdvice" />
 
-    <!-- N.B. the pointcut never matches if refresh-delay is set (because proxy-target-class is always false) -->
-    <lang:groovy id="groovyBean" script-source="classpath:/org/springframework/scripting/groovy/GroovyServiceImpl.grv" refresh-check-delay="1000"/>
+	<!-- N.B. the pointcut never matches if refresh-delay is set (because proxy-target-class is always false) -->
+	<lang:groovy id="groovyBean" script-source="classpath:/org/springframework/scripting/groovy/GroovyServiceImpl.grv" refresh-check-delay="1000"/>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/GroovyAspectIntegrationTests-groovy-interface-context.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/GroovyAspectIntegrationTests-groovy-interface-context.xml
@@ -7,12 +7,12 @@
 						http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd
 						http://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang-3.1.xsd">
 
-    <aop:config >
-       <aop:advisor id="logUserAdvisor" pointcut="@within(org.springframework.scripting.groovy.Log)" advice-ref="logUserAdvice"/>
-    </aop:config>
+	<aop:config >
+		<aop:advisor id="logUserAdvisor" pointcut="@within(org.springframework.scripting.groovy.Log)" advice-ref="logUserAdvice"/>
+	</aop:config>
 
-    <bean id="logUserAdvice" class="org.springframework.scripting.groovy.LogUserAdvice" />
+	<bean id="logUserAdvice" class="org.springframework.scripting.groovy.LogUserAdvice" />
 
-    <lang:groovy id="groovyBean" script-source="classpath:/org/springframework/scripting/groovy/GroovyServiceImpl.grv"/>
+	<lang:groovy id="groovyBean" script-source="classpath:/org/springframework/scripting/groovy/GroovyServiceImpl.grv"/>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/GroovyAspectIntegrationTests-groovy-proxy-target-class-context.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/GroovyAspectIntegrationTests-groovy-proxy-target-class-context.xml
@@ -7,12 +7,12 @@
 						http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd
 						http://www.springframework.org/schema/lang https://www.springframework.org/schema/lang/spring-lang-3.1.xsd">
 
-    <aop:config >
-       <aop:advisor id="logUserAdvisor" pointcut="@within(org.springframework.scripting.groovy.Log)" advice-ref="logUserAdvice"/>
-    </aop:config>
+	<aop:config >
+		<aop:advisor id="logUserAdvisor" pointcut="@within(org.springframework.scripting.groovy.Log)" advice-ref="logUserAdvice"/>
+	</aop:config>
 
-    <bean id="logUserAdvice" class="org.springframework.scripting.groovy.LogUserAdvice" />
+	<bean id="logUserAdvice" class="org.springframework.scripting.groovy.LogUserAdvice" />
 
-    <lang:groovy id="groovyBean" script-source="classpath:/org/springframework/scripting/groovy/GroovyServiceImpl.grv" refresh-check-delay="1000" proxy-target-class="true"/>
+	<lang:groovy id="groovyBean" script-source="classpath:/org/springframework/scripting/groovy/GroovyServiceImpl.grv" refresh-check-delay="1000" proxy-target-class="true"/>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/GroovyAspectIntegrationTests-java-context.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/GroovyAspectIntegrationTests-java-context.xml
@@ -5,12 +5,12 @@
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
 						http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd">
 
-    <aop:config >
-       <aop:advisor id="logUserAdvisor" pointcut="@within(org.springframework.scripting.groovy.Log)" advice-ref="logUserAdvice"/>
-    </aop:config>
+	<aop:config >
+		<aop:advisor id="logUserAdvisor" pointcut="@within(org.springframework.scripting.groovy.Log)" advice-ref="logUserAdvice"/>
+	</aop:config>
 
-    <bean id="logUserAdvice" class="org.springframework.scripting.groovy.LogUserAdvice" />
+	<bean id="logUserAdvice" class="org.springframework.scripting.groovy.LogUserAdvice" />
 
-    <bean id="javaBean" class="org.springframework.scripting.groovy.TestServiceImpl"/>
+	<bean id="javaBean" class="org.springframework.scripting.groovy.TestServiceImpl"/>
 
 </beans>

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/groovy-with-xsd.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/groovy-with-xsd.xml
@@ -30,7 +30,7 @@
 import org.springframework.scripting.Calculator
 class GroovyCalculator implements Calculator {
 	int add(int x, int y) {
-	   return x + y;
+		return x + y;
 	}
 }
 		</lang:inline-script>

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/groovyContext.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/groovyContext.xml
@@ -6,7 +6,7 @@
 				https://www.springframework.org/schema/beans/spring-beans.xsd
 				http://www.springframework.org/schema/lang
 				https://www.springframework.org/schema/lang/spring-lang.xsd"
- 		default-lazy-init="true">
+		default-lazy-init="true">
 
 	<bean class="org.springframework.scripting.support.ScriptFactoryPostProcessor"/>
 
@@ -17,7 +17,7 @@ package org.springframework.scripting.groovy;
 import org.springframework.scripting.Calculator
 class GroovyCalculator implements Calculator {
 	int add(int x, int y) {
-	   return x + y;
+		return x + y;
 	}
 }
 			</value>
@@ -40,19 +40,19 @@ class GroovyCalculator implements Calculator {
 		<property name="message" ref="myMessage"/>
 	</bean>
 
-  <bean id="messengerInstanceInline" class="org.springframework.scripting.groovy.GroovyScriptFactory">
-	  <constructor-arg>
-      <value>inline:
+	<bean id="messengerInstanceInline" class="org.springframework.scripting.groovy.GroovyScriptFactory">
+		<constructor-arg>
+			<value>inline:
 package org.springframework.scripting.groovy;
 import org.springframework.scripting.Messenger
 class GroovyMessenger implements Messenger {
-  def String message;
+	def String message;
 }
 return new GroovyMessenger();
-      </value>
-    </constructor-arg>
-    <property name="message" ref="myMessage"/>
-  </bean>
+			</value>
+		</constructor-arg>
+		<property name="message" ref="myMessage"/>
+	</bean>
 
 	<bean id="myMessage" class="java.lang.String">
 		<constructor-arg value="Hello World!"/>

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/groovyContextWithJsr223.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/groovyContextWithJsr223.xml
@@ -4,7 +4,7 @@
 		xmlns:lang="http://www.springframework.org/schema/lang"
 		xsi:schemaLocation="http://www.springframework.org/schema/beans
 				https://www.springframework.org/schema/beans/spring-beans.xsd"
- 		default-lazy-init="true">
+		default-lazy-init="true">
 
 	<bean class="org.springframework.scripting.support.ScriptFactoryPostProcessor"/>
 
@@ -16,7 +16,7 @@ package org.springframework.scripting.groovy;
 import org.springframework.scripting.Calculator
 class GroovyCalculator implements Calculator {
 	int add(int x, int y) {
-	   return x + y;
+		return x + y;
 	}
 }
 			</value>
@@ -39,20 +39,20 @@ class GroovyCalculator implements Calculator {
 		<property name="message" ref="myMessage"/>
 	</bean>
 
-  <bean id="messengerInstanceInline" class="org.springframework.scripting.support.StandardScriptFactory">
-	  <constructor-arg value="Groovy"/>
-	  <constructor-arg>
-      <value>inline:
+	<bean id="messengerInstanceInline" class="org.springframework.scripting.support.StandardScriptFactory">
+		<constructor-arg value="Groovy"/>
+		<constructor-arg>
+			<value>inline:
 package org.springframework.scripting.groovy;
 import org.springframework.scripting.Messenger
 class GroovyMessenger implements Messenger {
-  def String message;
+	def String message;
 }
 return new GroovyMessenger();
-      </value>
-    </constructor-arg>
-    <property name="message" ref="myMessage"/>
-  </bean>
+			</value>
+		</constructor-arg>
+		<property name="message" ref="myMessage"/>
+	</bean>
 
 	<bean id="myMessage" class="java.lang.String">
 		<constructor-arg value="Hello World!"/>

--- a/spring-context/src/test/resources/org/springframework/scripting/groovy/lwspBadGroovyContext.xml
+++ b/spring-context/src/test/resources/org/springframework/scripting/groovy/lwspBadGroovyContext.xml
@@ -8,7 +8,7 @@
 		<constructor-arg>
 			<!-- 'inline:' prefix is preceded by whitespace... -->
 			<value>
-    inline:
+	inline:
 			
 	class Bingo {
 

--- a/spring-core/src/test/resources/org/springframework/util/xml/testLexicalHandler.xml
+++ b/spring-core/src/test/resources/org/springframework/util/xml/testLexicalHandler.xml
@@ -3,6 +3,6 @@
 		[<!ENTITY entity "entity">]>
 <!--Comment-->
 <element>
-    <cdata><![CDATA[cdata]]></cdata>
-    <entity>&entity;</entity>
+	<cdata><![CDATA[cdata]]></cdata>
+	<entity>&entity;</entity>
 </element>

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config-nonexistent.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config-nonexistent.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config-pattern.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-config-pattern.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-destroy-config.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-destroy-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd">

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-destroy-nested-config-h2.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-destroy-nested-config-h2.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd">

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-destroy-nested-config.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-destroy-nested-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd">

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-cache-config.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-cache-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-config.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-endings-config.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-endings-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd">

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-endings-nested-config.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-endings-nested-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.1.xsd">

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-fail-config.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-fail-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-pattern-config.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/config/jdbc-initialize-pattern-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/object/GenericSqlQueryTests-context.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/object/GenericSqlQueryTests-context.xml
@@ -25,7 +25,7 @@
 				</bean>
 			</list>
 		</property>
-    <property name="rowMapperClass" value="org.springframework.jdbc.object.CustomerMapper"/>
+		<property name="rowMapperClass" value="org.springframework.jdbc.object.CustomerMapper"/>
 	</bean>
 
 	<bean id="queryWithNamedParameters" class="org.springframework.jdbc.object.GenericSqlQuery">
@@ -47,7 +47,7 @@
 				</bean>
 			</list>
 		</property>
-        <property name="rowMapperClass" value="org.springframework.jdbc.object.CustomerMapper"/>
+		<property name="rowMapperClass" value="org.springframework.jdbc.object.CustomerMapper"/>
 	</bean>
 
 	<bean id="queryWithRowMapperBean" class="org.springframework.jdbc.object.GenericSqlQuery">

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/support/custom-error-codes.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/support/custom-error-codes.xml
@@ -6,19 +6,19 @@
 	<!--
 		Whacky error codes for testing
 		-->
-  <bean id="Oracle" class="org.springframework.jdbc.support.SQLErrorCodes">
-    <property name="badSqlGrammarCodes"><value>1,2</value></property>
-    <property name="dataIntegrityViolationCodes"><value>1,1400,1722</value></property>
-    <property name="customTranslations">
-      <list>
-        <bean class="org.springframework.jdbc.support.CustomSQLErrorCodesTranslation">
-          <property name="errorCodes"><value>999</value></property>
-          <property name="exceptionClass">
-            <value>org.springframework.jdbc.support.CustomErrorCodeException</value>
-          </property>
-        </bean>
-      </list>
-    </property>
-  </bean>
+	<bean id="Oracle" class="org.springframework.jdbc.support.SQLErrorCodes">
+		<property name="badSqlGrammarCodes"><value>1,2</value></property>
+		<property name="dataIntegrityViolationCodes"><value>1,1400,1722</value></property>
+		<property name="customTranslations">
+			<list>
+				<bean class="org.springframework.jdbc.support.CustomSQLErrorCodesTranslation">
+					<property name="errorCodes"><value>999</value></property>
+					<property name="exceptionClass">
+						<value>org.springframework.jdbc.support.CustomErrorCodeException</value>
+					</property>
+				</bean>
+			</list>
+		</property>
+	</bean>
 
 </beans>

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/support/test-custom-translators-context.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/support/test-custom-translators-context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:jdbc="http://www.springframework.org/schema/jdbc"
+	xmlns:jdbc="http://www.springframework.org/schema/jdbc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/jdbc https://www.springframework.org/schema/jdbc/spring-jdbc-3.0.xsd">

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/support/test-error-codes.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/support/test-error-codes.xml
@@ -5,10 +5,10 @@
 
 	<!--
 		Whacky error codes for testing
-		-->
-  <bean id="Oracle" class="org.springframework.jdbc.support.SQLErrorCodes">
-    <property name="badSqlGrammarCodes"><value>1,2</value></property>
-    <property name="dataIntegrityViolationCodes"><value>1,1400,1722</value></property>
-  </bean>
+	-->
+	<bean id="Oracle" class="org.springframework.jdbc.support.SQLErrorCodes">
+		<property name="badSqlGrammarCodes"><value>1,2</value></property>
+		<property name="dataIntegrityViolationCodes"><value>1,1400,1722</value></property>
+	</bean>
 
 </beans>

--- a/spring-jdbc/src/test/resources/org/springframework/jdbc/support/wildcard-error-codes.xml
+++ b/spring-jdbc/src/test/resources/org/springframework/jdbc/support/wildcard-error-codes.xml
@@ -6,33 +6,33 @@
 	<!--
 		Whacky error codes for testing
 		-->
-  <bean id="Oracle" class="org.springframework.jdbc.support.SQLErrorCodes">
-    <property name="badSqlGrammarCodes"><value>1,2,942</value></property>
-    <property name="dataIntegrityViolationCodes"><value>1,1400,1722</value></property>
-  </bean>
+	<bean id="Oracle" class="org.springframework.jdbc.support.SQLErrorCodes">
+		<property name="badSqlGrammarCodes"><value>1,2,942</value></property>
+		<property name="dataIntegrityViolationCodes"><value>1,1400,1722</value></property>
+	</bean>
 
-  <bean id="DB0" class="org.springframework.jdbc.support.SQLErrorCodes">
-    <property name="databaseProductName"><value>*DB0</value></property>
-    <property name="badSqlGrammarCodes"><value>-204,1,2</value></property>
-    <property name="dataIntegrityViolationCodes"><value>3,4</value></property>
-  </bean>
+	<bean id="DB0" class="org.springframework.jdbc.support.SQLErrorCodes">
+		<property name="databaseProductName"><value>*DB0</value></property>
+		<property name="badSqlGrammarCodes"><value>-204,1,2</value></property>
+		<property name="dataIntegrityViolationCodes"><value>3,4</value></property>
+	</bean>
 
-  <bean id="DB1" class="org.springframework.jdbc.support.SQLErrorCodes">
-    <property name="databaseProductName"><value>DB1*</value></property>
-    <property name="badSqlGrammarCodes"><value>-204,1,2</value></property>
-    <property name="dataIntegrityViolationCodes"><value>3,4</value></property>
-  </bean>
+	<bean id="DB1" class="org.springframework.jdbc.support.SQLErrorCodes">
+		<property name="databaseProductName"><value>DB1*</value></property>
+		<property name="badSqlGrammarCodes"><value>-204,1,2</value></property>
+		<property name="dataIntegrityViolationCodes"><value>3,4</value></property>
+	</bean>
 
-  <bean id="DB2" class="org.springframework.jdbc.support.SQLErrorCodes">
+	<bean id="DB2" class="org.springframework.jdbc.support.SQLErrorCodes">
 		<property name="databaseProductName"><value>*DB2*</value></property>
-    <property name="badSqlGrammarCodes"><value>-204,1,2</value></property>
-    <property name="dataIntegrityViolationCodes"><value>3,4</value></property>
-  </bean>
+		<property name="badSqlGrammarCodes"><value>-204,1,2</value></property>
+		<property name="dataIntegrityViolationCodes"><value>3,4</value></property>
+	</bean>
 
-  <bean id="DB3" class="org.springframework.jdbc.support.SQLErrorCodes">
-    <property name="databaseProductName"><value>*DB3*</value></property>
-    <property name="badSqlGrammarCodes"><value>-204,1,2</value></property>
-    <property name="dataIntegrityViolationCodes"><value>3,4</value></property>
-  </bean>
+	<bean id="DB3" class="org.springframework.jdbc.support.SQLErrorCodes">
+		<property name="databaseProductName"><value>*DB3*</value></property>
+		<property name="badSqlGrammarCodes"><value>-204,1,2</value></property>
+		<property name="dataIntegrityViolationCodes"><value>3,4</value></property>
+	</bean>
 
 </beans>

--- a/spring-jms/src/main/resources/org/springframework/jms/config/spring-jms.xsd
+++ b/spring-jms/src/main/resources/org/springframework/jms/config/spring-jms.xsd
@@ -337,11 +337,11 @@
 			<xsd:attribute name="back-off" type="xsd:string">
 				<xsd:annotation>
 					<xsd:documentation><![CDATA[
-	 Specify the BackOff instance to use to compute the interval between recovery
-	 attempts. If the BackOff implementation returns "BackOffExecution#STOP", the listener
-	 container will not further attempt to recover. The recovery-interval value is
-	 ignored when this property is set. The default is a FixedBackOff with an
-	 interval of 5000 ms, that is 5 seconds.
+	Specify the BackOff instance to use to compute the interval between recovery
+	attempts. If the BackOff implementation returns "BackOffExecution#STOP", the listener
+	container will not further attempt to recover. The recovery-interval value is
+	ignored when this property is set. The default is a FixedBackOff with an
+	interval of 5000 ms, that is 5 seconds.
 					]]></xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/META-INF/persistence.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/META-INF/persistence.xml
@@ -1,8 +1,8 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence" version="1.0">
 
-    <persistence-unit name="OrderManagement">
-        <jar-file>order.jar</jar-file>
-        <jar-file>../../../order-supplemental.jar</jar-file>
-    </persistence-unit>
+	<persistence-unit name="OrderManagement">
+		<jar-file>order.jar</jar-file>
+		<jar-file>../../../order-supplemental.jar</jar-file>
+	</persistence-unit>
 
 </persistence>

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-example1.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-example1.xml
@@ -1,7 +1,7 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence
-          https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+			https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
 	version="1.0">
 
 	<persistence-unit name="OrderManagement" />

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-exclude-1.0.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-exclude-1.0.xml
@@ -1,7 +1,7 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xsi:schemaLocation="http://java.sun.com/xml/ns/persistence
-          https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+				https://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
 			 version="1.0">
 
 	<persistence-unit name="NoExcludeElement" />

--- a/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-exclude-2.0.xml
+++ b/spring-orm/src/test/resources/org/springframework/orm/jpa/persistence-exclude-2.0.xml
@@ -1,7 +1,7 @@
 <persistence xmlns="http://java.sun.com/xml/ns/persistence"
 			 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 			 xsi:schemaLocation="http://java.sun.com/xml/ns/persistence
-          https://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+				https://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
 			 version="2.0">
 
 	<persistence-unit name="NoExcludeElement" />

--- a/spring-oxm/src/test/resources/org/springframework/oxm/config/oxmNamespaceHandlerTest.xml
+++ b/spring-oxm/src/test/resources/org/springframework/oxm/config/oxmNamespaceHandlerTest.xml
@@ -2,7 +2,7 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:oxm="http://www.springframework.org/schema/oxm"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/oxm https://www.springframework.org/schema/oxm/spring-oxm.xsd">
+		http://www.springframework.org/schema/oxm https://www.springframework.org/schema/oxm/spring-oxm.xsd">
 
 	<!-- JAXB2 -->
 	<oxm:jaxb2-marshaller id="jaxb2ContextPathMarshaller" context-path="org.springframework.oxm.jaxb.test"/>

--- a/spring-oxm/src/test/resources/org/springframework/oxm/jaxb/jaxb2.xml
+++ b/spring-oxm/src/test/resources/org/springframework/oxm/jaxb/jaxb2.xml
@@ -1,5 +1,5 @@
 <tns:flights xmlns:tns="http://samples.springframework.org/flight">
-    <tns:flight>
-        <tns:number>42</tns:number>
-    </tns:flight>
+	<tns:flight>
+		<tns:number>42</tns:number>
+	</tns:flight>
 </tns:flights>

--- a/spring-oxm/src/test/resources/org/springframework/oxm/jibx/binding.xml
+++ b/spring-oxm/src/test/resources/org/springframework/oxm/jibx/binding.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <binding>
-    <mapping name="flights" class="org.springframework.oxm.jibx.Flights">
-        <namespace uri="http://samples.springframework.org/flight" default="elements"/>
-        <collection field="flightList">
-            <structure map-as="org.springframework.oxm.jibx.FlightType"/>
-        </collection>
-    </mapping>
-    <mapping name="flight" class="org.springframework.oxm.jibx.FlightType">
-        <namespace uri="http://samples.springframework.org/flight" default="elements"/>
-        <value name="airline" field="airline" usage="optional"/>
-        <value name="number" field="number" usage="required"/>
-    </mapping>
+	<mapping name="flights" class="org.springframework.oxm.jibx.Flights">
+		<namespace uri="http://samples.springframework.org/flight" default="elements"/>
+		<collection field="flightList">
+			<structure map-as="org.springframework.oxm.jibx.FlightType"/>
+		</collection>
+	</mapping>
+	<mapping name="flight" class="org.springframework.oxm.jibx.FlightType">
+		<namespace uri="http://samples.springframework.org/flight" default="elements"/>
+		<value name="airline" field="airline" usage="optional"/>
+		<value name="number" field="number" usage="required"/>
+	</mapping>
 </binding>

--- a/spring-oxm/src/test/schema/flight.xsd
+++ b/spring-oxm/src/test/schema/flight.xsd
@@ -16,21 +16,21 @@
   -->
 
 <schema xmlns="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
-        targetNamespace="http://samples.springframework.org/flight"
-        xmlns:tns="http://samples.springframework.org/flight">
-    <element name="flights">
-        <complexType>
-            <sequence>
-                <element name="flight" type="tns:flightType"
-                         maxOccurs="unbounded">
-                </element>
-            </sequence>
-        </complexType>
-    </element>
-    <element name="flight" type="tns:flightType"/>
-    <complexType name="flightType">
-        <sequence>
-            <element name="number" type="long"/>
-        </sequence>
-    </complexType>
+		targetNamespace="http://samples.springframework.org/flight"
+		xmlns:tns="http://samples.springframework.org/flight">
+	<element name="flights">
+		<complexType>
+			<sequence>
+				<element name="flight" type="tns:flightType"
+						 maxOccurs="unbounded">
+				</element>
+			</sequence>
+		</complexType>
+	</element>
+	<element name="flight" type="tns:flightType"/>
+	<complexType name="flightType">
+		<sequence>
+			<element name="number" type="long"/>
+		</sequence>
+	</complexType>
 </schema>

--- a/spring-test/src/test/resources/org/springframework/test/web/servlet/samples/context/root-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/web/servlet/samples/context/root-context.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="
 		http://www.springframework.org/schema/beans
 		https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 

--- a/spring-test/src/test/resources/org/springframework/test/web/servlet/samples/context/servlet-context.xml
+++ b/spring-test/src/test/resources/org/springframework/test/web/servlet/samples/context/servlet-context.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mvc="http://www.springframework.org/schema/mvc"
-    xsi:schemaLocation="
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xsi:schemaLocation="
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-3.1.xsd
 		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-3.1.xsd">
 
-    <mvc:annotation-driven/>
+	<mvc:annotation-driven/>
 
-    <bean class="org.springframework.test.web.servlet.samples.context.PersonController">
-        <constructor-arg ref="personDao"/>
-    </bean>
+	<bean class="org.springframework.test.web.servlet.samples.context.PersonController">
+		<constructor-arg ref="personDao"/>
+	</bean>
 
-    <mvc:view-controller path="/" view-name="home"/>
+	<mvc:view-controller path="/" view-name="home"/>
 
-    <mvc:resources mapping="/resources/**" location="/resources/"/>
+	<mvc:resources mapping="/resources/**" location="/resources/"/>
 
-    <mvc:default-servlet-handler/>
+	<mvc:default-servlet-handler/>
 
 </beans>

--- a/spring-tx/src/test/resources/org/springframework/transaction/annotation/annotationTransactionNamespaceHandlerTests.xml
+++ b/spring-tx/src/test/resources/org/springframework/transaction/annotation/annotationTransactionNamespaceHandlerTests.xml
@@ -4,8 +4,8 @@
 	   xmlns:context="http://www.springframework.org/schema/context"
 	   xmlns:tx="http://www.springframework.org/schema/tx"
 	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-4.0.xsd
-       http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-4.0.xsd
-       http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
+	   http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-4.0.xsd
+	   http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx-4.0.xsd">
 
 	<tx:annotation-driven order="#{ T(java.lang.Integer).MAX_VALUE }"/>
 

--- a/spring-tx/src/test/resources/org/springframework/transaction/config/annotationDrivenConfigurationClassTests.xml
+++ b/spring-tx/src/test/resources/org/springframework/transaction/config/annotationDrivenConfigurationClassTests.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:aop="http://www.springframework.org/schema/aop"
+	   xmlns:aop="http://www.springframework.org/schema/aop"
 	   xmlns:context="http://www.springframework.org/schema/context"
-       xmlns:tx="http://www.springframework.org/schema/tx"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
-       		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd
-       		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd
-       		http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx-2.5.xsd">
+	   xmlns:tx="http://www.springframework.org/schema/tx"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd
+				http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd
+				http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-2.5.xsd
+				http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx-2.5.xsd">
 
 	<context:annotation-config/>
 

--- a/spring-tx/src/test/resources/org/springframework/transaction/config/annotationDrivenProxyTargetClassTests.xml
+++ b/spring-tx/src/test/resources/org/springframework/transaction/config/annotationDrivenProxyTargetClassTests.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns:aop="http://www.springframework.org/schema/aop"
-       xmlns:tx="http://www.springframework.org/schema/tx"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx-2.5.xsd">
+	   xmlns:aop="http://www.springframework.org/schema/aop"
+	   xmlns:tx="http://www.springframework.org/schema/tx"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.5.xsd http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.5.xsd http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx-2.5.xsd">
 
 	<tx:annotation-driven proxy-target-class="true" order="0"/>
 

--- a/spring-web/src/test/resources/org/springframework/http/converter/feed/atom.xml
+++ b/spring-web/src/test/resources/org/springframework/http/converter/feed/atom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-    <title>title</title>
-    <subtitle>subtitle</subtitle>
-    <entry>
-        <id>id1</id>
-        <title>title1</title>
-    </entry>
-    <entry>
-        <id>id2</id>
-        <title>title2</title>
-    </entry>
+	<title>title</title>
+	<subtitle>subtitle</subtitle>
+	<entry>
+		<id>id1</id>
+		<title>title1</title>
+	</entry>
+	<entry>
+		<id>id2</id>
+		<title>title2</title>
+	</entry>
 </feed>

--- a/spring-web/src/test/resources/org/springframework/http/converter/feed/rss.xml
+++ b/spring-web/src/test/resources/org/springframework/http/converter/feed/rss.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <rss version="2.0">
-    <channel>
-        <title>title</title>
-        <link>https://example.com</link>
-        <description>description</description>
-        <item>
-            <title>title1</title>
-        </item>
-        <item>
-            <title>title2</title>
-        </item>
-    </channel>
- </rss>
+	<channel>
+		<title>title</title>
+		<link>https://example.com</link>
+		<description>description</description>
+		<item>
+			<title>title1</title>
+		</item>
+		<item>
+			<title>title2</title>
+		</item>
+	</channel>
+</rss>

--- a/spring-web/src/test/resources/org/springframework/web/context/request/requestScopeTests.xml
+++ b/spring-web/src/test/resources/org/springframework/web/context/request/requestScopeTests.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd">
 
 	<bean id="requestScopedObject" class="org.springframework.beans.testfixture.beans.TestBean" scope="request">
-        <property name="name" value="#{request.contextPath}"/>
+		<property name="name" value="#{request.contextPath}"/>
 	</bean>
 
 	<bean id="requestScopedDisposableObject" class="org.springframework.beans.testfixture.beans.DerivedTestBean" scope="request"/>

--- a/spring-webmvc/src/main/resources/org/springframework/web/servlet/config/spring-mvc.xsd
+++ b/spring-webmvc/src/main/resources/org/springframework/web/servlet/config/spring-mvc.xsd
@@ -482,8 +482,8 @@
 		<xsd:attribute name="cache-name" type="xsd:string" use="optional">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
-    The cache name to use in the configured cache manager.
-    Will use "spring-resource-chain-cache" by default.
+	The cache name to use in the configured cache manager.
+	Will use "spring-resource-chain-cache" by default.
 					]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>

--- a/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/web.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/context/WEB-INF/web.xml
@@ -15,8 +15,8 @@
 
 
 	<!-- This servlet must be loaded first to configure the log4j
-	 system and create the WebApplicationContext
-	 -->
+		 system and create the WebApplicationContext
+	-->
 	<servlet>
 		<servlet-name>config</servlet-name>
 		<servlet-class>org.springframework.framework.web.context.ContextLoaderServlet</servlet-class>
@@ -30,93 +30,93 @@
 		</init-param>
 		<!-- This is essential -->
 		<load-on-startup>1</load-on-startup>
-	  </servlet>
+	</servlet>
  
  
-  <servlet>
-      	<servlet-name>boxOffice</servlet-name>
-      	<servlet-class>org.springframework.framework.web.workflow.CommandServlet</servlet-class>
-  </servlet> 
+	<servlet>
+		<servlet-name>boxOffice</servlet-name>
+		<servlet-class>org.springframework.framework.web.workflow.CommandServlet</servlet-class>
+	</servlet> 
  
  
  
  
-  <servlet-mapping>
-        	<servlet-name>boxOffice</servlet-name>
-        	<url-pattern>/*.html</url-pattern>
-  </servlet-mapping>
+	<servlet-mapping>
+		<servlet-name>boxOffice</servlet-name>
+		<url-pattern>/*.html</url-pattern>
+	</servlet-mapping>
  
-  <servlet-mapping>
-          	<servlet-name>config</servlet-name>
-          	<url-pattern>/context/context.html</url-pattern>
-  </servlet-mapping>
+	<servlet-mapping>
+		<servlet-name>config</servlet-name>
+		<url-pattern>/context/context.html</url-pattern>
+	</servlet-mapping>
  
 
-<session-config>
-<session-timeout>60</session-timeout>
-</session-config>
+	<session-config>
+		<session-timeout>60</session-timeout>
+	</session-config>
 
-<welcome-file-list>
-	<!-- Simply doesn't work to a servlet -->
-	<welcome-file>/welcome.jsp</welcome-file>
-</welcome-file-list>
+	<welcome-file-list>
+		<!-- Simply doesn't work to a servlet -->
+		<welcome-file>/welcome.jsp</welcome-file>
+	</welcome-file-list>
 
-<error-page>
-     <error-code>403</error-code>
-     <location>/jsp/layout/twocolumn/403-Forbidden.jsp</location>
-  </error-page>
+	<error-page>
+		<error-code>403</error-code>
+		<location>/jsp/layout/twocolumn/403-Forbidden.jsp</location>
+	</error-page>
  
-    <error-page>
-       <error-code>404</error-code>
-       <location>/jsp/layout/twocolumn/404-NotFound.jsp</location>
-  </error-page>
+	<error-page>
+		<error-code>404</error-code>
+		<location>/jsp/layout/twocolumn/404-NotFound.jsp</location>
+	</error-page>
  
-  <error-page>
-         <exception-type>java.lang.Throwable</exception-type>
-         <location>/jsp/layout/twocolumn/uncaughtException.jsp</location>
-  </error-page>
+	<error-page>
+		<exception-type>java.lang.Throwable</exception-type>
+		<location>/jsp/layout/twocolumn/uncaughtException.jsp</location>
+	</error-page>
  
- <taglib>
- 	      	<taglib-uri>/bind</taglib-uri>
- 	      	<taglib-location>/WEB-INF/tlds/b11.tld</taglib-location>
-   </taglib>
+	<taglib>
+		<taglib-uri>/bind</taglib-uri>
+		<taglib-location>/WEB-INF/tlds/b11.tld</taglib-location>
+	</taglib>
   
-   <taglib>
-   	      	<taglib-uri>/events</taglib-uri>
-   	      	<taglib-location>/WEB-INF/tlds/event11.tld</taglib-location>
-  </taglib>
+	<taglib>
+		<taglib-uri>/events</taglib-uri>
+		<taglib-location>/WEB-INF/tlds/event11.tld</taglib-location>
+	</taglib>
  
-  <security-constraint>
-  	<web-resource-collection>
-  	<web-resource-name>SalesInfo
-  	</web-resource-name>
-  	<url-pattern>purchase.html</url-pattern>
-  	<http-method>GET</http-method>
-  	<http-method>POST</http-method>
-  	</web-resource-collection>
-  	<auth-constraint>
-  	<role-name>registeredUsers</role-name>
-  	</auth-constraint>
-  	<user-data-constraint>  	
-  	<transport-guarantee>NONE</transport-guarantee>
-  	</user-data-constraint>
-</security-constraint>
+	<security-constraint>
+		<web-resource-collection>
+		<web-resource-name>SalesInfo
+		</web-resource-name>
+		<url-pattern>purchase.html</url-pattern>
+		<http-method>GET</http-method>
+		<http-method>POST</http-method>
+		</web-resource-collection>
+		<auth-constraint>
+			<role-name>registeredUsers</role-name>
+		</auth-constraint>
+		<user-data-constraint>
+			<transport-guarantee>NONE</transport-guarantee>
+		</user-data-constraint>
+	</security-constraint>
 
 
- 	<login-config>
- 		<auth-method>FORM</auth-method>
+	<login-config>
+		<auth-method>FORM</auth-method>
  	
- 		<!-- Used only for BASIC authentication: only included because ServletUnit needs it -->
- 		<realm-name>ticket</realm-name>
+		<!-- Used only for BASIC authentication: only included because ServletUnit needs it -->
+		<realm-name>ticket</realm-name>
  	
- 		<form-login-config>
- 			<form-login-page>login.jsp</form-login-page>
- 			<form-error-page>loginError.jsp</form-error-page>
- 		</form-login-config>
- 	</login-config>
+		<form-login-config>
+			<form-login-page>login.jsp</form-login-page>
+			<form-error-page>loginError.jsp</form-error-page>
+		</form-login-config>
+	</login-config>
  
  
- 	<security-role>
+	<security-role>
 		<role-name>registeredUsers</role-name>
 	</security-role>
 

--- a/spring-webmvc/src/test/resources/org/springframework/web/context/beans1.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/context/beans1.xml
@@ -4,13 +4,13 @@
 
 <beans>
 
-  <bean id="beans1.bean1" class="org.springframework.beans.factory.access.TestBean">
-    <property name="name"><value>beans1.bean1</value></property>
-  </bean>
+	<bean id="beans1.bean1" class="org.springframework.beans.factory.access.TestBean">
+		<property name="name"><value>beans1.bean1</value></property>
+	</bean>
 
-  <bean id="beans1.bean2" class="org.springframework.beans.factory.access.TestBean">
-    <property name="name"><value>bean2</value></property>
-    <property name="objRef"><ref bean="beans1.bean2"/></property>
-  </bean>
+	<bean id="beans1.bean2" class="org.springframework.beans.factory.access.TestBean">
+		<property name="name"><value>bean2</value></property>
+		<property name="objRef"><ref bean="beans1.bean2"/></property>
+	</bean>
 
 </beans>

--- a/spring-webmvc/src/test/resources/org/springframework/web/context/ref1.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/context/ref1.xml
@@ -8,20 +8,20 @@
 
 <beans>
 
-  <!-- this definition could be inside one beanRefFactory.xml file -->
-  <bean id="a.qualified.name.of.some.sort"
-      class="org.springframework.context.support.ClassPathXmlApplicationContext">
-    <property name="configLocation" value="org/springframework/web/context/beans1.xml"/>
-  </bean>
+	<!-- this definition could be inside one beanRefFactory.xml file -->
+	<bean id="a.qualified.name.of.some.sort"
+			class="org.springframework.context.support.ClassPathXmlApplicationContext">
+		<property name="configLocation" value="org/springframework/web/context/beans1.xml"/>
+	</bean>
 
-  <!-- while the following two could be inside another, also on the classpath,
+	<!-- while the following two could be inside another, also on the classpath,
 	perhaps coming from another component jar -->
-  <bean id="another.qualified.name"
-      class="org.springframework.context.support.ClassPathXmlApplicationContext">
-    <property name="configLocation" value="org/springframework/web/context/beans1.xml"/>
-    <property name="parent" ref="a.qualified.name.of.some.sort"/>
-  </bean>
+	<bean id="another.qualified.name"
+			class="org.springframework.context.support.ClassPathXmlApplicationContext">
+		<property name="configLocation" value="org/springframework/web/context/beans1.xml"/>
+		<property name="parent" ref="a.qualified.name.of.some.sort"/>
+	</bean>
 
-  <alias name="another.qualified.name" alias="a.qualified.name.which.is.an.alias"/>
+	<alias name="another.qualified.name" alias="a.qualified.name.which.is.an.alias"/>
 
 </beans>

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-argument-resolvers.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-argument-resolvers.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
@@ -9,10 +9,10 @@
 		<mvc:argument-resolvers>
 			<bean class="org.springframework.web.servlet.config.TestWebArgumentResolver"/>
 			<bean class="org.springframework.web.servlet.config.TestHandlerMethodArgumentResolver"/>
-            <ref bean="customArgumentResolver" />
+			<ref bean="customArgumentResolver" />
 		</mvc:argument-resolvers>
 	</mvc:annotation-driven>
 
-    <bean id="customArgumentResolver" class="org.springframework.web.servlet.config.TestHandlerMethodArgumentResolver"/>
+	<bean id="customArgumentResolver" class="org.springframework.web.servlet.config.TestHandlerMethodArgumentResolver"/>
 
 </beans>

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-async-support.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-async-support.xml
@@ -1,5 +1,5 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-bean-decoration.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-bean-decoration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-cors-minimal.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-cors-minimal.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-cors.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-cors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-custom-conversion-service.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-custom-conversion-service.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-custom-pattern-parser.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-custom-pattern-parser.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-custom-validator.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-custom-validator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-default-servlet-optional-attrs.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-default-servlet-optional-attrs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-default-servlet.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-default-servlet.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-deprecated-path-matcher.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-deprecated-path-matcher.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-interceptors.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-interceptors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
@@ -11,13 +11,13 @@
 		<bean class="org.springframework.web.servlet.i18n.LocaleChangeInterceptor"/>
 	</mvc:interceptors>
 
-    <mvc:interceptors path-matcher="pathMatcher">
-        <mvc:interceptor>
-            <mvc:mapping path="/accounts/[0-9]*" />
-            <bean class="org.springframework.web.servlet.handler.UserRoleAuthorizationInterceptor"/>
-        </mvc:interceptor>
-    </mvc:interceptors>
+	<mvc:interceptors path-matcher="pathMatcher">
+		<mvc:interceptor>
+			<mvc:mapping path="/accounts/[0-9]*" />
+			<bean class="org.springframework.web.servlet.handler.UserRoleAuthorizationInterceptor"/>
+		</mvc:interceptor>
+	</mvc:interceptors>
 
-    <bean id="pathMatcher" class="org.springframework.web.servlet.config.MvcNamespaceTests$TestPathMatcher"/>
+	<bean id="pathMatcher" class="org.springframework.web.servlet.config.MvcNamespaceTests$TestPathMatcher"/>
 
 </beans>

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-message-codes-resolver.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-message-codes-resolver.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-message-converters-defaults-off.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-message-converters-defaults-off.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-message-converters.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-message-converters.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-path-matching-mappings.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-path-matching-mappings.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:mvc="http://www.springframework.org/schema/mvc"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   xmlns:mvc="http://www.springframework.org/schema/mvc"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
-    <mvc:resources mapping="/resources/**" location="/static, classpath:/META-INF/" />
+	<mvc:resources mapping="/resources/**" location="/static, classpath:/META-INF/" />
 
-    <mvc:annotation-driven>
-        <mvc:path-matching
-                path-helper="pathHelper"
-                path-matcher="pathMatcher" />
-    </mvc:annotation-driven>
+	<mvc:annotation-driven>
+		<mvc:path-matching
+				path-helper="pathHelper"
+				path-matcher="pathMatcher" />
+	</mvc:annotation-driven>
 
-    <mvc:view-controller path="/" view-name="home"/>
-    <mvc:view-controller path="/test" view-name="test"/>
+	<mvc:view-controller path="/" view-name="home"/>
+	<mvc:view-controller path="/test" view-name="test"/>
 
-    <bean id="pathMatcher" class="org.springframework.web.servlet.config.MvcNamespaceTests$TestPathMatcher" />
-    <bean id="pathHelper" class="org.springframework.web.servlet.config.MvcNamespaceTests$TestPathHelper" />
+	<bean id="pathMatcher" class="org.springframework.web.servlet.config.MvcNamespaceTests$TestPathMatcher" />
+	<bean id="pathHelper" class="org.springframework.web.servlet.config.MvcNamespaceTests$TestPathHelper" />
 
 </beans>

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-path-matching.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-path-matching.xml
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-       xmlns:mvc="http://www.springframework.org/schema/mvc"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+	   xmlns:mvc="http://www.springframework.org/schema/mvc"
+	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	   xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">
 
-    <mvc:annotation-driven content-negotiation-manager="contentNegotiationManager">
-        <mvc:path-matching path-helper="pathHelper" path-matcher="pathMatcher" />
-    </mvc:annotation-driven>
+	<mvc:annotation-driven content-negotiation-manager="contentNegotiationManager">
+		<mvc:path-matching path-helper="pathHelper" path-matcher="pathMatcher" />
+	</mvc:annotation-driven>
 
-    <bean id="pathMatcher" class="org.springframework.web.servlet.config.TestPathMatcher" />
-    <bean id="pathHelper" class="org.springframework.web.servlet.config.TestPathHelper" />
-    <bean id="contentNegotiationManager" class="org.springframework.web.accept.ContentNegotiationManagerFactoryBean">
-        <property name="mediaTypes">
-            <value>
-                xml=application/rss+xml
-            </value>
-        </property>
-    </bean>
+	<bean id="pathMatcher" class="org.springframework.web.servlet.config.TestPathMatcher" />
+	<bean id="pathHelper" class="org.springframework.web.servlet.config.TestPathHelper" />
+	<bean id="contentNegotiationManager" class="org.springframework.web.accept.ContentNegotiationManagerFactoryBean">
+		<property name="mediaTypes">
+			<value>
+				xml=application/rss+xml
+			</value>
+		</property>
+	</bean>
 </beans>

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-resources-chain-no-auto.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-resources-chain-no-auto.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-resources-chain.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-resources-chain.xml
@@ -16,7 +16,7 @@
   -->
 
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-resources-optional-attrs.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-resources-optional-attrs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-resources.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-resources.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-view-controllers-minimal.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-view-controllers-minimal.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
 		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-view-resolution-content-negotiation.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config-view-resolution-content-negotiation.xml
@@ -3,7 +3,7 @@
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xsi:schemaLocation="
-	   	http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-4.3.xsd
+		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc-4.3.xsd
 		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-4.3.xsd">
 
 	<!--

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/config/mvc-config.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <beans xmlns="http://www.springframework.org/schema/beans"
-    xmlns:mvc="http://www.springframework.org/schema/mvc"
+	xmlns:mvc="http://www.springframework.org/schema/mvc"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/mvc https://www.springframework.org/schema/mvc/spring-mvc.xsd">

--- a/spring-webmvc/src/test/resources/org/springframework/web/servlet/view/views.xml
+++ b/spring-webmvc/src/test/resources/org/springframework/web/servlet/view/views.xml
@@ -20,7 +20,7 @@
 			<value>
 				test1=testvalue1
 				test2=testvalue2
-      </value>
+			</value>
 		</property>
 	</bean>
 

--- a/spring-websocket/src/main/resources/org/springframework/web/socket/config/spring-websocket.xsd
+++ b/spring-websocket/src/main/resources/org/springframework/web/socket/config/spring-websocket.xsd
@@ -15,21 +15,21 @@
 		<xsd:annotation>
 			<xsd:documentation><![CDATA[
 	An entry in the registered HandlerMapping that matches a path with a handler.
-            ]]></xsd:documentation>
+			]]></xsd:documentation>
 		</xsd:annotation>
 		<xsd:attribute name="path" type="xsd:string" use="required">
 			<xsd:annotation>
 				<xsd:documentation><![CDATA[
 	A path that maps a particular request to a handler.
 	Exact path mapping URIs (such as "/myPath") are supported as well as Ant-type path patterns (such as /myPath/**).
-                ]]></xsd:documentation>
+			]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="handler" type="xsd:string" use="required">
 			<xsd:annotation>
 				<xsd:documentation source="java:org.springframework.web.socket.WebSocketHandler"><![CDATA[
-    The bean name of a WebSocketHandler to use for requests that match the path configuration.
-                ]]></xsd:documentation>
+	The bean name of a WebSocketHandler to use for requests that match the path configuration.
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>
@@ -38,9 +38,9 @@
 		<xsd:attribute name="ref" type="xsd:string" use="required">
 			<xsd:annotation>
 				<xsd:documentation source="java:org.springframework.web.socket.server.HandshakeHandler"><![CDATA[
-    The bean name of a HandshakeHandler to use for processing WebSocket handshake requests.
-    If none specified, a DefaultHandshakeHandler will be configured by default.
-                ]]></xsd:documentation>
+	The bean name of a HandshakeHandler to use for processing WebSocket handshake requests.
+	If none specified, a DefaultHandshakeHandler will be configured by default.
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>
@@ -58,14 +58,14 @@
 					<xsd:annotation>
 						<xsd:documentation source="org.springframework.web.socket.server.HandshakeInterceptor"><![CDATA[
 	A HandshakeInterceptor bean definition.
-                        ]]></xsd:documentation>
+						]]></xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element ref="beans:ref">
 					<xsd:annotation>
 						<xsd:documentation source="org.springframework.web.socket.server.HandshakeInterceptor"><![CDATA[
 	A reference to a HandshakeInterceptor bean.
-                    ]]></xsd:documentation>
+						]]></xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>
@@ -76,7 +76,7 @@
 		<xsd:annotation>
 			<xsd:documentation source="org.springframework.web.socket.sockjs.transport.handler.DefaultSockJsService"><![CDATA[
 	Configures a DefaultSockJsService for processing HTTP requests from SockJS clients.
-            ]]></xsd:documentation>
+			]]></xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:element name="transport-handlers" minOccurs="0" maxOccurs="1">
@@ -85,7 +85,7 @@
 	List of TransportHandler beans to be configured for the current handlers element.
 	One can choose not to register the default TransportHandlers and/or override those using
 	custom TransportHandlers.
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 				</xsd:annotation>
 				<xsd:complexType>
 					<xsd:sequence>
@@ -94,14 +94,14 @@
 								<xsd:annotation>
 									<xsd:documentation><![CDATA[
 	A TransportHandler bean definition.
-                        ]]></xsd:documentation>
+									]]></xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 							<xsd:element ref="beans:ref">
 								<xsd:annotation>
 									<xsd:documentation><![CDATA[
 	A reference to a TransportHandler bean.
-                        ]]></xsd:documentation>
+									]]></xsd:documentation>
 								</xsd:annotation>
 							</xsd:element>
 						</xsd:choice>
@@ -113,7 +113,7 @@
 	Default registrations include XhrPollingTransportHandler, XhrReceivingTransportHandler,
 	JsonpPollingTransportHandler, JsonpReceivingTransportHandler, XhrStreamingTransportHandler,
 	EventSourceTransportHandler, HtmlFileTransportHandler, and WebSocketTransportHandler.
-                        ]]></xsd:documentation>
+							]]></xsd:documentation>
 						</xsd:annotation>
 					</xsd:attribute>
 				</xsd:complexType>
@@ -123,7 +123,7 @@
 			<xsd:annotation>
 				<xsd:documentation source="java:org.springframework.web.socket.sockjs.support.AbstractSockJsService"><![CDATA[
 	A unique name for the service, mainly for logging purposes.
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="client-library-url" type="xsd:string">
@@ -145,7 +145,7 @@
 	the relative URL must start with "../../" to traverse up to the location
 	above the SockJS mapping. In case of a prefix-based Servlet mapping one more
 	traversal may be needed.
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="stream-bytes-limit" type="xsd:int">
@@ -153,7 +153,7 @@
 				<xsd:documentation source="java:org.springframework.web.socket.sockjs.support.AbstractSockJsService"><![CDATA[
 	Minimum number of bytes that can be send over a single HTTP streaming request before it will be closed.
 	Defaults to 128K (i.e. 128 1024).
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="session-cookie-needed" type="xsd:boolean">
@@ -162,7 +162,7 @@
 	The "cookie_needed" value in the response from the SockJs "/info" endpoint.
 	This property indicates whether the use of a JSESSIONID cookie is required for the application to function correctly,
 	for example, for load balancing or in Java Servlet containers for the use of an HTTP session.
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="heartbeat-time" type="xsd:long">
@@ -171,7 +171,7 @@
 	The amount of time in milliseconds when the server has not sent any messages and after which the server
 	should send a heartbeat frame to the client in order to keep the connection from breaking.
 	The default value is 25,000 (25 seconds).
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="disconnect-delay" type="xsd:long">
@@ -180,7 +180,7 @@
 	The amount of time in milliseconds before a client is considered disconnected after not having
 	a receiving connection, i.e. an active connection over which the server can send data to the client.
 	The default value is 5000.
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="message-cache-size" type="xsd:int">
@@ -189,7 +189,7 @@
 	The number of server-to-client messages that a session can cache while waiting for
 	the next HTTP polling request from the client.
 	The default size is 100.
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="websocket-enabled" type="xsd:boolean">
@@ -197,7 +197,7 @@
 				<xsd:documentation source="java:org.springframework.web.socket.sockjs.support.AbstractSockJsService"><![CDATA[
 	Some load balancers don't support websockets. Set this option to "false" to disable the WebSocket transport on the server side.
 	The default value is "true".
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="scheduler" type="xsd:string">
@@ -205,7 +205,7 @@
 				<xsd:documentation source="java:org.springframework.web.socket.sockjs.support.AbstractSockJsService"><![CDATA[
 	The bean name of a TaskScheduler; a new ThreadPoolTaskScheduler instance will be created if no value is provided.
 	This scheduler instance will be used for scheduling heart-beat messages.
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="message-codec" type="xsd:string">
@@ -213,7 +213,7 @@
 				<xsd:documentation source="java:org.springframework.web.socket.sockjs.support.AbstractSockJsService"><![CDATA[
 	The bean name of a SockJsMessageCodec to use for encoding and decoding SockJS messages.
 	By default Jackson2SockJsMessageCodec is used requiring the Jackson library to be present on the classpath.
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="suppress-cors" type="xsd:boolean">
@@ -221,7 +221,7 @@
 				<xsd:documentation source="java:org.springframework.web.socket.sockjs.support.AbstractSockJsService"><![CDATA[
 	This option can be used to disable automatic addition of CORS headers for SockJS requests.
 	The default value is "false".
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>
@@ -235,28 +235,28 @@
 	opposed to from a client).
 	The "login", "password", "heartbeat-send-interval" and "heartbeat-receive-interval" attributes
 	are provided to configure this "system" connection.
-                ]]></xsd:documentation>
+			]]></xsd:documentation>
 		</xsd:annotation>
 		<xsd:attribute name="prefix" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation source="java:org.springframework.messaging.simp.stomp.StompBrokerRelayMessageHandler"><![CDATA[
 	Comma-separated list of destination prefixes supported by the broker being configured.
 	Destinations that do not match the given prefix(es) are ignored.
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="relay-host" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation source="java:org.springframework.messaging.simp.stomp.StompBrokerRelayMessageHandler"><![CDATA[
 	The STOMP message broker host.
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="relay-port" type="xsd:int">
 			<xsd:annotation>
 				<xsd:documentation source="java:org.springframework.messaging.simp.stomp.StompBrokerRelayMessageHandler"><![CDATA[
 	The STOMP message broker port.
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="client-login" type="xsd:string">
@@ -264,7 +264,7 @@
 				<xsd:documentation source="java:org.springframework.messaging.simp.stomp.StompBrokerRelayMessageHandler"><![CDATA[
 	The login to use when creating connections to the STOMP broker on behalf of connected clients.
 	By default this is set to "guest".
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="client-passcode" type="xsd:string">
@@ -272,7 +272,7 @@
 				<xsd:documentation source="java:org.springframework.messaging.simp.stomp.StompBrokerRelayMessageHandler"><![CDATA[
 	The passcode to use when creating connections to the STOMP broker on behalf of connected clients.
 	By default this is set to "guest".
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="system-login" type="xsd:string">
@@ -282,7 +282,7 @@
 	the STOMP broker from within the application, i.e. messages not associated
 	with a specific client session (for example, REST/HTTP request handling method).
 	By default this is set to "guest".
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="system-passcode" type="xsd:string">
@@ -292,21 +292,21 @@
 	the STOMP broker from within the application, i.e. messages not associated
 	with a specific client session (for example, REST/HTTP request handling method).
 	By default this is set to "guest".
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="heartbeat-send-interval" type="xsd:long">
 			<xsd:annotation>
 				<xsd:documentation source="java:org.springframework.messaging.simp.stomp.StompBrokerRelayMessageHandler"><![CDATA[
 	The interval, in milliseconds, at which the "system" connection will send heartbeats to the STOMP broker.
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="heartbeat-receive-interval" type="xsd:long">
 			<xsd:annotation>
 				<xsd:documentation source="java:org.springframework.messaging.simp.stomp.StompBrokerRelayMessageHandler"><![CDATA[
 	The interval, in milliseconds, at which the "system" connection expects to receive heartbeats from the STOMP broker.
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="auto-startup" type="xsd:boolean">
@@ -315,7 +315,7 @@
 	Whether or not the StompBrokerRelay should be automatically started as part of its SmartLifecycle,
 	i.e. at the time of an application context refresh.
 	Default value is "true".
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="virtual-host" type="xsd:string">
@@ -325,7 +325,7 @@
 	This may be useful for example in a cloud environment where the actual host to which
 	the TCP connection is established is different from the host providing the cloud-based STOMP service.
 	By default this property is not set.
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="user-destination-broadcast" type="xsd:string">
@@ -335,7 +335,7 @@
 	the user is not connected. In a multi-application server scenario this
 	gives other application servers a chance to try.
 	By default this is not set.
-                    ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="user-registry-broadcast" type="xsd:string">
@@ -346,7 +346,7 @@
 	server scenarios this allows each server's user registry to be aware of
 	users connected to other servers.
 	By default this is not set.
-                    ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>
@@ -355,14 +355,14 @@
 		<xsd:annotation>
 			<xsd:documentation source="java:org.springframework.messaging.simp.broker.SimpleBrokerMessageHandler"><![CDATA[
 	Configures a SimpleBrokerMessageHandler that handles messages as a simple message broker implementation.
-                ]]></xsd:documentation>
+			]]></xsd:documentation>
 		</xsd:annotation>
 		<xsd:attribute name="prefix" type="xsd:string">
 			<xsd:annotation>
 				<xsd:documentation source="java:org.springframework.messaging.simp.stomp.SimpleBrokerMessageHandler"><![CDATA[
 	Comma-separated list of destination prefixes supported by the broker being configured.
 	Destinations that do not match the given prefix(es) are ignored.
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="heartbeat" type="xsd:string">
@@ -372,7 +372,7 @@
 	write or send a heartbeat. The second is how often the client should write. 0 means no heartbeats.
 	By default this is set to "0, 0" unless the scheduler attribute is also set in which case the
 	default becomes "10000,10000" (in milliseconds).
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="scheduler" type="xsd:string">
@@ -381,7 +381,7 @@
 	The name of a task TaskScheduler to use for heartbeat support. Setting this property also
 	automatically sets the heartbeat attribute to "10000, 10000".
 	By default this attribute is not set.
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="selector-header" type="xsd:string">
@@ -397,7 +397,7 @@
 
 	By default this is set to "selector". You can set it to a different
 	name, or to "" to turn off support for a selector header.
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 
@@ -414,7 +414,7 @@
 		<xsd:annotation>
 			<xsd:documentation source="java:org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor"><![CDATA[
 	Configuration for the ThreadPoolTaskExecutor that sends messages for the message channel.
-                ]]></xsd:documentation>
+			]]></xsd:documentation>
 		</xsd:annotation>
 		<xsd:attribute name="core-pool-size" type="xsd:int" use="optional">
 			<xsd:annotation>
@@ -426,38 +426,38 @@
 	By default this is set to twice the value of Runtime.availableProcessors().
 	In an application where tasks do not block frequently,
 	the number should be closer to or equal to the number of available CPUs/cores.
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="max-pool-size" type="xsd:int" use="optional">
 			<xsd:annotation>
 				<xsd:documentation source="java:org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor"><![CDATA[
-	 Set the max pool size of the ThreadPoolExecutor.
-	 NOTE: When an unbounded queue-capacity is configured (the default), the max pool size is effectively ignored.
-	 See the "Unbounded queues" strategy in java.util.concurrent.ThreadPoolExecutor for more details.
-	 By default this is set to Integer.MAX_VALUE.
-                ]]></xsd:documentation>
+	Set the max pool size of the ThreadPoolExecutor.
+	NOTE: When an unbounded queue-capacity is configured (the default), the max pool size is effectively ignored.
+	See the "Unbounded queues" strategy in java.util.concurrent.ThreadPoolExecutor for more details.
+	By default this is set to Integer.MAX_VALUE.
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="keep-alive-seconds" type="xsd:int" use="optional">
 			<xsd:annotation>
 				<xsd:documentation source="java:org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor"><![CDATA[
-	 Set the time limit for which threads may remain idle before being terminated.
-	 If there are more than the core number of threads currently in the pool, after waiting this amount of time without
-	 processing a task, excess threads will be terminated.  This overrides any value set in the constructor.
-	 By default this is set to 60.
-                ]]></xsd:documentation>
+	Set the time limit for which threads may remain idle before being terminated.
+	If there are more than the core number of threads currently in the pool, after waiting this amount of time without
+	processing a task, excess threads will be terminated.  This overrides any value set in the constructor.
+	By default this is set to 60.
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 		<xsd:attribute name="queue-capacity" type="xsd:int" use="optional">
 			<xsd:annotation>
 				<xsd:documentation source="java:org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor"><![CDATA[
-	 Set the queue capacity for the ThreadPoolExecutor.
-	 NOTE: When an unbounded queue-capacity is configured (the default) the core pool size is effectively the max pool size.
-	 This is essentially the "Unbounded queues" strategy as explained in java.util.concurrent.ThreadPoolExecutor.
-	 When this strategy is used, the max pool size is effectively ignored.
-	 By default this is set to Integer.MAX_VALUE.
-                ]]></xsd:documentation>
+	Set the queue capacity for the ThreadPoolExecutor.
+	NOTE: When an unbounded queue-capacity is configured (the default) the core pool size is effectively the max pool size.
+	This is essentially the "Unbounded queues" strategy as explained in java.util.concurrent.ThreadPoolExecutor.
+	When this strategy is used, the max pool size is effectively ignored.
+	By default this is set to Integer.MAX_VALUE.
+				]]></xsd:documentation>
 			</xsd:annotation>
 		</xsd:attribute>
 	</xsd:complexType>
@@ -467,7 +467,7 @@
 			<xsd:documentation source="java:org.springframework.messaging.support.ChannelInterceptor"><![CDATA[
 	List of ChannelInterceptor beans to be used with this channel.
 	Empty by default.
-                ]]></xsd:documentation>
+			]]></xsd:documentation>
 		</xsd:annotation>
 		<xsd:sequence>
 			<xsd:choice maxOccurs="unbounded">
@@ -475,14 +475,14 @@
 					<xsd:annotation>
 						<xsd:documentation><![CDATA[
 	A ChannelInterceptor bean definition.
-                        ]]></xsd:documentation>
+						]]></xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element ref="beans:ref">
 					<xsd:annotation>
 						<xsd:documentation><![CDATA[
 	A reference to a ChannelInterceptor bean.
-                        ]]></xsd:documentation>
+						]]></xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:choice>
@@ -506,7 +506,7 @@
 
 	See EnableWebSocket Javadoc for
 	information on code-based alternatives to enabling WebSocket support.
-            ]]></xsd:documentation>
+			]]></xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:sequence>
@@ -520,7 +520,7 @@
 					<xsd:documentation><![CDATA[
 	Order value for this SimpleUrlHandlerMapping.
 	Default value is 1.
-                ]]></xsd:documentation>
+				]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
 			<xsd:attribute name="allowed-origins" type="xsd:string">
@@ -563,7 +563,7 @@
 	A StompSubProtocolHandler is registered to handle various versions of the STOMP protocol.
 
 	See EnableWebSocketMessageBroker javadoc for information on code-based alternatives to enabling broker-backed messaging.
-            ]]></xsd:documentation>
+			]]></xsd:documentation>
 		</xsd:annotation>
 		<xsd:complexType>
 			<xsd:sequence>
@@ -571,7 +571,7 @@
 					<xsd:annotation>
 						<xsd:documentation><![CDATA[
 	Configure options related to the processing of messages received from and sent to WebSocket clients.
-                        ]]></xsd:documentation>
+				]]></xsd:documentation>
 					</xsd:annotation>
 					<xsd:complexType>
 						<xsd:sequence>
@@ -591,14 +591,14 @@
 												<xsd:annotation>
 													<xsd:documentation source="org.springframework.web.socket.handler.WebSocketHandlerDecoratorFactory"><![CDATA[
 	A WebSocketHandlerDecoratorFactory bean definition.
-                        ]]></xsd:documentation>
+													]]></xsd:documentation>
 												</xsd:annotation>
 											</xsd:element>
 											<xsd:element ref="beans:ref">
 												<xsd:annotation>
 													<xsd:documentation source="org.springframework.web.socket.handler.WebSocketHandlerDecoratorFactory"><![CDATA[
 	A reference to a WebSocketHandlerDecoratorFactory bean.
-                    ]]></xsd:documentation>
+													]]></xsd:documentation>
 												</xsd:annotation>
 											</xsd:element>
 										</xsd:choice>
@@ -626,7 +626,7 @@
 	does not specifically discuss how to send STOMP messages over WebSocket.
 	Version 2 of the spec will but in the mean time existing client libraries
 	have already established a practice that servers must handle.
-                                ]]></xsd:documentation>
+								]]></xsd:documentation>
 							</xsd:annotation>
 						</xsd:attribute>
 						<xsd:attribute name="send-timeout" type="xsd:int">
@@ -661,7 +661,7 @@
 	/proc/sys/net/ipv4/tcp_retries2 on Linux.
 
 	The default value is 10 seconds (i.e. 10 * 10000).
-                                ]]></xsd:documentation>
+								]]></xsd:documentation>
 							</xsd:annotation>
 						</xsd:attribute>
 						<xsd:attribute name="send-buffer-size" type="xsd:int">
@@ -690,23 +690,23 @@
 
 	The default value is 512K (i.e. 512 * 1024). If the value is set to less
 	than or equal to 0 then buffering is effectively disabled.
-                                ]]></xsd:documentation>
+								]]></xsd:documentation>
 							</xsd:annotation>
 						</xsd:attribute>
 						<xsd:attribute name="time-to-first-message" type="xsd:int">
 							<xsd:annotation>
 								<xsd:documentation><![CDATA[
-	 Set the maximum time allowed in milliseconds after the WebSocket
-	 connection is established and before the first sub-protocol message is
-	 received.
+	Set the maximum time allowed in milliseconds after the WebSocket
+	connection is established and before the first sub-protocol message is
+	received.
 
-	 This handler is for WebSocket connections that use a sub-protocol.
-	 Therefore, we expect the client to send at least one sub-protocol message
-	 in the beginning, or else we assume the connection isn't doing well, for example,
-	 proxy issue, slow network, and can be closed.
+	This handler is for WebSocket connections that use a sub-protocol.
+	Therefore, we expect the client to send at least one sub-protocol message
+	in the beginning, or else we assume the connection isn't doing well, for example,
+	proxy issue, slow network, and can be closed.
 
-	 By default this is set to 60,000 (1 minute).
-                                ]]></xsd:documentation>
+	By default this is set to 60,000 (1 minute).
+								]]></xsd:documentation>
 							</xsd:annotation>
 						</xsd:attribute>
 					</xsd:complexType>
@@ -715,7 +715,7 @@
 					<xsd:annotation>
 						<xsd:documentation><![CDATA[
 	Registers STOMP over WebSocket endpoints.
-                        ]]></xsd:documentation>
+						]]></xsd:documentation>
 					</xsd:annotation>
 					<xsd:complexType>
 						<xsd:sequence>
@@ -728,7 +728,7 @@
 								<xsd:documentation><![CDATA[
 	A path that maps a particular message destination to a handler method.
 	Exact path mapping URIs (such as "/myPath") are supported as well as Ant-stype path patterns (such as /myPath/**).
-                				]]></xsd:documentation>
+								]]></xsd:documentation>
 							</xsd:annotation>
 						</xsd:attribute>
 						<xsd:attribute name="allowed-origins" type="xsd:string">
@@ -764,15 +764,15 @@
 				<xsd:element name="stomp-error-handler" minOccurs="0">
 					<xsd:annotation>
 						<xsd:documentation><![CDATA[
-    Configures a StompSubProtocolErrorHandler to customize or handle STOMP ERROR to clients.
+	Configures a StompSubProtocolErrorHandler to customize or handle STOMP ERROR to clients.
 						]]></xsd:documentation>
 					</xsd:annotation>
 					<xsd:complexType>
 						<xsd:attribute name="ref" type="xsd:string" use="required">
 							<xsd:annotation>
 								<xsd:documentation source="java:org.springframework.web.socket.messaging.StompSubProtocolErrorHandler"><![CDATA[
-    The bean name of a StompSubProtocolErrorHandler.
-                ]]></xsd:documentation>
+	The bean name of a StompSubProtocolErrorHandler.
+								]]></xsd:documentation>
 							</xsd:annotation>
 						</xsd:attribute>
 					</xsd:complexType>
@@ -886,21 +886,21 @@
 					<xsd:annotation>
 						<xsd:documentation><![CDATA[
 	The channel for receiving messages from clients (for example, WebSocket clients).
-                ]]></xsd:documentation>
+						]]></xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element name="client-outbound-channel" type="channel" minOccurs="0" maxOccurs="1">
 					<xsd:annotation>
 						<xsd:documentation><![CDATA[
 	The channel for sending messages to clients (for example, WebSocket clients).
-                ]]></xsd:documentation>
+						]]></xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 				<xsd:element name="broker-channel" type="channel" minOccurs="0" maxOccurs="1">
 					<xsd:annotation>
 						<xsd:documentation><![CDATA[
 	The channel for sending messages with translated user destinations.
-                ]]></xsd:documentation>
+						]]></xsd:documentation>
 					</xsd:annotation>
 				</xsd:element>
 			</xsd:sequence>
@@ -915,7 +915,7 @@
 
 	Prefixes without a trailing slash will have one appended automatically.
 	By default the list of prefixes is empty in which case all destinations match.
-                    ]]></xsd:documentation>
+					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
 			<xsd:attribute name="preserve-publish-order" type="xsd:boolean">
@@ -931,7 +931,7 @@
 	will be sent to the clientOutboundChannel one at a time in
 	order to preserve the order of publication. Enable this only if needed
 	since there is some performance overhead to keep messages in order.
-                    ]]></xsd:documentation>
+					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
 			<xsd:attribute name="user-destination-prefix" type="xsd:string">
@@ -940,7 +940,7 @@
 	The prefix used to identify user destinations.
 	Any destinations that do not start with the given prefix are not be resolved.
 	The default value is "/user/".
-                    ]]></xsd:documentation>
+					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
 			<xsd:attribute name="path-matcher" type="xsd:string">
@@ -962,7 +962,7 @@
 
 	When the simple broker is enabled, the PathMatcher configured here is
 	also used to match message destinations when brokering messages.
-                    ]]></xsd:documentation>
+						]]></xsd:documentation>
 					<xsd:appinfo>
 						<tool:annotation kind="ref">
 							<tool:expected-type type="java:org.springframework.util.PathMatcher"/>
@@ -975,7 +975,7 @@
 					<xsd:documentation><![CDATA[
 	Order value for this SimpleUrlHandlerMapping.
 	Default value is 1.
-                ]]></xsd:documentation>
+					]]></xsd:documentation>
 				</xsd:annotation>
 			</xsd:attribute>
 			<xsd:attribute name="path-helper" type="xsd:string">

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-customchannels-default-executor.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-broker-customchannels-default-executor.xml
@@ -2,7 +2,7 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:websocket="http://www.springframework.org/schema/websocket"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<websocket:message-broker>

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers-attributes.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers-attributes.xml
@@ -2,7 +2,7 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:websocket="http://www.springframework.org/schema/websocket"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<websocket:handlers order="2" allowed-origins="https://mydomain1.example, https://mydomain2.example">

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers-sockjs-attributes.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers-sockjs-attributes.xml
@@ -2,7 +2,7 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:websocket="http://www.springframework.org/schema/websocket"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<websocket:handlers allowed-origins="https://mydomain1.example, https://mydomain2.example" allowed-origin-patterns="https://*.mydomain.example">

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers-sockjs.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers-sockjs.xml
@@ -2,7 +2,7 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:websocket="http://www.springframework.org/schema/websocket"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<websocket:handlers>

--- a/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers.xml
+++ b/spring-websocket/src/test/resources/org/springframework/web/socket/config/websocket-config-handlers.xml
@@ -2,7 +2,7 @@
 	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	   xmlns:websocket="http://www.springframework.org/schema/websocket"
 	   xsi:schemaLocation="
-        http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/websocket https://www.springframework.org/schema/websocket/spring-websocket.xsd">
 
 	<websocket:handlers>


### PR DESCRIPTION
This Pull Request is part of an academic research project. More preciously it is for my master's thesis, more background information [here](https://codeberg.org/BaumiCoder/Masterthesis).

## Definition: EditorConfig violations

The goal of this Pull Request is to address all [EditorConfig](https://editorconfig.org) violations in the project. With EditorConfig you have set for example `indent_style = tab` for many files, but there were files which use spaces for indentation. I call this an EditorConfig violation as a file content violates the respective EditorConfig property. They can have different kind of impacts. The mixture tabs and spaces can lead to visually wrong indentation.
For example if the file with authored with a tab width of 2 and one line has spaces in use instead of tabs, the visual indentation of these lines are now different as `indent_size = 4` lead to a tab width of 4.

## How to address them?

To check for such violations and fix them I developed the CLI tool [ecformat](https://codeberg.org/BaumiCoder/ecformat). However, there are different ways to address the violations:

1. **Adjust EditorConfig:** The EditorConfig properties for a file can be wrong. For example two trailing spaces in Markdown represent a line break. Therefore, `trim_trailing_whitespace = true` is often wrong for them. The correct way to address that is to set `trim_trailing_whitespace = false`  for them, which avoids automatic removal of such spaces. (I found no such cases in your repository.)
2. **Fix file content:** Another way is to fix the content of the file. Which means for example for `insert_final_newline = true` to insert the final newlines. To do so `ecformat fix` can be helpful.
3. **Ignore files:** For some files it is not meaningful to consider the EditorConfig violations, which `ecformat check` finds. 
   (See the help for `ecformat check --ignore-file` how this would be possible.) There are different reasons to ignore files:
   1. As EditorConfig is only for text files, considering binary files does not make sense.
   2. EditorConfig supports to set the property on the file level. However, there can be files with intentional differences inside. Such files need to be ignored fully by `ecformat` as it currently (version 0.2.0) has no support to ignore only a single property for some files.

## Changes in this Pull Request

For this Pull Request, I focused on the Properties of the current [EditorConfig specification](https://spec.editorconfig.org/#supported-pairs) 0.17.2. You only have some violations regarding indentation. In most cases, these are alignments and not indentation. As `ecformat` is programming language independent, it cannot distinguish between and indentation and alignment. Therefore, it detects them as indentation violations, but these are false-positives.

Common examples for alignment in Java, Kotlin and Groovy are multi line comments, where the `*` are aligned like this:

```java
/*
 * That is some multi line comment and we want to have the * symbols
 * all in the same text column for a nice border.
 */
```

In `.xml` files and `.xsd` files the attributes are often aligned (but not always) like this:

```xml
<beans xmlns="http://www.springframework.org/schema/beans"
	   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
	   xmlns:context="http://www.springframework.org/schema/context">
```

Therefore, `ecformat` cannot be very helpful here. However, there were some real indentation errors in the `.xml` and `.xsd` files. Mostly due to the use of only spaces for indentation in some lines of a file. For these cases I manually reviewed the changes for `ecformat fix` making adjustments in them were necessary.

If I fixed the indentations in the wrong way for some files, please let me know with a respective Review comment. Then I will adjust it.

## Avoid EditorConfig violations in the future

Such EditorConfig violations can creep in again. Possible reasons can be that the editor of some contributors has no EditorConfig support, or it would be required to install a respective plugin for the support. Furthermore, some people may sometimes use the space key for indentations, not knowing that tab characters are in use.

If you want to avoid them in the future, I would suggest integrating a respective utility. As EditorConfig does not distinguish between indentation and alignment, tools for it, like `ecformat` or [editorconfig-checker](https://editorconfig-checker.github.io), cannot handle these situations. Therefore, a tool specific for formatting XML files would be required, which can be integrated in the CI or directly in your styling related Gradle tasks.

Let me know if you are interested using such a tool and what kind of tool you would prefer. I could add one in this Pull Request or a follow-up Pull Request.
