### PR TITLE
Polish examples in example-classes.adoc and jackson.adoc

### DIFF
--- a/framework-docs/modules/ROOT/pages/core/expressions/example-classes.adoc
+++ b/framework-docs/modules/ROOT/pages/core/expressions/example-classes.adoc
@@ -145,7 +145,7 @@ Kotlin::
 ----
 	package org.spring.samples.spel.inventor
 
-	class PlaceOfBirth(var city: String, var country: String? = null) {
+	class PlaceOfBirth(var city: String, var country: String? = null)
 ----
 ======
 

--- a/framework-docs/modules/ROOT/pages/web/webflux/controller/ann-methods/jackson.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webflux/controller/ann-methods/jackson.adoc
@@ -32,8 +32,8 @@ Java::
 
 	public class User {
 
-		public interface WithoutPasswordView {};
-		public interface WithPasswordView extends WithoutPasswordView {};
+		public interface WithoutPasswordView {}
+		public interface WithPasswordView extends WithoutPasswordView {}
 
 		private String username;
 		private String password;

--- a/framework-docs/modules/ROOT/pages/web/webmvc/mvc-controller/ann-methods/jackson.adoc
+++ b/framework-docs/modules/ROOT/pages/web/webmvc/mvc-controller/ann-methods/jackson.adoc
@@ -31,8 +31,8 @@ Java::
 
 	public class User {
 
-		public interface WithoutPasswordView {};
-		public interface WithPasswordView extends WithoutPasswordView {};
+		public interface WithoutPasswordView {}
+		public interface WithPasswordView extends WithoutPasswordView {}
 
 		private String username;
 		private String password;
@@ -152,7 +152,7 @@ Kotlin::
 		@GetMapping("/user")
 		fun getUser(model: Model): String {
 			model["user"] = User("eric", "7!jd#h23")
-			model[JsonView::class.qualifiedName] = User.WithoutPasswordView::class.java
+			model[JsonView::class.java.name] = User.WithoutPasswordView::class.java
 			return "userView"
 		}
 	}


### PR DESCRIPTION
- Remove unnecessary braces from example-classes.adoc
- Remove unnecessary semicolons from example-classes.adoc

`JsonView::class.qualifiedName` can be null but `ModelExtensions#set` does not accept null. Change to `JsonView::class.java.name` to fix that.

https://github.com/spring-projects/spring-framework/blob/eceebb3077dda9e1b19d73c0398ef022cd91f99c/spring-context/src/main/kotlin/org/springframework/ui/ModelExtensions.kt#L29-L31