### PR TITLE
Preserve async API version resolver order

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/accept/DefaultApiVersionStrategy.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/accept/DefaultApiVersionStrategy.java
@@ -169,7 +169,7 @@ public class DefaultApiVersionStrategy implements ApiVersionStrategy {
 	@Override
 	public Mono<String> resolveApiVersion(ServerWebExchange exchange) {
 		return Flux.fromIterable(this.versionResolvers)
-				.flatMap(resolver -> resolver instanceof AsyncApiVersionResolver asyncResolver ?
+				.concatMap(resolver -> resolver instanceof AsyncApiVersionResolver asyncResolver ?
 						asyncResolver.resolveVersionAsync(exchange) :
 						Mono.justOrEmpty(resolver.resolveVersion(exchange)))
 				.next();

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/accept/DefaultApiVersionStrategiesTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/accept/DefaultApiVersionStrategiesTests.java
@@ -23,6 +23,7 @@ import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
+import reactor.test.publisher.TestPublisher;
 
 import org.springframework.web.accept.InvalidApiVersionException;
 import org.springframework.web.accept.MissingApiVersionException;
@@ -128,8 +129,40 @@ class DefaultApiVersionStrategiesTests {
 				.withMessage("versionRequired cannot be set to true if a defaultVersion is also configured");
 	}
 
+	@Test
+	void resolveVersionWithResolversInOrder() {
+		TestPublisher<String> firstResolverPublisher = TestPublisher.create();
+		ApiVersionStrategy strategy = apiVersionStrategy(List.of(
+				(AsyncApiVersionResolver) exchange -> firstResolverPublisher.flux().next(),
+				(AsyncApiVersionResolver) exchange -> Mono.just("2.0")));
+
+		StepVerifier.create(strategy.resolveApiVersion(
+					MockServerWebExchange.from(MockServerHttpRequest.get("/"))))
+				.then(() -> firstResolverPublisher.emit("1.0"))
+				.expectNext("1.0")
+				.verifyComplete();
+	}
+
+	@Test
+	void resolveVersionPropagatesErrorFromEarlierResolver() {
+		TestPublisher<String> firstResolverPublisher = TestPublisher.create();
+		ApiVersionStrategy strategy = apiVersionStrategy(List.of(
+				(AsyncApiVersionResolver) exchange -> firstResolverPublisher.flux().next(),
+				(AsyncApiVersionResolver) exchange -> Mono.just("2.0")));
+
+		StepVerifier.create(strategy.resolveApiVersion(
+					MockServerWebExchange.from(MockServerHttpRequest.get("/"))))
+				.then(() -> firstResolverPublisher.error(new IllegalStateException("test")))
+				.expectErrorMessage("test")
+				.verify();
+	}
+
 	private static DefaultApiVersionStrategy apiVersionStrategy() {
 		return apiVersionStrategy(null, false, null);
+	}
+
+	private static DefaultApiVersionStrategy apiVersionStrategy(List<ApiVersionResolver> resolvers) {
+		return new DefaultApiVersionStrategy(resolvers, parser, null, null, false, null, null);
 	}
 
 	private static DefaultApiVersionStrategy apiVersionStrategy(


### PR DESCRIPTION
This fixes reactive API version resolution so that resolver registration order is honored.

`DefaultApiVersionStrategy.resolveApiVersion` currently uses `flatMap`, which subscribes to resolver publishers concurrently. As a result, `next()` selects the first emitted value instead of the first non-empty resolver in the configured list. A later resolver can therefore win when it completes faster, and an error from an earlier resolver can be cancelled after a later resolver emits.

This change uses `concatMap` to subscribe to one resolver at a time. That matches the synchronous `resolveVersion` implementation and the documented first-non-null resolver behavior.

The added tests deterministically verify that:

- an earlier resolver wins even while a later resolver can emit immediately
- an error from an earlier resolver is propagated instead of being masked by a later value

The tests use `TestPublisher` rather than wall-clock delays.

Tests:

- `./gradlew :spring-webflux:test --tests org.springframework.web.reactive.accept.DefaultApiVersionStrategiesTests`
- `./gradlew :spring-webflux:check`