### PR TITLE
Restore serialization support for TypeDescriptor

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/TypeDescriptor.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/TypeDescriptor.java
@@ -16,6 +16,9 @@
 
 package org.springframework.core.convert;
 
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
@@ -73,7 +76,7 @@ public class TypeDescriptor implements Serializable {
 
 	private final ResolvableType resolvableType;
 
-	private final AnnotatedElementSupplier annotatedElementSupplier;
+	private transient AnnotatedElementSupplier annotatedElementSupplier;
 
 	private volatile @Nullable AnnotatedElementAdapter annotatedElement;
 
@@ -724,6 +727,22 @@ public class TypeDescriptor implements Serializable {
 	 */
 	public static @Nullable TypeDescriptor nested(Property property, int nestingLevel) {
 		return new TypeDescriptor(property).nested(nestingLevel);
+	}
+
+
+	private void writeObject(ObjectOutputStream outputStream) throws IOException {
+		// Resolve the annotations up front since the supplier is transient: it captures
+		// the Field/MethodParameter/Property this descriptor has been created from.
+		getAnnotatedElement();
+		outputStream.defaultWriteObject();
+	}
+
+	private void readObject(ObjectInputStream inputStream) throws IOException, ClassNotFoundException {
+		inputStream.defaultReadObject();
+		AnnotatedElementAdapter annotatedElement = AnnotatedElementAdapter.from(
+				this.annotatedElement != null ? this.annotatedElement.getAnnotations() : null);
+		this.annotatedElement = annotatedElement;
+		this.annotatedElementSupplier = () -> annotatedElement;
 	}
 
 

--- a/spring-core/src/test/java/org/springframework/core/convert/TypeDescriptorTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/TypeDescriptorTests.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
 
@@ -735,6 +736,94 @@ class TypeDescriptorTests {
 				out.toByteArray()));
 		TypeDescriptor readObject = (TypeDescriptor) inputStream.readObject();
 		assertThat(readObject).isEqualTo(typeDescriptor);
+	}
+
+	@Test  // gh-33948
+	void serializableWithFieldAnnotations() throws Exception {
+		Field field = getClass().getField("fieldAnnotated");
+		TypeDescriptor readObject = serializeAndDeserialize(new TypeDescriptor(field));
+		assertThat(readObject.getAnnotations()).containsExactly(field.getAnnotations());
+		assertThat(readObject.hasAnnotation(FieldAnnotation.class)).isTrue();
+	}
+
+	@Test  // gh-33948
+	void serializableWithMethodParameterAnnotations() throws Exception {
+		MethodParameter methodParameter = new MethodParameter(
+				getClass().getMethod("testAnnotatedMethod", String.class), 0);
+		TypeDescriptor readObject = serializeAndDeserialize(new TypeDescriptor(methodParameter));
+		assertThat(readObject.getAnnotations()).containsExactly(methodParameter.getParameterAnnotations());
+		assertThat(readObject.hasAnnotation(ParameterAnnotation.class)).isTrue();
+	}
+
+	@Test  // gh-33948
+	void serializableWithPropertyAnnotations() throws Exception {
+		Property property = new Property(getClass(), getClass().getMethod("getProperty"),
+				getClass().getMethod("setProperty", Map.class));
+		TypeDescriptor readObject = serializeAndDeserialize(new TypeDescriptor(property));
+		assertThat(readObject.getAnnotations()).containsExactly(property.getAnnotations());
+		assertThat(readObject.hasAnnotation(MethodAnnotation1.class)).isTrue();
+	}
+
+	@Test  // gh-33948
+	void serializableWithAnnotationArray() throws Exception {
+		Annotation[] annotations = getClass().getField("fieldAnnotated").getAnnotations();
+		TypeDescriptor readObject = serializeAndDeserialize(
+				new TypeDescriptor(ResolvableType.forClass(String.class), String.class, annotations));
+		assertThat(readObject.getAnnotations()).containsExactly(annotations);
+		assertThat(readObject.hasAnnotation(FieldAnnotation.class)).isTrue();
+	}
+
+	@Test  // gh-33948
+	void serializableWithoutAnnotations() throws Exception {
+		TypeDescriptor readObject = serializeAndDeserialize(new TypeDescriptor(getClass().getField("fieldScalar")));
+		assertThat(readObject.getAnnotations()).isEmpty();
+		// An empty AnnotatedElementAdapter is a shared instance which returns its annotation
+		// array as is, whereas any other adapter hands out a defensive copy on every call.
+		assertThat(readObject.getAnnotations()).isSameAs(readObject.getAnnotations());
+	}
+
+	@Test  // gh-33948
+	void serializableWithDerivedTypeDescriptor() throws Exception {
+		Field field = getClass().getField("mapPreserveContext");
+		TypeDescriptor valueTypeDescriptor = new TypeDescriptor(field).getMapValueTypeDescriptor();
+		TypeDescriptor readObject = serializeAndDeserialize(valueTypeDescriptor);
+		assertThat(readObject.getAnnotations()).containsExactly(field.getAnnotations());
+	}
+
+	@Test  // gh-33948
+	void serializationResolvesAnnotationsThatHaveNotBeenResolvedYet() throws Exception {
+		AtomicInteger resolutionCount = new AtomicInteger();
+		MethodParameter methodParameter =
+				new MethodParameter(getClass().getMethod("testAnnotatedMethod", String.class), 0) {
+					@Override
+					public Annotation[] getParameterAnnotations() {
+						resolutionCount.incrementAndGet();
+						return super.getParameterAnnotations();
+					}
+				};
+
+		TypeDescriptor typeDescriptor = new TypeDescriptor(methodParameter);
+		assertThat(resolutionCount).hasValue(0);
+
+		TypeDescriptor readObject = serializeAndDeserialize(typeDescriptor);
+		assertThat(resolutionCount).hasValue(1);
+		assertThat(readObject.getAnnotations()).containsExactly(methodParameter.getParameterAnnotations());
+	}
+
+	/**
+	 * Serialize the supplied {@link TypeDescriptor} without resolving its
+	 * annotations first, and assert that the deserialized copy is equal to it.
+	 */
+	private static TypeDescriptor serializeAndDeserialize(TypeDescriptor typeDescriptor) throws Exception {
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		try (ObjectOutputStream outputStream = new ObjectOutputStream(out)) {
+			outputStream.writeObject(typeDescriptor);
+		}
+		try (ObjectInputStream inputStream = new ObjectInputStream(new ByteArrayInputStream(out.toByteArray()))) {
+			TypeDescriptor readObject = (TypeDescriptor) inputStream.readObject();
+			assertThat(readObject).isEqualTo(typeDescriptor);
+			return readObject;
+		}
 	}
 
 	@Test


