### PR TITLE
Ignore concrete classes in ImportHttpServices scanning

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/service/registry/AbstractHttpServiceRegistrar.java
+++ b/spring-web/src/main/java/org/springframework/web/service/registry/AbstractHttpServiceRegistrar.java
@@ -348,7 +348,7 @@ public abstract class AbstractHttpServiceRegistrar implements
 		@Override
 		protected boolean isCandidateComponent(AnnotatedBeanDefinition beanDefinition) {
 			AnnotationMetadata metadata = beanDefinition.getMetadata();
-			return (metadata.isIndependent() && !metadata.isAnnotation());
+			return (metadata.isInterface() && metadata.isIndependent() && !metadata.isAnnotation());
 		}
 
 		/**

--- a/spring-web/src/test/java/org/springframework/web/service/registry/HttpServiceRegistrarTests.java
+++ b/spring-web/src/test/java/org/springframework/web/service/registry/HttpServiceRegistrarTests.java
@@ -70,6 +70,16 @@ class HttpServiceRegistrarTests {
 		assertBeanDefinitionCount(3);
 	}
 
+	@Test  // gh-36993
+	void scanIgnoresConcreteClassImplementingHttpExchangeInterface() {
+		doRegister(registry -> registry.forGroup(ECHO_GROUP).detectInBasePackages(EchoA.class));
+
+		// EchoAImpl implements EchoA but is not itself an interface, and must not
+		// be registered as an HTTP Service client alongside EchoA and EchoB.
+		assertRegistryBeanDef(new TestGroup(ECHO_GROUP, EchoA.class, EchoB.class));
+		assertBeanDefinitionCount(3);
+	}
+
 	@Test
 	void merge() {
 		doRegister(

--- a/spring-web/src/test/java/org/springframework/web/service/registry/echo/EchoAImpl.java
+++ b/spring-web/src/test/java/org/springframework/web/service/registry/echo/EchoAImpl.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.service.registry.echo;
+
+/**
+ * Concrete class implementing an {@code @HttpExchange} interface, present in the
+ * scanned package to verify that classpath scanning for HTTP Service interfaces
+ * ignores such classes rather than registering them as HTTP Service clients.
+ */
+public class EchoAImpl implements EchoA {
+
+	@Override
+	public String handle(String input) {
+		return input;
+	}
+
+}


### PR DESCRIPTION
## Summary
`AbstractHttpServiceRegistrar`'s classpath scanner uses `AnnotationTypeFilter` with `considerInterfaces=true` so that types can be discovered through an `@HttpExchange`-annotated interface. However, `isCandidateComponent()` did not verify that the discovered type itself was an interface.

As a result, concrete classes implementing an `@HttpExchange` interface were also registered as HTTP service clients, causing proxy creation to fail later with `IllegalArgumentException: [...] is not an interface`.

Fix: `isCandidateComponent()` now also requires `metadata.isInterface()`.

Fixes gh-36993