### PR TITLE
Preserve I/O errors in RestClient body extraction

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/DefaultRestClient.java
+++ b/spring-web/src/main/java/org/springframework/web/client/DefaultRestClient.java
@@ -270,6 +270,10 @@ final class DefaultRestClient implements RestClient {
 			else {
 				cause = exc;
 			}
+			if (cause instanceof IOException ioException) {
+				throw new ResourceAccessException("I/O error while extracting response for type [" +
+						ResolvableType.forType(bodyType) + "]", ioException);
+			}
 			throw new RestClientException("Error while extracting response for type [" +
 					ResolvableType.forType(bodyType) + "] and content type [" + contentType + "]", cause);
 		}

--- a/spring-web/src/test/java/org/springframework/web/client/DefaultRestClientTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/DefaultRestClientTests.java
@@ -19,6 +19,8 @@ package org.springframework.web.client;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -31,6 +33,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -38,9 +41,14 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -119,6 +127,80 @@ class DefaultRestClientTests {
 				this.client.get().uri(URL).retrieve()
 						.requiredBody(new ParameterizedTypeReference<String>() {})
 		);
+	}
+
+	@Test // gh-37078
+	void bodyWhenConverterThrowsIOExceptionThenResourceAccessException() throws IOException {
+		mockSentRequest(HttpMethod.GET, URL);
+		mockResponseStatus(HttpStatus.OK);
+		mockResponseBody(BODY, MediaType.TEXT_PLAIN);
+
+		HttpMessageConverter<String> converter = mock();
+		given(converter.canRead(String.class, MediaType.TEXT_PLAIN)).willReturn(true);
+		given(converter.read(eq(String.class), any(HttpInputMessage.class)))
+				.willThrow(new SocketTimeoutException("Read timed out"));
+
+		RestClient client = RestClient.builder()
+				.requestFactory(this.requestFactory)
+				.configureMessageConverters(converters -> converters
+						.disableDefaults()
+						.addCustomConverter(converter))
+				.build();
+
+		assertThatExceptionOfType(ResourceAccessException.class)
+				.isThrownBy(() -> client.get().uri(URL).retrieve().body(String.class))
+				.withMessageContaining("I/O error while extracting response for type")
+				.withMessageNotContaining("content type")
+				.withCauseInstanceOf(SocketTimeoutException.class);
+	}
+
+	@Test // gh-37078
+	void bodyWhenConverterThrowsUncheckedIOExceptionThenResourceAccessException() throws IOException {
+		mockSentRequest(HttpMethod.GET, URL);
+		mockResponseStatus(HttpStatus.OK);
+		mockResponseBody(BODY, MediaType.TEXT_PLAIN);
+
+		HttpMessageConverter<String> converter = mock();
+		given(converter.canRead(String.class, MediaType.TEXT_PLAIN)).willReturn(true);
+		given(converter.read(eq(String.class), any(HttpInputMessage.class)))
+				.willThrow(new UncheckedIOException(new SocketTimeoutException("Read timed out")));
+
+		RestClient client = RestClient.builder()
+				.requestFactory(this.requestFactory)
+				.configureMessageConverters(converters -> converters
+						.disableDefaults()
+						.addCustomConverter(converter))
+				.build();
+
+		assertThatExceptionOfType(ResourceAccessException.class)
+				.isThrownBy(() -> client.get().uri(URL).retrieve().body(String.class))
+				.withMessageContaining("I/O error while extracting response for type")
+				.withCauseInstanceOf(SocketTimeoutException.class);
+	}
+
+	@Test // gh-37078
+	void bodyWhenConverterThrowsHttpMessageNotReadableExceptionThenRestClientException() throws IOException {
+		mockSentRequest(HttpMethod.GET, URL);
+		mockResponseStatus(HttpStatus.OK);
+		mockResponseBody(BODY, MediaType.TEXT_PLAIN);
+
+		HttpMessageConverter<String> converter = mock();
+		given(converter.canRead(String.class, MediaType.TEXT_PLAIN)).willReturn(true);
+		given(converter.read(eq(String.class), any(HttpInputMessage.class)))
+				.willThrow(new HttpMessageNotReadableException("Could not read", this.response));
+
+		RestClient client = RestClient.builder()
+				.requestFactory(this.requestFactory)
+				.configureMessageConverters(converters -> converters
+						.disableDefaults()
+						.addCustomConverter(converter))
+				.build();
+
+		assertThatExceptionOfType(RestClientException.class)
+				.isThrownBy(() -> client.get().uri(URL).retrieve().body(String.class))
+				.isNotInstanceOf(ResourceAccessException.class)
+				.withMessageContaining("content type")
+				.withCauseInstanceOf(HttpMessageNotReadableException.class);
 	}
 
 	@ParameterizedTest(name = "{0}")


### PR DESCRIPTION
## Summary
`DefaultRestClient.readWithMessageConverters` was wrapping `IOException` / `UncheckedIOException` as `RestClientException` with a content-type extraction message, which made socket timeouts look like conversion failures.

I/O causes are now thrown as `ResourceAccessException` (already used elsewhere in this class for I/O). `HttpMessageNotReadableException` keeps the existing content-type message. Backward compatible for callers catching `RestClientException` since `ResourceAccessException` extends it.

Closes gh-37078

## Test plan
- [x] New unit tests in `DefaultRestClientTests` for IOException, UncheckedIOException, and HttpMessageNotReadableException paths
- [x] `./gradlew :spring-web:test --tests DefaultRestClientTests` green
