### PR TITLE
Fix Javadoc error in ProtobufDecoder

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/protobuf/ProtobufDecoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/protobuf/ProtobufDecoder.java
@@ -299,7 +299,7 @@ public class ProtobufDecoder extends ProtobufCodecSupport implements Decoder<Mes
 		/**
 		 * Read the message size from the given buffer. This method may be
 		 * called multiple times before the message size is fully read.
-		 * @return return the message size, or {@code null} if the data in the
+		 * @return the message size, or {@code null} if the data in the
 		 * input buffer was insufficient
 		 */
 		@Nullable Integer readMessageSize(DataBuffer input);


### PR DESCRIPTION
This pull request fixes a Javadoc error in `ProtobufDecoder.MessageSizeReader.readMessageSize()`, where the `@return` tag is followed by a redundant `return`.

### Motivation

The `@return` tag already renders as "Returns:" in the generated documentation, so the extra word is duplicated in the published API docs:

```
Returns:
return the message size, or null if the data in the input buffer was insufficient
```

The `MessageSizeReader` interface was introduced in 7.0, so this has not appeared in a released version of the reference Javadoc yet.

### Modifications

- Removed the redundant `return` from the `@return` tag in `MessageSizeReader.readMessageSize(DataBuffer)`.

No behavior change intended — this is a documentation-only change.

### Verification

Built the Javadoc locally and confirmed the rendered output in
`spring-web/build/docs/javadoc/org/springframework/http/codec/protobuf/ProtobufDecoder.MessageSizeReader.html`
before and after the change.