### PR DESCRIPTION
## Overview

`TypeDescriptor` has declared `Serializable` since 3.0, but instances created from a `Field`, a `MethodParameter` or a `Property` can no longer be serialized. Writing such an instance fails with `NotSerializableException`.

This is a regression from gh-33948 (`1a573d6e3c7`, "Lazily retrieve TypeDescriptor annotations on demand"). Serialization still works in 6.2.1 and fails in 6.2.13, and the current code on 7.0.x and main behaves the same as 6.2.13.

## Problem

That commit replaced the eagerly resolved `AnnotatedElementAdapter` field with a serializable lambda:

```java
private final AnnotatedElementSupplier annotatedElementSupplier;

public TypeDescriptor(Field field) {
    this.resolvableType = ResolvableType.forField(field);
    this.type = this.resolvableType.resolve(field.getType());
    this.annotatedElementSupplier = () -> AnnotatedElementAdapter.from(field.getAnnotations());
}
```

`AnnotatedElementSupplier` extends `Serializable`, so the lambda is written to the stream as a `SerializedLambda` along with everything it captures. The captured values are the very reflection objects the descriptor was created from, and none of them are serializable:

| Constructor | Captured value | Serializable |
| --- | --- | --- |
| `TypeDescriptor(Field)` | `java.lang.reflect.Field` | no |
| `TypeDescriptor(MethodParameter)` | `MethodParameter` | no |
| `TypeDescriptor(Property)` | `Property` | no |
| `TypeDescriptor(ResolvableType, Class, Annotation[])` | `Annotation[]` | yes |

