### PR TITLE
Add logging operators in DefaultExchangeFunction only when debug is enabled

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ExchangeFunctions.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/ExchangeFunctions.java
@@ -99,10 +99,14 @@ public abstract class ExchangeFunctions {
 			HttpMethod httpMethod = clientRequest.method();
 			URI url = clientRequest.url();
 
-			return this.connector
-					.connect(httpMethod, url, httpRequest -> clientRequest.writeTo(httpRequest, this.strategies))
-					.doOnRequest(n -> logRequest(clientRequest))
-					.doOnCancel(() -> logger.debug(clientRequest.logPrefix() + "Cancel signal (to close connection)"))
+			Mono<ClientHttpResponse> responseMono = this.connector
+					.connect(httpMethod, url, httpRequest -> clientRequest.writeTo(httpRequest, this.strategies));
+			if (logger.isDebugEnabled()) {
+				responseMono = responseMono
+						.doOnRequest(n -> logRequest(clientRequest))
+						.doOnCancel(() -> logger.debug(clientRequest.logPrefix() + "Cancel signal (to close connection)"));
+			}
+			return responseMono
 					.onErrorResume(WebClientUtils.WRAP_EXCEPTION_PREDICATE, t -> wrapException(t, clientRequest))
 					.map(httpResponse -> {
 						String logPrefix = getLogPrefix(clientRequest, httpResponse);


### PR DESCRIPTION
DefaultExchangeFunction.exchange added doOnRequest/doOnCancel logging operators unconditionally, which costs two subscriber wrappers per request even though the log message construction itself is already guarded lazily. Gate the operators on isDebugEnabled(), checked per exchange so runtime log level changes are still honored.