### PR TITLE
Add `@Nullable` annotations when treating `Map.remove()` as returning `@Nullable`

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/CompositeMap.java
+++ b/spring-core/src/main/java/org/springframework/util/CompositeMap.java
@@ -117,7 +117,7 @@ final class CompositeMap<K, V extends @Nullable Object> implements Map<K, V> {
 	}
 
 	@Override
-	public V remove(Object key) {
+	public @Nullable V remove(Object key) {
 		V firstResult = this.first.remove(key);
 		V secondResult = this.second.remove(key);
 		if (firstResult != null) {

--- a/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompHeaders.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/simp/stomp/StompHeaders.java
@@ -510,7 +510,7 @@ public class StompHeaders implements MultiValueMap<String, String>, Serializable
 	}
 
 	@Override
-	public List<String> remove(Object key) {
+	public @Nullable List<String> remove(Object key) {
 		return this.headers.remove(key);
 	}
 


### PR DESCRIPTION
The next release of NullAway treats `Map.remove` as returning `@Nullable`, leading to errors at these locations.  Fix them by marking the return type as `@Nullable`.