### PR TITLE
Fix/issue 36631 mock session validity

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockHttpServletRequest.java
@@ -251,7 +251,7 @@ public class MockHttpServletRequest implements HttpServletRequest {
 
 	private @Nullable HttpSession session;
 
-	private boolean requestedSessionIdValid = true;
+	private @Nullable Boolean requestedSessionIdValid;
 
 	private boolean requestedSessionIdFromCookie = true;
 
@@ -1352,7 +1352,14 @@ public class MockHttpServletRequest implements HttpServletRequest {
 
 	@Override
 	public boolean isRequestedSessionIdValid() {
-		return this.requestedSessionIdValid;
+		if (this.requestedSessionIdValid != null) {
+			return this.requestedSessionIdValid;
+		}
+		if (this.requestedSessionId == null) {
+			return false;
+		}
+		HttpSession session = getSession(false);
+		return (session != null && this.requestedSessionId.equals(session.getId()));
 	}
 
 	public void setRequestedSessionIdFromCookie(boolean requestedSessionIdFromCookie) {

--- a/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletRequestTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockHttpServletRequestTests.java
@@ -714,6 +714,32 @@ class MockHttpServletRequestTests {
 		assertThat(listenerEvent.event.getAsyncContext()).isEqualTo(newAsyncContext);
 	}
 
+	@Test
+	void isRequestedSessionIdValidWithoutSession() {
+		assertThat(request.getRequestedSessionId()).isNull();
+		assertThat(request.isRequestedSessionIdValid()).isFalse();
+	}
+
+	@Test
+	void isRequestedSessionIdValidWithMatchingSession() {
+		MockHttpSession session = new MockHttpSession();
+		request.setSession(session);
+		request.setRequestedSessionId(session.getId());
+		assertThat(request.isRequestedSessionIdValid()).isTrue();
+	}
+
+	@Test
+	void isRequestedSessionIdValidAfterChangeSessionId() {
+		MockHttpSession session = new MockHttpSession();
+		request.setSession(session);
+		request.setRequestedSessionId(session.getId());
+		String previousRequestedId = request.getRequestedSessionId();
+		request.changeSessionId();
+		assertThat(session.getId()).isNotEqualTo(previousRequestedId);
+		assertThat(request.getRequestedSessionId()).isEqualTo(previousRequestedId);
+		assertThat(request.isRequestedSessionIdValid()).isFalse();
+	}
+
 	private void assertEqualEnumerations(Enumeration<?> enum1, Enumeration<?> enum2) {
 		int count = 0;
 		while (enum1.hasMoreElements()) {


### PR DESCRIPTION
Closes gh-36631

Hey team, 

While looking into #36631, I noticed that `MockHttpServletRequest.isRequestedSessionIdValid()` was hardcoded to default to `true`, which deviates from the Servlet 6.1 specs and causes some headaches for session rotation tests in Spring Security.

To fix this while keeping things backward compatible, I changed the primitive `boolean requestedSessionIdValid` to a wrapper `Boolean`. 

This way, if someone explicitly calls the setter, we still respect their hardcoded override. But if it's left `null` (the default), we now dynamically calculate the validity on the fly by checking if the requested ID actually matches the active `HttpSession`.

I've also added three new tests in `MockHttpServletRequestTests` to cover the missing ID, matching ID, and stale ID (after `changeSessionId()`) scenarios. The whole test suite is running green on my end!

Let me know if you'd like me to tweak anything!