Reproduction:

```java
Field field = MyBean.class.getDeclaredField("name");
new ObjectOutputStream(out).writeObject(new TypeDescriptor(field));
// java.io.NotSerializableException: java.lang.reflect.Field
```

The failure occurs even when the annotations have already been resolved, since the supplier field itself is neither `transient` nor cleared once the adapter has been cached.

The existing `TypeDescriptorTests.serializable()` test did not catch this because `TypeDescriptor.forObject("")` routes to the `(ResolvableType, Class, Annotation[])` constructor with a `null` annotation array, which is the one path that still serializes.

Descriptors reaching a serialization boundary are not exotic: `ConversionFailedException` and `ConverterNotFoundException` both hold non-transient `TypeDescriptor` fields, and those exceptions are serializable by virtue of being `Throwable`.

## Fix

Mark the supplier `transient` and let the already serializable `AnnotatedElementAdapter` carry the annotations across the stream instead:

```java
private transient AnnotatedElementSupplier annotatedElementSupplier;

private void writeObject(ObjectOutputStream outputStream) throws IOException {
    // Resolve the annotations up front since the supplier is transient: it captures
    // the Field/MethodParameter/Property this descriptor has been created from.
    getAnnotatedElement();
    outputStream.defaultWriteObject();
}

private void readObject(ObjectInputStream inputStream) throws IOException, ClassNotFoundException {
    inputStream.defaultReadObject();
    AnnotatedElementAdapter annotatedElement = AnnotatedElementAdapter.from(
            this.annotatedElement != null ? this.annotatedElement.getAnnotations() : null);
    this.annotatedElement = annotatedElement;
    this.annotatedElementSupplier = () -> annotatedElement;
}
```

Notes on the two hooks:

- `writeObject()` resolves the annotations only at serialization time, so the lazy retrieval introduced by gh-33948 is preserved for every other code path. Without it, a descriptor that has never been asked for its annotations would write a `null` adapter and lose them.
- `readObject()` runs the restored adapter through `AnnotatedElementAdapter.from(...)` so that an empty adapter is folded back into the shared `EMPTY` instance. `AnnotatedElementAdapter.isEmpty()` is an identity check and the class has no `readResolve()`, so without this the `isEmpty()` shortcut in `hasAnnotation()` and `getAnnotation()` would be lost after a round trip.

Tests cover all four constructors, a descriptor without annotations, a derived descriptor, and the lazy-versus-serialization timing.

## Note on impact

Making the field `private transient` removes it from the default `serialVersionUID` computation, so the computed UID changes (`-4882614078662365050` to `1724818276882560505`, serialized fields 4 to 3). Streams written by an earlier version are therefore rejected with `InvalidClassException` rather than being read.

Pinning the previous UID was considered and deliberately not done: with a matching UID the old supplier field would be read and discarded, `annotatedElement` would be `null` because the old code never forced resolution, and the annotations would be lost silently. `TypeDescriptor` does not declare a `serialVersionUID` and carries `@SuppressWarnings("serial")`, so cross-version stream compatibility was never part of its contract, and failing loudly seems preferable to dropping annotations quietly. Note also that streams containing a `Field`, `MethodParameter` or `Property` based descriptor cannot exist today, since writing them is exactly what fails.

One behavioural detail worth flagging: annotation resolution can now surface during serialization, so a missing annotation class shows up as `TypeNotPresentException` from `writeObject()` where it previously surfaced as `NotSerializableException`. Both cases fail, and the former carries more information about the cause.

Unrelated to this change, `TypeDescriptor.getElementTypeDescriptor()` results still fail to serialize with `NotSerializableException: sun.reflect.generics.reflectiveObjects.TypeVariableImpl`, before and after this fix. That one originates in the `ResolvableType` held by the descriptor rather than in the annotation supplier, so it is left alone here.
