### PR TITLE
Preserve bracketed YAML map keys

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlProcessor.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/config/YamlProcessor.java
@@ -247,7 +247,8 @@ public abstract class YamlProcessor {
 				value = asMap(value);
 			}
 			if (key instanceof CharSequence) {
-				result.put(key.toString(), value);
+				String keyString = key.toString();
+				result.put((keyString.startsWith("[") ? "[" + keyString + "]" : keyString), value);
 			}
 			else {
 				// It has to be a map key in this case

--- a/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlPropertiesFactoryBeanTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/config/YamlPropertiesFactoryBeanTests.java
@@ -227,6 +227,21 @@ class YamlPropertiesFactoryBeanTests {
 	}
 
 	@Test
+	void loadNestedMapWithBracketedKey() {
+		YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+		factory.setResources(new ByteArrayResource("""
+				root:
+				  webservices:
+				    "[domain.test:8080]":
+				      - username: me
+				        password: mypassword
+				""".getBytes()));
+		Properties properties = factory.getObject();
+		assertThat(properties.getProperty("root.webservices[[domain.test:8080]][0].username")).isEqualTo("me");
+		assertThat(properties.getProperty("root.webservices[[domain.test:8080]][0].password")).isEqualTo("mypassword");
+	}
+
+	@Test
 	@SuppressWarnings("unchecked")
 	void yaml() {
 		Yaml yaml = new Yaml();


### PR DESCRIPTION
Closes gh-27020

This preserves YAML map keys that already start with `[` by flattening them as literal map keys instead of treating them like collection indexes.

Verification:
- `./gradlew :spring-beans:test --tests org.springframework.beans.factory.config.YamlPropertiesFactoryBeanTests.loadNestedMapWithBracketedKey`
- `./gradlew :spring-beans:test --tests org.springframework.beans.factory.config.YamlPropertiesFactoryBeanTests`
- `./gradlew :spring-beans:test --tests org.springframework.beans.factory.config.YamlProcessorTests`
