### PR TITLE
Fix `BeanFactory.getBean(String, ParameterizedTypeReference)` to respect AOP proxy

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/AbstractBeanFactory.java
@@ -208,7 +208,7 @@ public abstract class AbstractBeanFactory extends FactoryBeanRegistrySupport imp
 	public <T> T getBean(String name, ParameterizedTypeReference<T> typeReference) throws BeansException {
 		Object bean = getBean(name);
 		Type requiredType = typeReference.getType();
-		if (!ResolvableType.forType(requiredType).isInstance(bean)) {
+		if (!isTypeMatch(name, ResolvableType.forType(requiredType), true)) {
 			throw new BeanNotOfRequiredTypeException(name, requiredType, bean.getClass());
 		}
 		return (T) bean;

--- a/spring-context/src/test/java/org/springframework/cache/config/ExpressionCachingIntegrationTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/config/ExpressionCachingIntegrationTests.java
@@ -27,20 +27,21 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.ParameterizedTypeReference;
 
 /**
  * @author Stephane Nicoll
+ * @author Yanming Zhou
  */
 class ExpressionCachingIntegrationTests {
 
 	@Test  // SPR-11692
-	@SuppressWarnings("unchecked")
 	void expressionIsCacheBasedOnActualMethod() {
 		ConfigurableApplicationContext context =
 				new AnnotationConfigApplicationContext(SharedConfig.class, Spr11692Config.class);
 
-		BaseDao<User> userDao = (BaseDao<User>) context.getBean("userDao");
-		BaseDao<Order> orderDao = (BaseDao<Order>) context.getBean("orderDao");
+		BaseDao<User> userDao = context.getBean("userDao", new ParameterizedTypeReference<>() {});
+		BaseDao<Order> orderDao = context.getBean("orderDao", new ParameterizedTypeReference<>() {});
 
 		userDao.persist(new User("1"));
 		orderDao.persist(new Order("2"));


### PR DESCRIPTION
## Overview

Before this commit, the implementation uses `ResolvableType::isInstance` which doesn't take JDK proxy into account, it fails if `proxyTargetClass = false`:

```
Bean named 'userDao' is expected to be of type 'org.springframework.cache.config.ExpressionCachingIntegrationTests$BaseDao<org.springframework.cache.config.ExpressionCachingIntegrationTests$User>' but was actually of type 'org.springframework.cache.config.$Proxy53'
org.springframework.beans.factory.BeanNotOfRequiredTypeException: Bean named 'userDao' is expected to be of type 'org.springframework.cache.config.ExpressionCachingIntegrationTests$BaseDao<org.springframework.cache.config.ExpressionCachingIntegrationTests$User>' but was actually of type 'org.springframework.cache.config.$Proxy53'
	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:212)
	at org.springframework.context.support.AbstractApplicationContext.getBean(AbstractApplicationContext.java:1312)
	at org.springframework.cache.config.ExpressionCachingIntegrationTests.expressionIsCacheBasedOnActualMethod(ExpressionCachingIntegrationTests.java:42)
```

## Related Issues

- #34687
