### PR TITLE
Ignore static get/is accessor methods in PropertyDescriptorUtils

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/PropertyDescriptorUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/PropertyDescriptorUtils.java
@@ -19,6 +19,7 @@ package org.springframework.beans;
 import java.beans.IntrospectionException;
 import java.beans.PropertyDescriptor;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
@@ -71,11 +72,13 @@ abstract class PropertyDescriptorUtils {
 				setter = true;
 				nameIndex = 3;
 			}
-			else if (methodName.startsWith("get") && method.getParameterCount() == 0 && method.getReturnType() != void.class) {
+			else if (methodName.startsWith("get") && method.getParameterCount() == 0 &&
+					method.getReturnType() != void.class && !Modifier.isStatic(method.getModifiers())) {
 				setter = false;
 				nameIndex = 3;
 			}
-			else if (methodName.startsWith("is") && method.getParameterCount() == 0 && method.getReturnType() == boolean.class) {
+			else if (methodName.startsWith("is") && method.getParameterCount() == 0 &&
+					method.getReturnType() == boolean.class && !Modifier.isStatic(method.getModifiers())) {
 				setter = false;
 				nameIndex = 2;
 			}

--- a/spring-beans/src/test/java/org/springframework/beans/PropertyDescriptorUtilsPropertyResolutionTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/PropertyDescriptorUtilsPropertyResolutionTests.java
@@ -70,6 +70,13 @@ class PropertyDescriptorUtilsPropertyResolutionTests {
 		}
 
 		@Test
+		void classWithStaticGetters() {
+			var pdMap = resolver.resolve(ClassWithStaticGetters.class);
+
+			assertThat(pdMap).containsOnlyKeys("class");
+		}
+
+		@Test
 		void classWithOnlySetter() {
 			var pdMap = resolver.resolve(ClassWithOnlySetter.class);
 
@@ -131,6 +138,17 @@ class PropertyDescriptorUtilsPropertyResolutionTests {
 
 			public Number getId() {
 				return 42;
+			}
+		}
+
+		static class ClassWithStaticGetters {
+
+			public static Long getId() {
+				return 42L;
+			}
+
+			public static boolean isActive() {
+				return true;
 			}
 		}
 


### PR DESCRIPTION
## Summary

Static `get...` and `is...` methods are currently discovered as JavaBeans properties by Spring's basic property introspection.

This change excludes static getter methods, aligning Spring's behavior with the standard JDK `Introspector`.

Closes #37068 

## Root cause

Spring Framework 6.0 replaced the previous `Introspector`-based property discovery with the reflection-based `PropertyDescriptorUtils.determineBasicProperties()` implementation.

The basic property discovery logic validates accessor names, parameter counts, and return types, but did not exclude static getter methods. Consequently, methods such as `getInstance()`, `getBean()`, or `isActive()` could be exposed as properties despite not operating on a bean instance.

## Changes

- Exclude static `get...` methods from basic property discovery.
- Exclude static `is...` methods from basic property discovery.
- Add regression coverage for both getter forms.
- Preserve Spring's existing support for static setter methods.

Static setters are intentionally unaffected since their support is an existing compatibility requirement covered by `BeanWrapperTests.cornerSpr10115`.

## Before-and-after verification

### Before the fix

To verify that the regression test detects the original behavior, the new test was applied without the production change and run with:

```
./gradlew :spring-beans:test \
    --tests org.springframework.beans.PropertyDescriptorUtilsPropertyResolutionTests
```

#### Outcome

The test failed for Spring's `BasicPropertiesResolver`.

The resolver incorrectly returned property descriptors for the static getter methods:

- `getId()` produced the `id` property.
- `isActive()` produced the `active` property.

The assertion expected only the standard `class` property:

```
assertThat(pdMap).containsOnlyKeys("class");
```

Conceptually, the failing result was:

```
Expected property keys:
  ["class"]

Actual property keys:
  ["active", "class", "id"]
```

The same test passed for the standard JDK `Introspector`, demonstrating that the regression was specific to Spring's basic property discovery.

### After the fix

After adding the static-method checks to the `get...` and `is...` getter conditions, the regression test was rerun with:

```
./gradlew :spring-beans:test \
    --tests org.springframework.beans.PropertyDescriptorUtilsPropertyResolutionTests
```

#### Outcome

```
BUILD SUCCESSFUL
```

Both property resolvers now return only the `class` property for the test class:

- Spring's `BasicPropertiesResolver`
- The standard JDK `Introspector`

This confirms that static `get...` and `is...` methods are no longer exposed as JavaBeans properties.

### Static setter compatibility

Spring has existing support for static setter methods, covered by `BeanWrapperTests.cornerSpr10115`. The compatibility test was run together with the regression suite:

```
./gradlew :spring-beans:test \
    --tests org.springframework.beans.PropertyDescriptorUtilsPropertyResolutionTests \
    --tests org.springframework.beans.BeanWrapperTests.cornerSpr10115
```

#### Outcome

```
BUILD SUCCESSFUL
```

This verifies that the fix excludes only static getter methods and does not alter the established static-setter behavior.

### Full module test suite

Finally, the complete `spring-beans` test suite was run:

```
./gradlew :spring-beans:test
```

#### Outcome

```
BUILD SUCCESSFUL

2,256 tests completed
9 skipped
0 failed
```