### PR TITLE
Use HttpHeaders.copyOf in DefaultClientResponseBuilder

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientResponseBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientResponseBuilder.java
@@ -144,7 +144,7 @@ final class DefaultClientResponseBuilder implements ClientResponse.Builder {
 	@SuppressWarnings({"ConstantConditions", "NullAway"})
 	private HttpHeaders getHeaders() {
 		if (this.headers == null) {
-			this.headers = new HttpHeaders(this.originalResponse.headers().asHttpHeaders());
+			this.headers = HttpHeaders.copyOf(this.originalResponse.headers().asHttpHeaders());
 		}
 		return this.headers;
 	}

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/DefaultClientResponseBuilderTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/DefaultClientResponseBuilderTests.java
@@ -86,6 +86,9 @@ class DefaultClientResponseBuilderTests {
 				.cookies(cookies -> cookies.set("baz", ResponseCookie.from("baz", "quux").build()))
 				.build();
 
+		assertThat(otherResponse.headers().asHttpHeaders().getFirst("foo")).isEqualTo("bar");
+		assertThat(otherResponse.headers().asHttpHeaders().getFirst("bar")).isEqualTo("baz");
+		assertThat(otherResponse.cookies().getFirst("baz").getValue()).isEqualTo("qux");
 
 		assertThat(result.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
 		assertThat(result.headers().asHttpHeaders().size()).isEqualTo(3);


### PR DESCRIPTION
Fixes #37086.

`ClientResponse.mutate()` currently modifies the original response's headers because `DefaultClientResponseBuilder` initializes its headers using the `HttpHeaders(HttpHeaders)` constructor, which shares the underlying headers.

This change uses `HttpHeaders.copyOf(...)` so that the builder works with an independent copy of the original response's headers.

A regression test has been added to verify that mutating the builder does not modify the original response's headers or cookies.