### PR TITLE
Fix missing nullability in JdbcTemplate.batchUpdate

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -1046,12 +1046,12 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 	}
 
 	@Override
-	public int[] batchUpdate(String sql, List<Object[]> batchArgs) throws DataAccessException {
+	public int[] batchUpdate(String sql, List<@Nullable Object[]> batchArgs) throws DataAccessException {
 		return batchUpdate(sql, batchArgs, new int[0]);
 	}
 
 	@Override
-	public int[] batchUpdate(String sql, List<Object[]> batchArgs, int[] argTypes) throws DataAccessException {
+	public int[] batchUpdate(String sql, List<@Nullable Object[]> batchArgs, int[] argTypes) throws DataAccessException {
 		if (batchArgs.isEmpty()) {
 			return new int[0];
 		}

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -1061,9 +1061,9 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 				new BatchPreparedStatementSetter() {
 					@Override
 					public void setValues(PreparedStatement ps, int i) throws SQLException {
-						Object[] values = batchArgs.get(i);
+						@Nullable Object[] values = batchArgs.get(i);
 						int colIndex = 0;
-						for (Object value : values) {
+						for (@Nullable Object value : values) {
 							colIndex++;
 							if (value instanceof SqlParameterValue paramValue) {
 								StatementCreatorUtils.setParameterValue(ps, colIndex, paramValue, paramValue.getValue());


### PR DESCRIPTION
Updated batchUpdate method signatures to allow nullable Object arrays.

Fixes #37011 