### PR TITLE
Remove stray TODO in exception handler tests

### DIFF
--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ExceptionHandlerExceptionResolverTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ExceptionHandlerExceptionResolverTests.java
@@ -84,8 +84,6 @@ import static org.mockito.Mockito.mock;
 @SuppressWarnings("unused")
 class ExceptionHandlerExceptionResolverTests {
 
-	//TODO
-
 	private static int DEFAULT_RESOLVER_COUNT;
 
 	private static int DEFAULT_HANDLER_COUNT;


### PR DESCRIPTION
Remove a stray TODO comment introduced in 52af43d6d2