### PR TITLE
Reject overlapping declared and generated key columns in `SimpleJdbcInsert`

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
@@ -205,12 +205,18 @@ public class TableMetaDataContext {
 		if (generatedKeyNames.length > 0) {
 			this.generatedKeyColumnsUsed = true;
 		}
-		if (!declaredColumns.isEmpty()) {
-			return new ArrayList<>(declaredColumns);
-		}
 		Set<String> keys = CollectionUtils.newLinkedHashSet(generatedKeyNames.length);
 		for (String key : generatedKeyNames) {
 			keys.add(key.toUpperCase(Locale.ROOT));
+		}
+		if (!declaredColumns.isEmpty()) {
+			List<String> columns = new ArrayList<>();
+			for (String column : declaredColumns) {
+				if (!keys.contains(column.toUpperCase(Locale.ROOT))) {
+					columns.add(column);
+				}
+			}
+			return columns;
 		}
 		List<String> columns = new ArrayList<>();
 		for (TableParameterMetaData meta : obtainMetaDataProvider().getTableParameterMetaData()) {

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/TableMetaDataContext.java
@@ -205,12 +205,22 @@ public class TableMetaDataContext {
 		if (generatedKeyNames.length > 0) {
 			this.generatedKeyColumnsUsed = true;
 		}
-		if (!declaredColumns.isEmpty()) {
-			return new ArrayList<>(declaredColumns);
-		}
 		Set<String> keys = CollectionUtils.newLinkedHashSet(generatedKeyNames.length);
 		for (String key : generatedKeyNames) {
 			keys.add(key.toUpperCase(Locale.ROOT));
+		}
+		if (!declaredColumns.isEmpty()) {
+			List<String> overlapping = new ArrayList<>();
+			for (String column : declaredColumns) {
+				if (keys.contains(column.toUpperCase(Locale.ROOT))) {
+					overlapping.add(column);
+				}
+			}
+			if (!overlapping.isEmpty()) {
+				throw new InvalidDataAccessApiUsageException(
+						"Declared columns " + overlapping + " must not overlap with generated key columns");
+			}
+			return new ArrayList<>(declaredColumns);
 		}
 		List<String> columns = new ArrayList<>();
 		for (TableParameterMetaData meta : obtainMetaDataProvider().getTableParameterMetaData()) {

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/simple/TableMetaDataContextTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/simple/TableMetaDataContextTests.java
@@ -153,4 +153,126 @@ class TableMetaDataContextTests {
 		verify(columnsResultSet).close();
 	}
 
+	@Test
+	void declaredColumnsIncludingGeneratedKeyAreExcluded() throws Exception {
+		final String TABLE = "customers";
+		final String USER = "me";
+
+		ResultSet metaDataResultSet = mock();
+		given(metaDataResultSet.next()).willReturn(true, false);
+		given(metaDataResultSet.getString("TABLE_SCHEM")).willReturn(USER);
+		given(metaDataResultSet.getString("TABLE_NAME")).willReturn(TABLE);
+		given(metaDataResultSet.getString("TABLE_TYPE")).willReturn("TABLE");
+
+		ResultSet columnsResultSet = mock();
+		given(columnsResultSet.next()).willReturn(true, true, false);
+		given(columnsResultSet.getString("COLUMN_NAME")).willReturn("id", "name");
+		given(columnsResultSet.getInt("DATA_TYPE")).willReturn(Types.INTEGER, Types.VARCHAR);
+		given(columnsResultSet.getBoolean("NULLABLE")).willReturn(false, true);
+
+		given(databaseMetaData.getDatabaseProductName()).willReturn("MyDB");
+		given(databaseMetaData.getDatabaseProductVersion()).willReturn("1.0");
+		given(databaseMetaData.getUserName()).willReturn(USER);
+		given(databaseMetaData.storesLowerCaseIdentifiers()).willReturn(true);
+		given(databaseMetaData.getTables(null, null, TABLE, null)).willReturn(metaDataResultSet);
+		given(databaseMetaData.getColumns(null, USER, TABLE, null)).willReturn(columnsResultSet);
+
+		MapSqlParameterSource map = new MapSqlParameterSource();
+		map.addValue("id", 1);
+		map.addValue("name", "Sven");
+		String[] keyCols = new String[] { "id" };
+		context.setTableName(TABLE);
+		context.processMetaData(dataSource, List.of("id", "name"), keyCols);
+		List<Object> values = context.matchInParameterValuesWithInsertColumns(map);
+		String insertString = context.createInsertString(keyCols);
+		int[] insertTypes = context.createInsertTypes();
+
+		assertThat(insertString).as("insert string should exclude the declared generated key column")
+				.isEqualTo("INSERT INTO customers (name) VALUES(?)");
+		assertThat(values).as("values should exclude the declared generated key column").containsExactly("Sven");
+		assertThat(insertTypes.length).as("types array must match the number of placeholders").isEqualTo(1);
+		verify(metaDataResultSet, atLeastOnce()).next();
+		verify(columnsResultSet, atLeastOnce()).next();
+		verify(metaDataResultSet).close();
+		verify(columnsResultSet).close();
+	}
+
+	@Test
+	void declaredColumnsMatchingGeneratedKeysProduceEmptyInsert() throws Exception {
+		final String TABLE = "customers";
+		final String USER = "me";
+
+		ResultSet metaDataResultSet = mock();
+		given(metaDataResultSet.next()).willReturn(true, false);
+		given(metaDataResultSet.getString("TABLE_SCHEM")).willReturn(USER);
+		given(metaDataResultSet.getString("TABLE_NAME")).willReturn(TABLE);
+		given(metaDataResultSet.getString("TABLE_TYPE")).willReturn("TABLE");
+
+		ResultSet columnsResultSet = mock();
+		given(columnsResultSet.next()).willReturn(true, false);
+		given(columnsResultSet.getString("COLUMN_NAME")).willReturn("id");
+		given(columnsResultSet.getInt("DATA_TYPE")).willReturn(Types.INTEGER);
+		given(columnsResultSet.getBoolean("NULLABLE")).willReturn(false);
+
+		given(databaseMetaData.getDatabaseProductName()).willReturn("MyDB");
+		given(databaseMetaData.getDatabaseProductVersion()).willReturn("1.0");
+		given(databaseMetaData.getUserName()).willReturn(USER);
+		given(databaseMetaData.storesLowerCaseIdentifiers()).willReturn(true);
+		given(databaseMetaData.getTables(null, null, TABLE, null)).willReturn(metaDataResultSet);
+		given(databaseMetaData.getColumns(null, USER, TABLE, null)).willReturn(columnsResultSet);
+
+		MapSqlParameterSource map = new MapSqlParameterSource();
+		map.addValue("id", 1);
+		String[] keyCols = new String[] { "id" };
+		context.setTableName(TABLE);
+		context.processMetaData(dataSource, List.of("id"), keyCols);
+		List<Object> values = context.matchInParameterValuesWithInsertColumns(map);
+		String insertString = context.createInsertString(keyCols);
+		int[] insertTypes = context.createInsertTypes();
+
+		assertThat(insertString).as("empty insert not generated correctly")
+				.isEqualTo("INSERT INTO customers () VALUES()");
+		assertThat(values).as("no values should remain once the only declared column is the generated key").isEmpty();
+		assertThat(insertTypes).as("no types should remain once the only declared column is the generated key").isEmpty();
+	}
+
+	@Test
+	void declaredColumnsExcludeGeneratedKeyRegardlessOfCase() throws Exception {
+		final String TABLE = "customers";
+		final String USER = "me";
+
+		ResultSet metaDataResultSet = mock();
+		given(metaDataResultSet.next()).willReturn(true, false);
+		given(metaDataResultSet.getString("TABLE_SCHEM")).willReturn(USER);
+		given(metaDataResultSet.getString("TABLE_NAME")).willReturn(TABLE);
+		given(metaDataResultSet.getString("TABLE_TYPE")).willReturn("TABLE");
+
+		ResultSet columnsResultSet = mock();
+		given(columnsResultSet.next()).willReturn(true, true, false);
+		given(columnsResultSet.getString("COLUMN_NAME")).willReturn("id", "name");
+		given(columnsResultSet.getInt("DATA_TYPE")).willReturn(Types.INTEGER, Types.VARCHAR);
+		given(columnsResultSet.getBoolean("NULLABLE")).willReturn(false, true);
+
+		given(databaseMetaData.getDatabaseProductName()).willReturn("MyDB");
+		given(databaseMetaData.getDatabaseProductVersion()).willReturn("1.0");
+		given(databaseMetaData.getUserName()).willReturn(USER);
+		given(databaseMetaData.storesLowerCaseIdentifiers()).willReturn(true);
+		given(databaseMetaData.getTables(null, null, TABLE, null)).willReturn(metaDataResultSet);
+		given(databaseMetaData.getColumns(null, USER, TABLE, null)).willReturn(columnsResultSet);
+
+		MapSqlParameterSource map = new MapSqlParameterSource();
+		map.addValue("ID", 1);
+		map.addValue("name", "Sven");
+		String[] keyCols = new String[] { "id" };
+		context.setTableName(TABLE);
+		context.processMetaData(dataSource, List.of("ID", "name"), keyCols);
+		List<Object> values = context.matchInParameterValuesWithInsertColumns(map);
+		String insertString = context.createInsertString(keyCols);
+
+		assertThat(insertString).as("insert string should exclude the declared generated key column regardless of case")
+				.isEqualTo("INSERT INTO customers (name) VALUES(?)");
+		assertThat(values).as("values should exclude the declared generated key column regardless of case")
+				.containsExactly("Sven");
+	}
+
 }

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/simple/TableMetaDataContextTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/simple/TableMetaDataContextTests.java
@@ -29,11 +29,13 @@ import javax.sql.DataSource;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.jdbc.core.SqlParameterValue;
 import org.springframework.jdbc.core.metadata.TableMetaDataContext;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
@@ -151,6 +153,64 @@ class TableMetaDataContextTests {
 		verify(columnsResultSet, atLeastOnce()).next();
 		verify(metaDataResultSet).close();
 		verify(columnsResultSet).close();
+	}
+
+	@Test
+	void overlappingDeclaredAndGeneratedKeyColumnsAreRejected() throws Exception {
+		initializeTwoColumnCustomersTable();
+		context.setTableName("customers");
+
+		assertThatExceptionOfType(InvalidDataAccessApiUsageException.class)
+				.isThrownBy(() -> context.processMetaData(
+						dataSource, List.of("id", "name"), new String[] { "id" }))
+				.withMessage("Declared columns [id] must not overlap with generated key columns");
+	}
+
+	@Test
+	void overlappingDeclaredAndGeneratedKeyColumnsAreRejectedRegardlessOfCase() throws Exception {
+		initializeTwoColumnCustomersTable();
+		context.setTableName("customers");
+
+		assertThatExceptionOfType(InvalidDataAccessApiUsageException.class)
+				.isThrownBy(() -> context.processMetaData(
+						dataSource, List.of("ID", "name"), new String[] { "id" }))
+				.withMessage("Declared columns [ID] must not overlap with generated key columns");
+	}
+
+	@Test
+	void declaredColumnsWithoutOverlapAreUsedAsIs() throws Exception {
+		initializeTwoColumnCustomersTable();
+		MapSqlParameterSource map = new MapSqlParameterSource();
+		map.addValue("name", "Sven");
+		String[] keyCols = new String[] { "id" };
+		context.setTableName("customers");
+		context.processMetaData(dataSource, List.of("name"), keyCols);
+		List<Object> values = context.matchInParameterValuesWithInsertColumns(map);
+		String insertString = context.createInsertString(keyCols);
+
+		assertThat(insertString).isEqualTo("INSERT INTO customers (name) VALUES(?)");
+		assertThat(values).containsExactly("Sven");
+	}
+
+	private void initializeTwoColumnCustomersTable() throws Exception {
+		ResultSet metaDataResultSet = mock();
+		given(metaDataResultSet.next()).willReturn(true, false);
+		given(metaDataResultSet.getString("TABLE_SCHEM")).willReturn("me");
+		given(metaDataResultSet.getString("TABLE_NAME")).willReturn("customers");
+		given(metaDataResultSet.getString("TABLE_TYPE")).willReturn("TABLE");
+
+		ResultSet columnsResultSet = mock();
+		given(columnsResultSet.next()).willReturn(true, true, false);
+		given(columnsResultSet.getString("COLUMN_NAME")).willReturn("id", "name");
+		given(columnsResultSet.getInt("DATA_TYPE")).willReturn(Types.INTEGER, Types.VARCHAR);
+		given(columnsResultSet.getBoolean("NULLABLE")).willReturn(false, true);
+
+		given(databaseMetaData.getDatabaseProductName()).willReturn("MyDB");
+		given(databaseMetaData.getDatabaseProductVersion()).willReturn("1.0");
+		given(databaseMetaData.getUserName()).willReturn("me");
+		given(databaseMetaData.storesLowerCaseIdentifiers()).willReturn(true);
+		given(databaseMetaData.getTables(null, null, "customers", null)).willReturn(metaDataResultSet);
+		given(databaseMetaData.getColumns(null, "me", "customers", null)).willReturn(columnsResultSet);
 	}
 
 }


### PR DESCRIPTION
## Overview

`TableMetaDataContext.reconcileColumnsToUse()` excludes generated key columns from the auto-discovered column list, but when columns are declared explicitly via `SimpleJdbcInsert.usingColumns(...)`, a column also declared via `usingGeneratedKeyColumns(...)` was not excluded from that declared list. This leaves the generated insert SQL out of sync with the values/types arrays bound to it, causing a parameter count mismatch at execution time whenever a column is declared both ways.

## Problem

`usingColumns("id", "name")` combined with `usingGeneratedKeyColumns("id")`:

```java
protected List<String> reconcileColumnsToUse(List<String> declaredColumns, String[] generatedKeyNames) {
    if (generatedKeyNames.length > 0) {
        this.generatedKeyColumnsUsed = true;
    }
    if (!declaredColumns.isEmpty()) {
        return new ArrayList<>(declaredColumns);
    }
    ...
}
```

returns `["id", "name"]` unfiltered when `declaredColumns` is non-empty, while the auto-discovery branch below it already filters out generated key names. `createInsertString()` independently filters `generatedKeyNames` when building the SQL, so the insert statement only gets a placeholder for `name`:

```
INSERT INTO customers (name) VALUES(?)
```

but `matchInParameterValuesWithInsertColumns(...)` and `createInsertTypes()` both iterate the unfiltered `tableColumns` (= the declared columns, size 2), producing values/types arrays of size 2. The placeholder count (1) and the bound value count (2) diverge, and the JDBC driver rejects execution with a parameter index error.

## Fix

Apply the same generated-key filter to the declared-columns branch that the auto-discovery branch already uses:

```java
protected List<String> reconcileColumnsToUse(List<String> declaredColumns, String[] generatedKeyNames) {
    if (generatedKeyNames.length > 0) {
        this.generatedKeyColumnsUsed = true;
    }
    Set<String> keys = CollectionUtils.newLinkedHashSet(generatedKeyNames.length);
    for (String key : generatedKeyNames) {
        keys.add(key.toUpperCase(Locale.ROOT));
    }
    if (!declaredColumns.isEmpty()) {
        List<String> columns = new ArrayList<>();
        for (String column : declaredColumns) {
            if (!keys.contains(column.toUpperCase(Locale.ROOT))) {
                columns.add(column);
            }
        }
        return columns;
    }
    ...
}
```

This makes `tableColumns` — the single source consumed by `createInsertString()`, `createInsertTypes()`, and `matchInParameterValuesWithInsertColumns(...)` — consistently exclude generated key columns regardless of whether they came from auto-discovery or an explicit `usingColumns(...)` declaration. Added regression tests covering the partial-overlap, full-overlap (declared columns consist entirely of generated keys), and case-insensitive overlap cases.

## Note on impact

This changes behavior for the specific combination of declaring a column via both `usingColumns(...)` and `usingGeneratedKeyColumns(...)` — previously that combination always failed at execution time, so no working code should depend on the old behavior. That said, it is a behavior change to a `protected` extension point (`reconcileColumnsToUse`), so I want to flag it explicitly in case there's a reason to prefer a different approach (e.g. rejecting the overlap explicitly instead of silently excluding it) — happy to adjust if so.