### PR TITLE
Restrict type variable name fallback to subtype narrowing

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/ResolvableType.java
+++ b/spring-core/src/main/java/org/springframework/core/ResolvableType.java
@@ -963,10 +963,15 @@ public class ResolvableType implements Serializable {
 			if (ownerType != null) {
 				return forType(ownerType, this.variableResolver).resolveVariable(variableToCompare);
 			}
-			// Fallback: comparison by variable name, independent of generic declaration context.
-			for (int i = 0; i < variables.length; i++) {
-				if (ObjectUtils.nullSafeEquals(variables[i].getName(), variableToCompare.getName())) {
-					return forType(typeArguments[i], this.variableResolver);
+			// Fallback: comparison by variable name, limited to a subtype narrowing the
+			// resolved supertype (for example, ArrayList narrowing List<String>). A name
+			// match against an unrelated declaration must not be accepted (gh-36890).
+			if (variableToCompare.getGenericDeclaration() instanceof Class<?> declaringClass &&
+					resolved.isAssignableFrom(declaringClass)) {
+				for (int i = 0; i < variables.length; i++) {
+					if (ObjectUtils.nullSafeEquals(variables[i].getName(), variableToCompare.getName())) {
+						return forType(typeArguments[i], this.variableResolver);
+					}
 				}
 			}
 		}

--- a/spring-core/src/test/java/org/springframework/core/GenericTypeResolverTests.java
+++ b/spring-core/src/test/java/org/springframework/core/GenericTypeResolverTests.java
@@ -266,6 +266,29 @@ class GenericTypeResolverTests {
 		assertThat(resolvedType).isEqualTo(Long.class);
 	}
 
+	@Test  // gh-36890
+	void resolveTypeAgainstSameNamedVariablesInTopLevelDeclarations() {
+		Type resolvedType = resolveType(
+				method(TopCreate.class, "create", Object.class).getGenericParameterTypes()[0], TopController.class);
+		assertThat(resolvedType).isEqualTo(Long.class);
+	}
+
+	@Test  // gh-36890
+	void resolveMethodLevelTypeVariableIsNotShadowedByClassVariable() {
+		Type resolvedType = resolveType(
+				method(TopRepo.class, "convert", Object.class).getGenericReturnType(), TopStringRepo.class);
+		assertThat(resolvedType).isInstanceOf(TypeVariable.class);
+	}
+
+	@Test  // gh-36890
+	void resolveTypeVariableByNameWhenNarrowingParameterizedSupertype() {
+		// A raw subtype narrowing a parameterized supertype must still carry the argument
+		// across by variable name, even though Box<E> and Container<E> are distinct declarations.
+		ResolvableType containerOfString = ResolvableType.forClassWithGenerics(Container.class, String.class);
+		ResolvableType box = ResolvableType.forType(Box.class, containerOfString);
+		assertThat(box.getGeneric().resolve()).isEqualTo(String.class);
+	}
+
 	private static Method method(Class<?> target, String methodName, Class<?>... parameterTypes) {
 		Method method = findMethod(target, methodName, parameterTypes);
 		assertThat(method).describedAs(target.getName() + "#" + methodName).isNotNull();
@@ -522,4 +545,34 @@ class GenericTypeResolverTests {
 	static class Controller implements Search<String, Long>, Create<Long, Long> {
 	}
 
+}
+
+
+interface TopSearch<I, O> {
+}
+
+interface TopCreate<I, O> {
+
+	default O create(I body) {
+		return null;
+	}
+}
+
+class TopController implements TopSearch<String, Long>, TopCreate<Long, Long> {
+}
+
+class TopRepo<T> {
+
+	<T> T convert(Object o) {
+		return null;
+	}
+}
+
+class TopStringRepo extends TopRepo<String> {
+}
+
+interface Container<E> {
+}
+
+class Box<E> implements Container<E> {
 }


### PR DESCRIPTION
## Overview

Follow-up to gh-36890. That fix resolves same-named type variables against the correct declaration for nested types, but the same scenario is still broken for top-level declarations, which is exactly the shape of the originally reported case (a REST controller implementing two generic interfaces).

## Problem

`ResolvableType.resolveVariable(TypeVariable)` falls back to matching type variables purely by name when the parameterized type has no owner type:

```java
Type ownerType = parameterizedType.getOwnerType();
if (ownerType != null) {
    return forType(ownerType, this.variableResolver).resolveVariable(variableToCompare);
}
// Fallback: comparison by variable name, independent of generic declaration context.
for (int i = 0; i < variables.length; i++) {
    if (ObjectUtils.nullSafeEquals(variables[i].getName(), variableToCompare.getName())) {
        return forType(typeArguments[i], this.variableResolver);
    }
}
```

For a nested type the owner recursion returns before the fallback is reached, so gh-36890's regression test (which uses nested types) passes. But a top-level type has a `null` owner type and therefore still falls through to the name-only comparison, matching an unrelated declaration that merely shares a variable name.

Given:

```java
interface TopSearch<I, O> {}
interface TopCreate<I, O> { O create(I body); }
class TopController implements TopSearch<String, Long>, TopCreate<Long, Long> {}
```

resolving `TopCreate`'s `I` against `TopController` returns `String` (from the sibling `TopSearch.I`) instead of `Long`. The identical structure nested inside a class resolves to `Long`, so nested and top-level diverge. The same name-only fallback also lets a class-level type argument leak into a shadowing method-level type variable.

## Fix

Guard the name fallback so it only applies to a genuine subtype narrowing a parameterized supertype (for example `ArrayList` narrowing `List<String>`), which is the one case where matching differently-declared variables by name is legitimate:

```java
if (variableToCompare.getGenericDeclaration() instanceof Class<?> declaringClass &&
        resolved.isAssignableFrom(declaringClass)) {
    for (int i = 0; i < variables.length; i++) {
        if (ObjectUtils.nullSafeEquals(variables[i].getName(), variableToCompare.getName())) {
            return forType(typeArguments[i], this.variableResolver);
        }
    }
}
```

A name match against a sibling declaration or a method-level type variable is no longer accepted.

Added three tests in `GenericTypeResolverTests`: the top-level sibling-interface case, the method-level shadowing case, and a positive test confirming the legitimate subtype-narrowing path still resolves by name. The existing `ResolvableTypeTests.narrow()` and gh-34386/gh-36890 tests continue to pass.
