### PR TITLE
Support arbitrary levels of nested class names in `ClassUtils.forName()`

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/ClassUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ClassUtils.java
@@ -67,6 +67,7 @@ import org.springframework.lang.Contract;
  * @author Sam Brannen
  * @author Sebastien Deleuze
  * @author Sungbin Yang
+ * @author Chengang Guan
  * @since 1.1
  * @see TypeUtils
  * @see ReflectionUtils
@@ -308,16 +309,27 @@ public abstract class ClassUtils {
 			return Class.forName(name, false, clToUse);
 		}
 		catch (ClassNotFoundException ex) {
-			int lastDotIndex = name.lastIndexOf(PACKAGE_SEPARATOR);
-			int previousDotIndex = name.lastIndexOf(PACKAGE_SEPARATOR, lastDotIndex - 1);
-			if (lastDotIndex != -1 && previousDotIndex != -1 && Character.isUpperCase(name.charAt(previousDotIndex + 1))) {
-				String nestedClassName =
-						name.substring(0, lastDotIndex) + NESTED_CLASS_SEPARATOR + name.substring(lastDotIndex + 1);
-				try {
-					return Class.forName(nestedClassName, false, clToUse);
+			if (name.lastIndexOf(NESTED_CLASS_SEPARATOR) > 0) {
+				// not java source style
+				throw ex;
+			}
+			String curName = name;
+			for (;;) {
+				int lastDotIndex = curName.lastIndexOf(PACKAGE_SEPARATOR);
+				int previousDotIndex = curName.lastIndexOf(PACKAGE_SEPARATOR, lastDotIndex - 1);
+				if (lastDotIndex != -1 && previousDotIndex != -1 &&
+						Character.isUpperCase(curName.charAt(previousDotIndex + 1))) {
+					curName = curName.substring(0, lastDotIndex) + NESTED_CLASS_SEPARATOR +
+							curName.substring(lastDotIndex + 1);
+					try {
+						return Class.forName(curName, false, clToUse);
+					}
+					catch (ClassNotFoundException ex2) {
+						// Swallow - let original exception get through
+					}
 				}
-				catch (ClassNotFoundException ex2) {
-					// Swallow - let original exception get through
+				else {
+					break;
 				}
 			}
 			throw ex;

--- a/spring-core/src/main/java/org/springframework/util/ClassUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ClassUtils.java
@@ -309,7 +309,7 @@ public abstract class ClassUtils {
 			return Class.forName(name, false, clToUse);
 		}
 		catch (ClassNotFoundException ex) {
-			if (name.charAt(name.length() - 1) != PACKAGE_SEPARATOR) {
+			if (!name.isEmpty() && name.charAt(name.length() - 1) != PACKAGE_SEPARATOR) {
 				StringBuilder nestedClassName = new StringBuilder(name);
 				int lastDotIndex = -1;
 				for (int i = nestedClassName.length() - 1; i >= 0; i--) {

--- a/spring-core/src/main/java/org/springframework/util/ClassUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ClassUtils.java
@@ -273,6 +273,10 @@ public abstract class ClassUtils {
 	 * for primitives (for example, "int") and array class names (for example, "String[]").
 	 * Furthermore, it is also capable of resolving nested class names in Java source
 	 * style (for example, "java.lang.Thread.State" instead of "java.lang.Thread$State").
+	 * <p>Note: When using the Java source style, it assumes standard naming conventions,
+	 * package names all lowercase and class names starting with uppercase. If your class
+	 * or package name deviates from these conventions, use the fully qualified binary
+	 * name instead to ensure correct resolution.
 	 * @param name the name of the Class
 	 * @param classLoader the class loader to use
 	 * (can be {@code null}, which indicates the default class loader)

--- a/spring-core/src/main/java/org/springframework/util/ClassUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ClassUtils.java
@@ -312,7 +312,8 @@ public abstract class ClassUtils {
 			if (!name.isEmpty() && name.charAt(name.length() - 1) != PACKAGE_SEPARATOR) {
 				StringBuilder nestedClassName = new StringBuilder(name);
 				int lastDotIndex = -1;
-				for (int i = nestedClassName.length() - 1; i >= 0; i--) {
+				int i = nestedClassName.length() - 1;
+				for (; i >= 0; i--) {
 					if (nestedClassName.charAt(i) == PACKAGE_SEPARATOR) {
 						char next = nestedClassName.charAt(i + 1);
 						if (Character.isUpperCase(next)) {
@@ -331,6 +332,10 @@ public abstract class ClassUtils {
 							break;
 						}
 					}
+				}
+				if (i == -1 && lastDotIndex != -1 && !Character.isUpperCase(nestedClassName.charAt(0))) {
+					// Single package name, such as a.ClassA
+					nestedClassName.setCharAt(lastDotIndex, PACKAGE_SEPARATOR);
 				}
 				try {
 					return Class.forName(nestedClassName.toString(), false, clToUse);

--- a/spring-core/src/main/java/org/springframework/util/ClassUtils.java
+++ b/spring-core/src/main/java/org/springframework/util/ClassUtils.java
@@ -309,27 +309,34 @@ public abstract class ClassUtils {
 			return Class.forName(name, false, clToUse);
 		}
 		catch (ClassNotFoundException ex) {
-			if (name.lastIndexOf(NESTED_CLASS_SEPARATOR) > 0) {
-				// not java source style
-				throw ex;
-			}
-			String curName = name;
-			for (;;) {
-				int lastDotIndex = curName.lastIndexOf(PACKAGE_SEPARATOR);
-				int previousDotIndex = curName.lastIndexOf(PACKAGE_SEPARATOR, lastDotIndex - 1);
-				if (lastDotIndex != -1 && previousDotIndex != -1 &&
-						Character.isUpperCase(curName.charAt(previousDotIndex + 1))) {
-					curName = curName.substring(0, lastDotIndex) + NESTED_CLASS_SEPARATOR +
-							curName.substring(lastDotIndex + 1);
-					try {
-						return Class.forName(curName, false, clToUse);
-					}
-					catch (ClassNotFoundException ex2) {
-						// Swallow - let original exception get through
+			if (name.charAt(name.length() - 1) != PACKAGE_SEPARATOR) {
+				StringBuilder nestedClassName = new StringBuilder(name);
+				int lastDotIndex = -1;
+				for (int i = nestedClassName.length() - 1; i >= 0; i--) {
+					if (nestedClassName.charAt(i) == PACKAGE_SEPARATOR) {
+						char next = nestedClassName.charAt(i + 1);
+						if (Character.isUpperCase(next)) {
+							lastDotIndex = i;
+							nestedClassName.setCharAt(i, NESTED_CLASS_SEPARATOR);
+						}
+						else {
+							// Package name has been encountered
+							if (lastDotIndex == -1) {
+								throw ex;
+							}
+							else {
+								// Replace the $ before the top-level class name with dot(.)
+								nestedClassName.setCharAt(lastDotIndex, PACKAGE_SEPARATOR);
+							}
+							break;
+						}
 					}
 				}
-				else {
-					break;
+				try {
+					return Class.forName(nestedClassName.toString(), false, clToUse);
+				}
+				catch (ClassNotFoundException ex2) {
+					// Swallow - let original exception get through
 				}
 			}
 			throw ex;

--- a/spring-core/src/test/java/a/$Cls.java
+++ b/spring-core/src/test/java/a/$Cls.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package a;
+
+/**
+ * Test class for {@code org.springframework.util.ClassUtilsTests}.
+ *
+ * <p>The use case for this test class requires that the class name is non-standard.
+ *
+ * @author Chengang Guan
+ */
+public class $Cls {
+
+	public static class Inner {
+	}
+
+}

--- a/spring-core/src/test/java/a/Upper/UpperPackageCls.java
+++ b/spring-core/src/test/java/a/Upper/UpperPackageCls.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package a.Upper;
+
+/**
+ * Test class for {@code org.springframework.util.ClassUtilsTests}.
+ *
+ * <p>The use case for this test class requires that the package name is in uppercase.
+ *
+ * @author Chengang Guan
+ */
+public class UpperPackageCls {
+
+	public static class Inner {
+	}
+
+}

--- a/spring-core/src/test/java/a/_Cls.java
+++ b/spring-core/src/test/java/a/_Cls.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package a;
+
+/**
+ * Test class for {@code org.springframework.util.ClassUtilsTests}.
+ *
+ * <p>The use case for this test class requires that the class name is non-standard.
+ *
+ * @author Chengang Guan
+ */
+public class _Cls {
+
+	public static class Inner {
+	}
+
+}

--- a/spring-core/src/test/java/a/lowerStartCls.java
+++ b/spring-core/src/test/java/a/lowerStartCls.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package a;
+
+/**
+ * Test class for {@code org.springframework.util.ClassUtilsTests}.
+ *
+ * <p>The use case for this test class requires that the class name is non-standard.
+ *
+ * @author Chengang Guan
+ */
+public class lowerStartCls {
+
+	public static class Inner {
+	}
+
+}

--- a/spring-core/src/test/java/org/springframework/util/ClassUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/ClassUtilsTests.java
@@ -54,6 +54,7 @@ import org.springframework.tests.sample.objects.ITestObject;
 import org.springframework.tests.sample.objects.TestObject;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Tests for {@link ClassUtils}.
@@ -63,6 +64,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Rob Harrop
  * @author Rick Evans
  * @author Sam Brannen
+ * @author Chengang Guan
  */
 class ClassUtilsTests {
 
@@ -99,6 +101,20 @@ class ClassUtilsTests {
 		assertThat(ClassHavingNestedClass.class.getPackageName().length()).isEqualTo(1);
 		assertThat(ClassUtils.forName("a.ClassHavingNestedClass$NestedClass", classLoader)).isEqualTo(ClassHavingNestedClass.NestedClass.class);
 		assertThat(ClassUtils.forName("a.ClassHavingNestedClass.NestedClass", classLoader)).isEqualTo(ClassHavingNestedClass.NestedClass.class);
+	}
+
+	@Test
+	void forNamesWithDeepNestingTypes() throws ClassNotFoundException {
+		assertThat(ClassUtils.forName("org.springframework.util.ClassUtilsTests.NestedClass.NestedClassLevel1", classLoader))
+				.isEqualTo(NestedClass.NestedClassLevel1.class);
+		assertThat(ClassUtils.forName("org.springframework.util.ClassUtilsTests.NestedClass.NestedClassLevel1.NestedClassLevel2", classLoader))
+				.isEqualTo(NestedClass.NestedClassLevel1.NestedClassLevel2.class);
+		assertThat(ClassUtils.forName("org.springframework.util.ClassUtilsTests$NestedClass$NestedClassLevel1$NestedClassLevel2", classLoader))
+				.isEqualTo(NestedClass.NestedClassLevel1.NestedClassLevel2.class);
+		assertThatThrownBy(() -> ClassUtils.forName("org.springframework.util.ClassUtilsTests.NestedClass$NestedClassLevel1", classLoader))
+				.isInstanceOf(ClassNotFoundException.class);
+		assertThatThrownBy(() -> ClassUtils.forName("org.springframework.util.ClassUtilsTests$NestedClass.NestedClassLevel1", classLoader))
+				.isInstanceOf(ClassNotFoundException.class);
 	}
 
 	@Test
@@ -979,6 +995,12 @@ class ClassUtilsTests {
 	}
 
 	public static class NestedClass {
+
+		public static class NestedClassLevel1 {
+
+			public static class NestedClassLevel2 {
+			}
+		}
 
 		static boolean noArgCalled;
 		static boolean argCalled;

--- a/spring-core/src/test/java/org/springframework/util/ClassUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/ClassUtilsTests.java
@@ -134,6 +134,18 @@ class ClassUtilsTests {
 	}
 
 	@Test
+	void forNameWithNonStandardClassName() throws ClassNotFoundException {
+		assertThat(ClassUtils.forName("a.Upper.UpperPackageCls$Inner", classLoader)).isEqualTo(a.Upper.UpperPackageCls.Inner.class);
+		assertThatThrownBy(() -> ClassUtils.forName("a.Upper.UpperPackageCls.Inner", classLoader)).isInstanceOf(ClassNotFoundException.class);
+		assertThat(ClassUtils.forName("a.$Cls$Inner", classLoader)).isEqualTo(a.$Cls.Inner.class);
+		assertThatThrownBy(() -> ClassUtils.forName("a.$Cls.Inner", classLoader)).isInstanceOf(ClassNotFoundException.class);
+		assertThat(ClassUtils.forName("a._Cls$Inner", classLoader)).isEqualTo(a._Cls.Inner.class);
+		assertThatThrownBy(() -> ClassUtils.forName("a._Cls.Inner", classLoader)).isInstanceOf(ClassNotFoundException.class);
+		assertThat(ClassUtils.forName("a.lowerStartCls$Inner", classLoader)).isEqualTo(a.lowerStartCls.Inner.class);
+		assertThatThrownBy(() -> ClassUtils.forName("a.lowerStartCls.Inner", classLoader)).isInstanceOf(ClassNotFoundException.class);
+	}
+
+	@Test
 	void forNameWithPrimitiveClasses() throws ClassNotFoundException {
 		assertThat(ClassUtils.forName("boolean", classLoader)).isEqualTo(boolean.class);
 		assertThat(ClassUtils.forName("byte", classLoader)).isEqualTo(byte.class);

--- a/spring-core/src/test/java/org/springframework/util/ClassUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/ClassUtilsTests.java
@@ -123,10 +123,14 @@ class ClassUtilsTests {
 		String endWithDotClassName = "org.springframework.util.ClassUtilsTests.";
 		String noDotClassName = "ClassUtilsTests";
 		String packNameOnly = "org.springframework.util";
+		String emptyClassName = "";
+		String spaceClassName = " ";
 
 		assertThatThrownBy(() -> ClassUtils.forName(endWithDotClassName, classLoader)).isInstanceOf(ClassNotFoundException.class);
 		assertThatThrownBy(() -> ClassUtils.forName(noDotClassName, classLoader)).isInstanceOf(ClassNotFoundException.class);
 		assertThatThrownBy(() -> ClassUtils.forName(packNameOnly, classLoader)).isInstanceOf(ClassNotFoundException.class);
+		assertThatThrownBy(() -> ClassUtils.forName(emptyClassName, classLoader)).isInstanceOf(ClassNotFoundException.class);
+		assertThatThrownBy(() -> ClassUtils.forName(spaceClassName, classLoader)).isInstanceOf(ClassNotFoundException.class);
 	}
 
 	@Test

--- a/spring-core/src/test/java/org/springframework/util/ClassUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/util/ClassUtilsTests.java
@@ -104,17 +104,29 @@ class ClassUtilsTests {
 	}
 
 	@Test
-	void forNamesWithDeepNestingTypes() throws ClassNotFoundException {
-		assertThat(ClassUtils.forName("org.springframework.util.ClassUtilsTests.NestedClass.NestedClassLevel1", classLoader))
-				.isEqualTo(NestedClass.NestedClassLevel1.class);
-		assertThat(ClassUtils.forName("org.springframework.util.ClassUtilsTests.NestedClass.NestedClassLevel1.NestedClassLevel2", classLoader))
-				.isEqualTo(NestedClass.NestedClassLevel1.NestedClassLevel2.class);
-		assertThat(ClassUtils.forName("org.springframework.util.ClassUtilsTests$NestedClass$NestedClassLevel1$NestedClassLevel2", classLoader))
-				.isEqualTo(NestedClass.NestedClassLevel1.NestedClassLevel2.class);
-		assertThatThrownBy(() -> ClassUtils.forName("org.springframework.util.ClassUtilsTests.NestedClass$NestedClassLevel1", classLoader))
-				.isInstanceOf(ClassNotFoundException.class);
-		assertThatThrownBy(() -> ClassUtils.forName("org.springframework.util.ClassUtilsTests$NestedClass.NestedClassLevel1", classLoader))
-				.isInstanceOf(ClassNotFoundException.class);
+	void forNameWithDeepNestingTypes() throws ClassNotFoundException {
+		String javaSourceStyle = "org.springframework.util.ClassUtilsTests.NestedClass.NestedClassLevel1";
+		String deepNestingJavaSourceStyle = "org.springframework.util.ClassUtilsTests.NestedClass.NestedClassLevel1.NestedClassLevel2";
+		String mixedStyle1 = "org.springframework.util.ClassUtilsTests$NestedClass.NestedClassLevel1.NestedClassLevel2";
+		String mixedStyle2 = "org.springframework.util.ClassUtilsTests.NestedClass$NestedClassLevel1.NestedClassLevel2";
+		String mixedStyle3 = "org.springframework.util.ClassUtilsTests.NestedClass.NestedClassLevel1$NestedClassLevel2";
+
+		assertThat(ClassUtils.forName(javaSourceStyle, classLoader)).isEqualTo(NestedClass.NestedClassLevel1.class);
+		assertThat(ClassUtils.forName(deepNestingJavaSourceStyle, classLoader)).isEqualTo(NestedClass.NestedClassLevel1.NestedClassLevel2.class);
+		assertThat(ClassUtils.forName(mixedStyle1, classLoader)).isEqualTo(NestedClass.NestedClassLevel1.NestedClassLevel2.class);
+		assertThat(ClassUtils.forName(mixedStyle2, classLoader)).isEqualTo(NestedClass.NestedClassLevel1.NestedClassLevel2.class);
+		assertThat(ClassUtils.forName(mixedStyle3, classLoader)).isEqualTo(NestedClass.NestedClassLevel1.NestedClassLevel2.class);
+	}
+
+	@Test
+	void forNameWithInvalidClassName() throws ClassNotFoundException {
+		String endWithDotClassName = "org.springframework.util.ClassUtilsTests.";
+		String noDotClassName = "ClassUtilsTests";
+		String packNameOnly = "org.springframework.util";
+
+		assertThatThrownBy(() -> ClassUtils.forName(endWithDotClassName, classLoader)).isInstanceOf(ClassNotFoundException.class);
+		assertThatThrownBy(() -> ClassUtils.forName(noDotClassName, classLoader)).isInstanceOf(ClassNotFoundException.class);
+		assertThatThrownBy(() -> ClassUtils.forName(packNameOnly, classLoader)).isInstanceOf(ClassNotFoundException.class);
 	}
 
 	@Test


### PR DESCRIPTION
Prior to this commit, `ClassUtils#forName` only performed a single-level conversion when resolving nested class names in Java source style (e.g. "`java.lang.Thread.State`"). For multi-level nested classes such as "`com.example.Outer.Middle.Inner`", the method would fail to resolve the actual class "`com.example.Outer$Middle$Inner`" because only the last dot was converted to a dollar sign.

This commit improves the resolution by introducing a loop that iteratively converts dots to dollar signs from right to left, until the class is found or no further conversion is possible. Additionally, if the given name already contains a dollar sign, the method now fails fast without attempting unnecessary conversions.