### PR TITLE
Provide MediaType to AbstractJacksonHttpMessageConverter.customizeReader

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/AbstractJacksonHttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/AbstractJacksonHttpMessageConverter.java
@@ -352,7 +352,7 @@ public abstract class AbstractJacksonHttpMessageConverter<T extends ObjectMapper
 			if (hints != null && hints.containsKey(JSON_VIEW_HINT)) {
 				objectReader = objectReader.withView((Class<?>) hints.get(JSON_VIEW_HINT));
 			}
-			objectReader = customizeReader(objectReader, javaType);
+			objectReader = customizeReader(objectReader, javaType, contentType);
 			if (isUnicode) {
 				return objectReader.readValue(inputStream);
 			}
@@ -378,6 +378,19 @@ public abstract class AbstractJacksonHttpMessageConverter<T extends ObjectMapper
 	 */
 	protected ObjectReader customizeReader(ObjectReader reader, JavaType javaType) {
 		return reader;
+	}
+
+	/**
+	 * Subclasses can use this method to customize the {@link ObjectReader} used
+	 * for reading values.
+	 * @param reader the reader instance to customize
+	 * @param javaType the type of element values to read
+	 * @param contentType the content type of the HTTP input message
+	 * @return the customized {@link ObjectReader}
+	 * @since 6.2
+	 */
+	protected ObjectReader customizeReader(ObjectReader reader, JavaType javaType, @Nullable MediaType contentType) {
+		return customizeReader(reader, javaType);
 	}
 
 	/**

--- a/spring-web/src/main/java/org/springframework/http/converter/json/AbstractJackson2HttpMessageConverter.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/json/AbstractJackson2HttpMessageConverter.java
@@ -385,7 +385,7 @@ public abstract class AbstractJackson2HttpMessageConverter extends AbstractGener
 				Class<?> deserializationView = mappingJacksonInputMessage.getDeserializationView();
 				if (deserializationView != null) {
 					ObjectReader objectReader = objectMapper.readerWithView(deserializationView).forType(javaType);
-					objectReader = customizeReader(objectReader, javaType);
+					objectReader = customizeReader(objectReader, javaType, contentType);
 					if (isUnicode) {
 						return objectReader.readValue(inputStream);
 					}
@@ -397,7 +397,7 @@ public abstract class AbstractJackson2HttpMessageConverter extends AbstractGener
 			}
 
 			ObjectReader objectReader = objectMapper.reader().forType(javaType);
-			objectReader = customizeReader(objectReader, javaType);
+			objectReader = customizeReader(objectReader, javaType, contentType);
 			if (isUnicode) {
 				return objectReader.readValue(inputStream);
 			}
@@ -424,6 +424,19 @@ public abstract class AbstractJackson2HttpMessageConverter extends AbstractGener
 	 */
 	protected ObjectReader customizeReader(ObjectReader reader, JavaType javaType) {
 		return reader;
+	}
+
+	/**
+	 * Subclasses can use this method to customize {@link ObjectReader} used
+	 * for reading values.
+	 * @param reader the reader instance to customize
+	 * @param javaType the target type of element values to read to
+	 * @param contentType the content type of the HTTP input message
+	 * @return the customized {@link ObjectReader}
+	 * @since 6.2
+	 */
+	protected ObjectReader customizeReader(ObjectReader reader, JavaType javaType, @Nullable MediaType contentType) {
+		return customizeReader(reader, javaType);
 	}
 
 	/**

--- a/spring-web/src/test/java/org/springframework/http/converter/json/MappingJackson2HttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/json/MappingJackson2HttpMessageConverterTests.java
@@ -149,6 +149,24 @@ class MappingJackson2HttpMessageConverterTests {
 	}
 
 	@Test
+	void customizeReaderWithMediaType() throws IOException {
+		MediaType contentType = new MediaType("application", "json");
+		MappingJackson2HttpMessageConverter customConverter = new MappingJackson2HttpMessageConverter() {
+			@Override
+			protected ObjectReader customizeReader(ObjectReader reader, JavaType javaType, @Nullable MediaType mediaType) {
+				assertThat(mediaType).isEqualTo(contentType);
+				return super.customizeReader(reader, javaType, mediaType);
+			}
+		};
+
+		String body = "{\"string\":\"Foo\"}";
+		MockHttpInputMessage inputMessage = new MockHttpInputMessage(body.getBytes(StandardCharsets.UTF_8));
+		inputMessage.getHeaders().setContentType(contentType);
+		MyBean result = (MyBean) customConverter.read(MyBean.class, inputMessage);
+		assertThat(result.getString()).isEqualTo("Foo");
+	}
+
+	@Test
 	@SuppressWarnings("unchecked")
 	void readUntyped() throws IOException {
 		String body = "{" +


### PR DESCRIPTION
Closes gh-37094

This commit adds an overloaded customizeReader method to both AbstractJacksonHttpMessageConverter and AbstractJackson2HttpMessageConverter that accepts a MediaType parameter. This allows subclasses to apply configuration dynamically based on the input content type. The existing 2-argument method is preserved for backward compatibility.