### PR TITLE
Allow null contextPath in ServerHttpRequest.Builder

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/reactive/DefaultServerHttpRequestBuilder.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/DefaultServerHttpRequestBuilder.java
@@ -103,7 +103,7 @@ class DefaultServerHttpRequestBuilder implements ServerHttpRequest.Builder {
 	}
 
 	@Override
-	public ServerHttpRequest.Builder contextPath(String contextPath) {
+	public ServerHttpRequest.Builder contextPath(@Nullable String contextPath) {
 		this.contextPath = contextPath;
 		return this;
 	}

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ServerHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ServerHttpRequest.java
@@ -146,8 +146,10 @@ public interface ServerHttpRequest extends HttpRequest, ReactiveHttpInputMessage
 		 * contextPath} and it must match the start of the path of the URI of
 		 * the request. That means changing the contextPath, implies also
 		 * changing the path via {@link #path(String)}.
+		 * <p>The given value may be {@code null} or empty to indicate there
+		 * is no context path.
 		 */
-		Builder contextPath(String contextPath);
+		Builder contextPath(@Nullable String contextPath);
 
 		/**
 		 * Set or override the specified header values under the given name.

--- a/spring-web/src/test/java/org/springframework/http/server/reactive/ServerHttpRequestTests.java
+++ b/spring-web/src/test/java/org/springframework/http/server/reactive/ServerHttpRequestTests.java
@@ -195,6 +195,16 @@ class ServerHttpRequestTests {
 	}
 
 	@Test
+	void mutateContextPathToNull() throws Exception {
+		ServerHttpRequest request = createRequest("/context/path", "/context");
+
+		ServerHttpRequest mutated = request.mutate().contextPath(null).build();
+		assertThat(mutated.getPath().contextPath().value()).isEmpty();
+		assertThat(mutated.getPath().pathWithinApplication().value()).isEqualTo("/context/path");
+		assertThat(mutated.getURI().getRawPath()).isEqualTo("/context/path");
+	}
+
+	@Test
 	void mutateContextPathWithoutUpdatingPathShouldFail() throws Exception {
 		ServerHttpRequest request = createRequest("/context/path", "/context");
 


### PR DESCRIPTION
closes #37098 