### PR TITLE
Fix buffer leak in RSocket SETUP frame handling

### DIFF
--- a/spring-messaging/src/main/java/org/springframework/messaging/rsocket/annotation/support/MessagingRSocket.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/rsocket/annotation/support/MessagingRSocket.java
@@ -103,9 +103,6 @@ class MessagingRSocket implements RSocket {
 	 * @return completion handle for success or error
 	 */
 	public Mono<Void> handleConnectionSetupPayload(ConnectionSetupPayload payload) {
-		// frameDecoder does not apply to connectionSetupPayload
-		// so retain here since handle expects it.
-		payload.retain();
 		return handle(payload, FrameType.SETUP);
 	}
 

--- a/spring-messaging/src/main/java/org/springframework/messaging/rsocket/annotation/support/RSocketMessageHandler.java
+++ b/spring-messaging/src/main/java/org/springframework/messaging/rsocket/annotation/support/RSocketMessageHandler.java
@@ -425,6 +425,7 @@ public class RSocketMessageHandler extends MessageMappingMessageHandler {
 				responder = createResponder(setupPayload, sendingRSocket);
 			}
 			catch (Throwable ex) {
+				setupPayload.release();
 				return Mono.error(ex);
 			}
 			return responder.handleConnectionSetupPayload(setupPayload).then(Mono.just(responder));


### PR DESCRIPTION
Remove the explicit `payload.retain()` call in `MessagingRSocket#handleConnectionSetupPayload` because the setup payload is fully owned by the SocketAcceptor, and `MessagingRSocket#handle` properly strips metadata, wraps the data in a DataBuffer, and eventually releases the initial buffer. The extra `.retain()` caused the underlying Netty buffer reference count to drop to 1 rather than 0 on success.

Additionally, handle early failures in `RSocketMessageHandler#responder` by releasing the connection setup payload explicitly if responder creation fails (e.g. invalid mime types).

Issue: #37026