### PR TITLE
Encode quoted pairs in ContentDisposition name

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
+++ b/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
@@ -172,7 +172,7 @@ public final class ContentDisposition {
 			sb.append(this.type);
 		}
 		if (this.name != null) {
-			sb.append("; name=\"").append(this.name).append('\"');
+			sb.append("; name=\"").append(encodeQuotedPairs(this.name)).append('\"');
 		}
 		if (this.filename != null) {
 			if (this.charset == null || StandardCharsets.US_ASCII.equals(this.charset)) {
@@ -253,7 +253,7 @@ public final class ContentDisposition {
 						part.substring(eqIndex + 2, part.length() - 1) :
 						part.substring(eqIndex + 1));
 				if (attribute.equals("name") ) {
-					name = value;
+					name = (value.indexOf('\\') != -1 ? decodeQuotedPairs(value) : value);
 				}
 				else if (attribute.equals("filename*") ) {
 					int idx1 = value.indexOf('\'');

--- a/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
+++ b/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
@@ -240,6 +240,26 @@ class ContentDispositionTests {
 			assertThat(parsed.toString()).isEqualTo(cd.toString());
 		}
 
+		@Test  // gh-37064
+		void parseFormattedWithNameQuotedPairs() {
+			ContentDisposition cd = ContentDisposition.formData()
+					.name("foo\"bar\\baz")
+					.filename("foo\\bar \"baz\" qux \\\" quux.txt")
+					.build();
+			ContentDisposition parsed = ContentDisposition.parse(cd.toString());
+			assertThat(parsed).isEqualTo(cd);
+			assertThat(parsed.toString()).isEqualTo(cd.toString());
+		}
+
+		@Test  // gh-37064
+		void parseNameWithQuotedPairs() {
+			String header = "form-data; name=\"foo\\\"bar\\\\baz\"; filename=\"x.txt\"";
+			ContentDisposition cd = ContentDisposition.parse(header);
+			assertThat(cd.getName()).isEqualTo("foo\"bar\\baz");
+			assertThat(cd.getFilename()).isEqualTo("x.txt");
+			assertThat(cd.toString()).isEqualTo(header);
+		}
+
 		@Test // gh-30252
 		void parseFormattedWithQuestionMark() {
 			String filename = "filename with ?问号.txt";
@@ -359,6 +379,18 @@ class ContentDispositionTests {
 							.filename("test.txt", StandardCharsets.UTF_16)
 							.build()
 							.toString());
+		}
+
+		@Test  // gh-37064
+		void formatWithNameWithQuotes() {
+			BiConsumer<String, String> tester = (input, output) ->
+					assertThat(ContentDisposition.formData().name(input).build().toString())
+							.isEqualTo("form-data; name=\"" + output + "\"");
+
+			tester.accept("foo\"bar", "foo\\\"bar");
+			tester.accept("foo\\bar", "foo\\\\bar");
+			tester.accept("foo\\\"bar", "foo\\\\\\\"bar");
+			tester.accept("\"foo\"", "\\\"foo\\\"");
 		}
 	}
 


### PR DESCRIPTION
## Overview

Fixes #37064.

`ContentDisposition` already applied quoted-pair encoding/decoding for the `filename` parameter, but the `name` parameter was written and read as a raw quoted string. As a result, a name containing `"` or `\` produced an invalid header and failed to round-trip through `toString()` / `parse()`, which also broke `equals` for otherwise equivalent instances.

## Changes

- Encode `name` with `encodeQuotedPairs` in `toString()`
- Decode `name` with `decodeQuotedPairs` in `parse()` when backslashes are present (same approach as `filename`)
- Add regression tests for formatting, parsing, and build/parse symmetry