### PR TITLE
Reset TwoByteMatcher partial match on mismatching byte

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/buffer/DataBufferUtils.java
+++ b/spring-core/src/main/java/org/springframework/core/io/buffer/DataBufferUtils.java
@@ -917,6 +917,14 @@ public abstract class DataBufferUtils {
 			super(delimiter);
 			Assert.isTrue(delimiter.length == 2, "Expected a 2-byte delimiter");
 		}
+
+		@Override
+		public boolean match(byte b) {
+			if (getMatches() > 0 && b != delimiter()[getMatches()]) {
+				setMatches(0);
+			}
+			return super.match(b);
+		}
 	}
 
 

--- a/spring-core/src/test/java/org/springframework/core/codec/StringDecoderTests.java
+++ b/spring-core/src/test/java/org/springframework/core/codec/StringDecoderTests.java
@@ -154,6 +154,30 @@ class StringDecoderTests extends AbstractDecoderTests<StringDecoder> {
 	}
 
 	@Test
+	void decodePreservesCharacterBeforeLoneNewlineAfterCarriageReturn() {
+		Flux<DataBuffer> input = Flux.just(stringBuffer("a\rXY\nb"));
+
+		testDecode(input, String.class, step -> step
+				.expectNext("a\rXY")
+				.expectNext("b")
+				.expectComplete()
+				.verify());
+	}
+
+	@Test
+	void decodePreservesCharacterAcrossBuffersAfterCarriageReturn() {
+		Flux<DataBuffer> input = Flux.just(
+				stringBuffer("a\r"),
+				stringBuffer("Xb\n")
+		);
+
+		testDecode(input, String.class, step -> step
+				.expectNext("a\rXb")
+				.expectComplete()
+				.verify());
+	}
+
+	@Test
 	void maxInMemoryLimit() {
 		Flux<DataBuffer> input = Flux.just(
 				stringBuffer("abc\n"), stringBuffer("defg\n"),

--- a/spring-core/src/test/java/org/springframework/core/io/buffer/DataBufferUtilsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/io/buffer/DataBufferUtilsTests.java
@@ -1324,6 +1324,48 @@ class DataBufferUtilsTests extends AbstractDataBufferAllocatingTests {
 	}
 
 	@ParameterizedDataBufferAllocatingTest
+	void matcherDoesNotMatchAcrossNonContiguousDelimiterBytes(DataBufferFactory bufferFactory) {
+		super.bufferFactory = bufferFactory;
+
+		DataBuffer buffer = stringBuffer("a\rXY\nb");
+
+		byte[] delims = "\r\n".getBytes(StandardCharsets.UTF_8);
+		DataBufferUtils.Matcher matcher = DataBufferUtils.matcher(delims);
+		int result = matcher.match(buffer);
+		assertThat(result).isEqualTo(-1);
+
+		release(buffer);
+	}
+
+	@ParameterizedDataBufferAllocatingTest
+	void matcherMatchesContiguousTwoByteDelimiter(DataBufferFactory bufferFactory) {
+		super.bufferFactory = bufferFactory;
+
+		DataBuffer buffer = stringBuffer("a\r\nb");
+
+		byte[] delims = "\r\n".getBytes(StandardCharsets.UTF_8);
+		DataBufferUtils.Matcher matcher = DataBufferUtils.matcher(delims);
+		int result = matcher.match(buffer);
+		assertThat(result).isEqualTo(2);
+
+		release(buffer);
+	}
+
+	@ParameterizedDataBufferAllocatingTest
+	void matcherDoesNotMatchAfterRepeatedFirstDelimiterByte(DataBufferFactory bufferFactory) {
+		super.bufferFactory = bufferFactory;
+
+		DataBuffer buffer = stringBuffer("a\r\rX\nb");
+
+		byte[] delims = "\r\n".getBytes(StandardCharsets.UTF_8);
+		DataBufferUtils.Matcher matcher = DataBufferUtils.matcher(delims);
+		int result = matcher.match(buffer);
+		assertThat(result).isEqualTo(-1);
+
+		release(buffer);
+	}
+
+	@ParameterizedDataBufferAllocatingTest
 	void propagateContextByteChannel(DataBufferFactory bufferFactory) throws IOException {
 		Path path = Paths.get(this.resource.getURI());
 		try (SeekableByteChannel out = Files.newByteChannel(this.tempFile, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {


### PR DESCRIPTION
## Overview

`DataBufferUtils.TwoByteMatcher` does not reset its partial-match counter when a byte fails to match after the first delimiter byte has matched. As a result the matcher reports a delimiter match across non-contiguous bytes, which causes `StringDecoder` (and any consumer of `DataBufferUtils.matcher(byte[]...)`) to silently drop a character whenever a lone `\r` appears inside a line. This PR adds the missing reset so the two-byte matcher only matches a contiguous delimiter.

## Problem

`AbstractNestedMatcher.match(byte)` deliberately leaves the fallback (what to do on a mismatch mid-match) to its subclasses: `KnuthMorrisPrattMatcher` overrides `match(byte)` to backtrack via its suffix-prefix table, and `SingleByteMatcher` is stateless. `TwoByteMatcher`, however, inherited the base method without providing any fallback, so after the first delimiter byte matched (`matches == 1`) the counter stayed at 1 across any number of non-matching bytes, and a later occurrence of the second delimiter byte falsely completed the match.

For the default delimiters used by `StringDecoder.allMimeTypes()` (`\r\n` and `\n`), decoding `"a\rXY\nb"`:

| | first line |
|---|---|
| expected | `a\rXY` |
| actual | `a\rX` |

`CompositeMatcher` prefers the longest delimiter that matches at a position, so the false `\r\n` match (length 2) is chosen over the real `\n` (length 1), and the byte before `\n` is consumed as part of the delimiter and lost.

## Fix

`TwoByteMatcher` now overrides `match(byte)` to reset the counter to `0` when the incoming byte is not the expected next delimiter byte, then delegates to `super.match(b)` — mirroring the structure of `KnuthMorrisPrattMatcher` (its `while` loop collapses to a single reset because a two-byte delimiter can only be in a `matches == 1` partial state). A genuine contiguous delimiter is unaffected: when the byte is the expected one the reset is skipped and the match completes.

Added two tests: a unit test asserting `DataBufferUtils.matcher("\r\n")` returns `-1` for non-contiguous input, and a `StringDecoder` test asserting the character before a lone `\n` is preserved.
