### PR TITLE
Reject MIME type parameters differing only in case

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
@@ -23,8 +23,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.function.BiPredicate;
@@ -246,7 +246,9 @@ public abstract class MimeTypeUtils {
 			String parameter = mimeType.substring(index + 1, nextIndex).trim();
 			if (parameter.length() > 0) {
 				if (parameters == null) {
-					parameters = new LinkedHashMap<>(4);
+					// Parameter names are case-insensitive, so use a case-insensitive
+					// map in order to reject duplicates that differ only in case.
+					parameters = new LinkedCaseInsensitiveMap<>(4, Locale.ROOT);
 				}
 				int eqIndex = parameter.indexOf('=');
 				if (eqIndex >= 0) {

--- a/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeTypeUtils.java
@@ -23,8 +23,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.function.BiPredicate;
@@ -437,7 +437,7 @@ public abstract class MimeTypeUtils {
 
 		private void putParameter(String name, String value) {
 			if (this.parameters == null) {
-				this.parameters = new LinkedHashMap<>(4);
+				this.parameters = new LinkedCaseInsensitiveMap<>(4, Locale.ROOT);
 			}
 			if (this.parameters.put(name, value) != null) {
 				throw new InvalidMimeTypeException(this.input, "duplicate parameter '" + name + "=" + value + "'");

--- a/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
+++ b/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
@@ -125,6 +125,13 @@ class MimeTypeTests {
 	}
 
 	@Test
+	void rejectsDuplicateParameterWithDifferentCase() {
+		String s = "text/plain;dupe=\"1\";DUPE=\"2\"";
+		assertThatThrownBy(() -> MimeType.valueOf(s)).isInstanceOf(InvalidMimeTypeException.class)
+				.hasMessageContaining("Invalid mime type \"text/plain;dupe=\"1\";DUPE=\"2\"\": duplicate parameter 'DUPE=\"2\"'");
+	}
+
+	@Test
 	void withConversionService() {
 		ConversionService conversionService = new DefaultConversionService();
 		assertThat(conversionService.canConvert(String.class, MimeType.class)).isTrue();

--- a/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
+++ b/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
@@ -174,6 +174,12 @@ class MimeTypeTests {
 					.hasMessageContaining("Invalid mime type \"text/plain;dupe=\"1\";dupe=\"2\"\": duplicate parameter 'dupe=\"2\"'");
 		}
 
+		@Test
+		void valueOfDuplicateParameterWithDifferentCase() {
+			assertThatThrownBy(() -> MimeType.valueOf("text/plain;dupe=\"1\";DUPE=\"2\"")).isInstanceOf(InvalidMimeTypeException.class)
+					.hasMessageContaining("Invalid mime type \"text/plain;dupe=\"1\";DUPE=\"2\"\": duplicate parameter 'DUPE=\"2\"'");
+		}
+
 	}
 
 


### PR DESCRIPTION
## Overview

`MimeTypeUtils` rejects duplicate MIME type parameters (gh-36841), but the check is case-sensitive while MIME parameter names are case-insensitive. As a result, duplicates that differ only in case (for example `charset` and `CHARSET`) slip through and are silently collapsed to the last value. This aligns the duplicate check with the case-insensitive nature of parameter names.

Since this PR was first opened, the parser was rewritten as a state machine (`MimeTypeParser`, commit 0799920); this PR has been reworked against the new parser accordingly.

## Problem

When parsing parameters, `MimeTypeParser.putParameter(...)` accumulates them in a `LinkedHashMap` and rejects duplicates by throwing when `Map#put` returns a previous value:

```java
private void putParameter(String name, String value) {
    if (this.parameters == null) {
        this.parameters = new LinkedHashMap<>(4);
    }
    if (this.parameters.put(name, value) != null) {
        throw new InvalidMimeTypeException(this.input, "duplicate parameter '" + name + "=" + value + "'");
    }
}
```

Because a `LinkedHashMap` treats `charset` and `CHARSET` as distinct keys, a case-variant duplicate never triggers the check:

| Input | Before |
| --- | --- |
| `text/plain;dupe="1";dupe="2"` | rejected (`InvalidMimeTypeException`) |
| `text/plain;dupe="1";DUPE="2"` | accepted, silently keeps `"2"` |

This is inconsistent: MIME parameter names are case-insensitive (RFC 2045), and `MimeType` itself stores parameters in a `LinkedCaseInsensitiveMap` so that `getParameter("CHARSET")` and `getParameter("charset")` resolve to the same value. RFC 6838 section 4.3 (cited by gh-36841) treats duplicate parameters as an error, so a case-only variant is logically the same duplicate.

## Fix

Accumulate parameters in a `LinkedCaseInsensitiveMap` so that a case-variant duplicate maps to the same key, causing `put` to return the previous value and the existing check to reject it:

```java
// Parameter names are case-insensitive, so use a case-insensitive
// map in order to reject duplicates that differ only in case.
this.parameters = new LinkedCaseInsensitiveMap<>(4, Locale.ROOT);
```

`Locale.ROOT` matches how `MimeType` builds its own parameter map, keeping case-insensitive comparison locale-independent. The final `MimeType` is unaffected: its constructor re-copies the parameters into its own `LinkedCaseInsensitiveMap`, and for non-duplicate input the accumulating map behaves the same as before (same keys, values, and iteration order). Only the duplicate-detection sensitivity changes.

## Note on impact

This is a parsing behavior change: `Content-Type`/`Accept`-style strings that repeat a parameter with different casing now throw `InvalidMimeTypeException` instead of parsing successfully. This matches the intent of gh-36841 and the case-insensitive contract of parameter names; valid MIME types are unaffected.
