### PR TITLE
Fix Jaxb2Marshaller when mtomEnabled and schema validation are both set

### DIFF
--- a/spring-oxm/src/main/java/org/springframework/oxm/jaxb/Jaxb2Marshaller.java
+++ b/spring-oxm/src/main/java/org/springframework/oxm/jaxb/Jaxb2Marshaller.java
@@ -53,6 +53,7 @@ import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
+import javax.xml.transform.dom.DOMResult;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stax.StAXSource;
@@ -705,7 +706,26 @@ public class Jaxb2Marshaller implements MimeMarshaller, MimeUnmarshaller, Generi
 	@Override
 	public void marshal(Object graph, Result result, @Nullable MimeContainer mimeContainer) throws XmlMappingException {
 		try {
-			Marshaller marshaller = createMarshaller();
+			// XOP packaging replaces base64Binary simple content with xop:Include children.
+			// Schema validation must therefore run against the logical (non-XOP) infoset first,
+			// then MTOM marshalling proceeds without a Schema so validation does not see XOP.
+			// See spring-projects/spring-ws#1030 / SWS-958.
+			if (this.mtomEnabled && mimeContainer != null && this.schema != null) {
+				Marshaller validatingMarshaller = createMarshaller(true);
+				// Non-XOP marshaller keeps base64 as simple content and supports @XmlAttachmentRef.
+				validatingMarshaller.setAttachmentMarshaller(LogicalAttachmentMarshaller.INSTANCE);
+				validatingMarshaller.marshal(graph, new DOMResult());
+				Marshaller mtomMarshaller = createMarshaller(false);
+				mtomMarshaller.setAttachmentMarshaller(new Jaxb2AttachmentMarshaller(mimeContainer));
+				if (StaxUtils.isStaxResult(result)) {
+					marshalStaxResult(mtomMarshaller, graph, result);
+				}
+				else {
+					mtomMarshaller.marshal(graph, result);
+				}
+				return;
+			}
+			Marshaller marshaller = createMarshaller(true);
 			if (this.mtomEnabled && mimeContainer != null) {
 				marshaller.setAttachmentMarshaller(new Jaxb2AttachmentMarshaller(mimeContainer));
 			}
@@ -729,9 +749,13 @@ public class Jaxb2Marshaller implements MimeMarshaller, MimeUnmarshaller, Generi
 	 * @see #createUnmarshaller()
 	 */
 	public Marshaller createMarshaller() {
+		return createMarshaller(true);
+	}
+
+	private Marshaller createMarshaller(boolean applySchema) {
 		try {
 			Marshaller marshaller = getJaxbContext().createMarshaller();
-			initJaxbMarshaller(marshaller);
+			initJaxbMarshaller(marshaller, applySchema);
 			return marshaller;
 		}
 		catch (JAXBException ex) {
@@ -766,6 +790,10 @@ public class Jaxb2Marshaller implements MimeMarshaller, MimeUnmarshaller, Generi
 	 * and {@link #setAdapters adapters}.
 	 */
 	protected void initJaxbMarshaller(Marshaller marshaller) throws JAXBException {
+		initJaxbMarshaller(marshaller, true);
+	}
+
+	private void initJaxbMarshaller(Marshaller marshaller, boolean applySchema) throws JAXBException {
 		if (this.marshallerProperties != null) {
 			for (Map.Entry<String, ?> entry : this.marshallerProperties.entrySet()) {
 				marshaller.setProperty(entry.getKey(), entry.getValue());
@@ -782,7 +810,7 @@ public class Jaxb2Marshaller implements MimeMarshaller, MimeUnmarshaller, Generi
 				marshaller.setAdapter(adapter);
 			}
 		}
-		if (this.schema != null) {
+		if (applySchema && this.schema != null) {
 			marshaller.setSchema(this.schema);
 		}
 	}
@@ -979,6 +1007,38 @@ public class Jaxb2Marshaller implements MimeMarshaller, MimeUnmarshaller, Generi
 		else {
 			// fallback
 			return new UncategorizedMappingException("Unknown JAXB exception", ex);
+		}
+	}
+
+
+	/**
+	 * Attachment marshaller used only while validating the logical infoset (no XOP).
+	 * {@link #isXOPPackage()} is {@code false} so {@code xs:base64Binary} stays simple
+	 * content; SWA/{@code @XmlAttachmentRef} fields still get a placeholder content id.
+	 */
+	private static final class LogicalAttachmentMarshaller extends AttachmentMarshaller {
+
+		static final LogicalAttachmentMarshaller INSTANCE = new LogicalAttachmentMarshaller();
+
+		@Override
+		public boolean isXOPPackage() {
+			return false;
+		}
+
+		@Override
+		public String addMtomAttachment(byte[] data, int offset, int length, String mimeType,
+				String elementNamespace, String elementLocalName) {
+			return "cid:validation";
+		}
+
+		@Override
+		public String addMtomAttachment(DataHandler dataHandler, String elementNamespace, String elementLocalName) {
+			return "cid:validation";
+		}
+
+		@Override
+		public String addSwaRefAttachment(DataHandler dataHandler) {
+			return "cid:validation";
 		}
 	}
 

--- a/spring-oxm/src/test/java/org/springframework/oxm/jaxb/Jaxb2MarshallerTests.java
+++ b/spring-oxm/src/test/java/org/springframework/oxm/jaxb/Jaxb2MarshallerTests.java
@@ -45,6 +45,7 @@ import org.xml.sax.Locator;
 import org.xmlunit.diff.DifferenceEvaluator;
 
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.testfixture.xml.XmlContent;
 import org.springframework.oxm.AbstractMarshallerTests;
@@ -289,6 +290,50 @@ class Jaxb2MarshallerTests extends AbstractMarshallerTests<Jaxb2Marshaller> {
 		marshaller.marshal(object, new StreamResult(writer), mimeContainer);
 		assertThat(writer.toString()).as("No XML written").isNotEmpty();
 		verify(mimeContainer, times(3)).addAttachment(isA(String.class), isA(DataHandler.class));
+	}
+
+	@Test  // spring-ws#1030 / SWS-958: mtomEnabled + schema must validate logical infoset then XOP-encode
+	void marshalAttachmentsWithSchema() throws Exception {
+		marshaller = new Jaxb2Marshaller();
+		marshaller.setClassesToBeBound(BinaryObject.class);
+		marshaller.setMtomEnabled(true);
+		marshaller.setSchema(new ClassPathResource("binary-object.xsd", getClass()));
+		marshaller.afterPropertiesSet();
+		MimeContainer mimeContainer = mock();
+
+		Resource logo = new ClassPathResource("spring-ws.png", getClass());
+		DataHandler dataHandler = new DataHandler(new FileDataSource(logo.getFile()));
+
+		given(mimeContainer.convertToXopPackage()).willReturn(true);
+		byte[] bytes = FileCopyUtils.copyToByteArray(logo.getInputStream());
+		BinaryObject object = new BinaryObject(bytes, dataHandler);
+		StringWriter writer = new StringWriter();
+		marshaller.marshal(object, new StreamResult(writer), mimeContainer);
+		String xml = writer.toString();
+		assertThat(xml).as("No XML written").isNotEmpty();
+		assertThat(xml).contains("Include");
+		verify(mimeContainer, times(3)).addAttachment(isA(String.class), isA(DataHandler.class));
+	}
+
+	@Test  // spring-ws#1030: schema still rejects content that does not match when MTOM is enabled
+	void marshalAttachmentsWithSchemaRejectsInvalidGraph() throws Exception {
+		marshaller = new Jaxb2Marshaller();
+		marshaller.setClassesToBeBound(BinaryObject.class);
+		marshaller.setMtomEnabled(true);
+		// flight.xsd does not describe BinaryObject — logical validation must still fail before XOP
+		marshaller.setSchema(new FileSystemResource("src/test/schema/flight.xsd"));
+		marshaller.afterPropertiesSet();
+		MimeContainer mimeContainer = mock();
+
+		Resource logo = new ClassPathResource("spring-ws.png", getClass());
+		DataHandler dataHandler = new DataHandler(new FileDataSource(logo.getFile()));
+		given(mimeContainer.convertToXopPackage()).willReturn(true);
+		byte[] bytes = FileCopyUtils.copyToByteArray(logo.getInputStream());
+		BinaryObject object = new BinaryObject(bytes, dataHandler);
+
+		assertThatExceptionOfType(XmlMappingException.class).isThrownBy(() ->
+				marshaller.marshal(object, new StreamResult(new StringWriter()), mimeContainer));
+		verify(mimeContainer, times(0)).addAttachment(isA(String.class), isA(DataHandler.class));
 	}
 
 	@Test  // SPR-10714

--- a/spring-oxm/src/test/resources/org/springframework/oxm/jaxb/binary-object.xsd
+++ b/spring-oxm/src/test/resources/org/springframework/oxm/jaxb/binary-object.xsd
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://springframework.org/spring-ws"
+           xmlns:tns="http://springframework.org/spring-ws"
+           elementFormDefault="qualified">
+
+	<xs:element name="binaryObject" type="tns:binaryObjectType"/>
+
+	<xs:complexType name="binaryObjectType">
+		<xs:sequence>
+			<xs:element name="bytes" type="xs:base64Binary" minOccurs="0"/>
+			<xs:element name="dataHandler" type="xs:base64Binary" minOccurs="0"/>
+			<!-- swaRef is a simple URI type; treat as string for validation -->
+			<xs:element name="swaDataHandler" type="xs:string" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>


### PR DESCRIPTION
## Overview

When `Jaxb2Marshaller` has both `mtomEnabled=true` and a configured `schema`/`schemas`, marshalling fails with:

```
cvc-type.3.1.2: Element '…' is a simple type, so it must have no element information item [children].
```

XOP packaging replaces `xs:base64Binary` simple content with `xop:Include` element children. JAXB applies the `Schema` to the **XOP-encoded** stream, so validation rejects valid logical content.

Reported via [spring-projects/spring-ws#1030](https://github.com/spring-projects/spring-ws/issues/1030) (SWS-958); sample: https://github.com/mpeterka/spring-ws-mtom (`testMarshallMtom`).

The bug lives in `spring-oxm` (`Jaxb2Marshaller`), not in Spring WS itself.

## Fix

When MTOM is active **and** a schema is configured:

1. **Validate** the logical infoset first: marshall with schema, with a non-XOP `AttachmentMarshaller` (`isXOPPackage() == false`) so `base64Binary` stays simple content and `@XmlAttachmentRef`/SWA still get a placeholder content id.
2. **MTOM-encode** without schema: marshall with the real `MimeContainer` attachment marshaller so `xop:Include` is written without re-validating the XOP package.

This matches the expected order from the issue: validate → replace with MTOM includes → send.

## Tests

- `marshalAttachmentsWithSchema` — MTOM + matching XSD succeeds and still adds attachments
- `marshalAttachmentsWithSchemaRejectsInvalidGraph` — wrong schema still fails **before** attachments are added
- Existing `marshalAttachments` unchanged

```
./gradlew :spring-oxm:test --tests org.springframework.oxm.jaxb.Jaxb2MarshallerTests \
  --tests org.springframework.oxm.jaxb.Jaxb2UnmarshallerTests
```

**24 + 12 tests green** (Temurin 25).

## Related

- Fixes [spring-projects/spring-ws#1030](https://github.com/spring-projects/spring-ws/issues/1030)
- Does not change inbound unmarshalling + schema (still XOP-on-the-wire vs logical schema); server-side `PayloadValidatingInterceptor` can be a follow-up if needed.