### PR TITLE
Avoid retaining class files in annotation metadata

### DIFF
--- a/spring-core/src/main/java24/org/springframework/core/type/classreading/ClassFileAnnotationDelegate.java
+++ b/spring-core/src/main/java24/org/springframework/core/type/classreading/ClassFileAnnotationDelegate.java
@@ -76,7 +76,7 @@ abstract class ClassFileAnnotationDelegate {
 				}
 			}
 			Map<String, Object> compactedAttributes = (attributes.isEmpty() ? Collections.emptyMap() : attributes);
-			return MergedAnnotation.of(classLoader, new Source(annotation), annotationType, compactedAttributes);
+			return MergedAnnotation.of(classLoader, new Source(className), annotationType, compactedAttributes);
 		}
 		catch (ClassNotFoundException | LinkageError ex) {
 			// Non-loadable annotation type -> ignore.
@@ -146,7 +146,7 @@ abstract class ClassFileAnnotationDelegate {
 	}
 
 
-	record Source(Annotation annotation) {
+	record Source(String className) {
 	}
 
 }


### PR DESCRIPTION
This is the Class-File versus ASM metadata overhead case from #36737, reported with a reproducer in #37111. On Java 24+ `MetadataReaderFactoryDelegate` selects the Class-File reader, which retains considerably more heap than the ASM one for the same classes.

`ClassFileAnnotationDelegate` keeps the raw `java.lang.classfile.Annotation` as the `MergedAnnotation` source. That annotation holds a `Utf8Entry`, so retaining the metadata of an annotated class also retains its class file `byte[]`, the parsed constant pool, and the class model. This stores the declaring class name instead, which is what `SimpleAnnotationMetadataReadingVisitor.Source` holds on the ASM path.

Measured with the reproducer (Temurin 25.0.3, spring-core 7.0.8):

| | retained heap |
|---|---|
| `SimpleMetadataReaderFactory` (ASM) | 12.3 MB |
| `ClassFileMetadataReaderFactory` before | 84.5 MB |
| `ClassFileMetadataReaderFactory` after | 16.7 MB |

In a large application's test context this took the retained size of a single `DefaultListableBeanFactory` from 128.4 MB to 53.4 MB. Forcing the ASM reader in the same build, by copying `MetadataReaderFactoryDelegate` into the project [as suggested here](https://github.com/spring-projects/spring-framework/issues/36737#issuecomment-4395495629), gives 46.1 MB.

The difference that is left is not addressed here. `ClassFileMethodMetadata` holds `AccessFlags` and `MethodTypeDesc` objects and `ClassFileAnnotationMetadata` one `AccessFlags`, where `SimpleMethodMetadata` and `SimpleAnnotationMetadata` keep plain `int` and `String` values instead. #36978 already makes that change for `ClassFileMethodMetadata`. Once both are changed, the reproducer matches the ASM baseline of 12.3 MB and the test context mentioned above comes to 46.9 MB.