### PR TITLE
feat(http): support HTTP QUERY method

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
@@ -135,6 +135,15 @@ public interface WebTestClient {
 	RequestBodyUriSpec patch();
 
 	/**
+	 * Prepare an HTTP QUERY request.
+	 * @return a spec for specifying the target URL
+	 * @see <a href="https://www.rfc-editor.org/rfc/rfc10008.html">RFC 10008</a>
+	 */
+	default RequestBodyUriSpec query() {
+		return method(HttpMethod.QUERY);
+	}
+
+	/**
 	 * Prepare an HTTP DELETE request.
 	 * @return a spec for specifying the target URL
 	 */

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/assertj/MockMvcTester.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/assertj/MockMvcTester.java
@@ -306,6 +306,21 @@ public final class MockMvcTester {
 	}
 
 	/**
+	 * Prepare an HTTP QUERY request.
+	 * <p>The returned builder can be wrapped in {@code assertThat} to enable
+	 * assertions on the result. For multi-statements assertions, use
+	 * {@link MockMvcRequestBuilder#exchange() exchange()} to assign the
+	 * result. To control the time to wait for asynchronous request to complete
+	 * on a per-request basis, use
+	 * {@link MockMvcRequestBuilder#exchange(Duration) exchange(Duration)}.
+	 * @return a request builder for specifying the target URI
+	 * @see <a href="https://www.rfc-editor.org/rfc/rfc10008.html">RFC 10008</a>
+	 */
+	public MockMvcRequestBuilder query() {
+		return method(HttpMethod.QUERY);
+	}
+
+	/**
 	 * Prepare an HTTP DELETE request.
 	 * <p>The returned builder can be wrapped in {@code assertThat} to enable
 	 * assertions on the result. For multi-statements assertions, use

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/RestTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/RestTestClient.java
@@ -114,6 +114,15 @@ public interface RestTestClient {
 	RequestBodyUriSpec patch();
 
 	/**
+	 * Prepare an HTTP QUERY request.
+	 * @return a spec for specifying the target URL
+	 * @see <a href="https://www.rfc-editor.org/rfc/rfc10008.html">RFC 10008</a>
+	 */
+	default RequestBodyUriSpec query() {
+		return method(HttpMethod.QUERY);
+	}
+
+	/**
 	 * Prepare an HTTP DELETE request.
 	 * @return a spec for specifying the target URL
 	 */

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockMvcRequestBuilders.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockMvcRequestBuilders.java
@@ -121,6 +121,25 @@ public abstract class MockMvcRequestBuilders {
 	}
 
 	/**
+	 * Create a {@link MockHttpServletRequestBuilder} for a QUERY request.
+	 * @param uriTemplate a URI template; the resulting URI will be encoded
+	 * @param uriVariables zero or more URI variables
+	 * @see <a href="https://www.rfc-editor.org/rfc/rfc10008.html">RFC 10008</a>
+	 */
+	public static MockHttpServletRequestBuilder query(String uriTemplate, @Nullable Object... uriVariables) {
+		return new MockHttpServletRequestBuilder(HttpMethod.QUERY).uri(uriTemplate, uriVariables);
+	}
+
+	/**
+	 * Create a {@link MockHttpServletRequestBuilder} for a QUERY request.
+	 * @param uri the URI
+	 * @see <a href="https://www.rfc-editor.org/rfc/rfc10008.html">RFC 10008</a>
+	 */
+	public static MockHttpServletRequestBuilder query(URI uri) {
+		return new MockHttpServletRequestBuilder(HttpMethod.QUERY).uri(uri);
+	}
+
+	/**
 	 * Create a {@link MockHttpServletRequestBuilder} for a DELETE request.
 	 * @param uriTemplate a URI template; the resulting URI will be encoded
 	 * @param uriVariables zero or more URI variables

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/assertj/MockMvcTesterTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/assertj/MockMvcTesterTests.java
@@ -179,6 +179,12 @@ class MockMvcTesterTests {
 	}
 
 	@Test
+	void queryConfiguresBuilder() {
+		assertThat(createMockHttpServletRequest(tester -> tester.query().uri("/search/{id}", 123)))
+				.satisfies(hasSettings(HttpMethod.QUERY, "/search/{id}", "/search/123"));
+	}
+
+	@Test
 	void deleteConfiguresBuilder() {
 		assertThat(createMockHttpServletRequest(tester -> tester.delete().uri("/users/{id}", 42)))
 				.satisfies(hasSettings(HttpMethod.DELETE, "/users/{id}", "/users/42"));

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/client/RestTestClientTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/client/RestTestClientTests.java
@@ -57,7 +57,7 @@ class RestTestClientTests {
 	class HttpMethods {
 
 		@ParameterizedTest
-		@ValueSource(strings = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"})
+		@ValueSource(strings = {"GET", "POST", "PUT", "DELETE", "PATCH", "QUERY", "HEAD"})
 		void method(String method) {
 			RestTestClientTests.this.client.method(HttpMethod.valueOf(method)).uri("/test")
 					.exchange()
@@ -106,6 +106,14 @@ class RestTestClientTests {
 		}
 
 		@Test
+		void query() {
+			RestTestClientTests.this.client.query().uri("/test")
+					.exchange()
+					.expectStatus().isOk()
+					.expectBody().jsonPath("$.method").isEqualTo("QUERY");
+		}
+
+		@Test
 		void head() {
 			RestTestClientTests.this.client.head().uri("/test")
 					.exchange()
@@ -118,7 +126,7 @@ class RestTestClientTests {
 			RestTestClientTests.this.client.options().uri("/test")
 					.exchange()
 					.expectStatus().isOk()
-					.expectHeader().valueEquals("Allow", "GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS")
+					.expectHeader().valueEquals("Allow", "GET,HEAD,POST,PUT,PATCH,QUERY,DELETE,OPTIONS")
 					.expectBody().isEmpty();
 		}
 

--- a/spring-web/src/main/java/org/springframework/http/HttpMethod.java
+++ b/spring-web/src/main/java/org/springframework/http/HttpMethod.java
@@ -68,6 +68,12 @@ public final class HttpMethod implements Comparable<HttpMethod>, Serializable {
 	public static final HttpMethod PATCH = new HttpMethod("PATCH");
 
 	/**
+	 * The safe and idempotent HTTP method {@code QUERY}, which supports request content.
+	 * @see <a href="https://www.rfc-editor.org/rfc/rfc10008.html">RFC 10008</a>
+	 */
+	public static final HttpMethod QUERY = new HttpMethod("QUERY");
+
+	/**
 	 * The HTTP method {@code DELETE}.
 	 * @see <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html#sec9.7">HTTP 1.1, section 9.7</a>
 	 */
@@ -85,7 +91,7 @@ public final class HttpMethod implements Comparable<HttpMethod>, Serializable {
 	 */
 	public static final HttpMethod TRACE = new HttpMethod("TRACE");
 
-	private static final HttpMethod[] values = new HttpMethod[] { GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE };
+	private static final HttpMethod[] values = new HttpMethod[] { GET, HEAD, POST, PUT, PATCH, QUERY, DELETE, OPTIONS, TRACE };
 
 
 	private final String name;
@@ -98,7 +104,7 @@ public final class HttpMethod implements Comparable<HttpMethod>, Serializable {
 	/**
 	 * Returns an array containing the standard HTTP methods. Specifically,
 	 * this method returns an array containing {@link #GET}, {@link #HEAD},
-	 * {@link #POST}, {@link #PUT}, {@link #PATCH}, {@link #DELETE},
+	 * {@link #POST}, {@link #PUT}, {@link #PATCH}, {@link #QUERY}, {@link #DELETE},
 	 * {@link #OPTIONS}, and {@link #TRACE}.
 	 *
 	 * <p>Note that the returned value does not include any HTTP methods defined
@@ -134,6 +140,7 @@ public final class HttpMethod implements Comparable<HttpMethod>, Serializable {
 			case "POST" -> POST;
 			case "PUT" -> PUT;
 			case "PATCH" -> PATCH;
+			case "QUERY" -> QUERY;
 			case "DELETE" -> DELETE;
 			case "OPTIONS" -> OPTIONS;
 			case "TRACE" -> TRACE;

--- a/spring-web/src/main/java/org/springframework/http/client/SimpleClientHttpRequestFactory.java
+++ b/spring-web/src/main/java/org/springframework/http/client/SimpleClientHttpRequestFactory.java
@@ -155,7 +155,7 @@ public class SimpleClientHttpRequestFactory implements ClientHttpRequestFactory 
 
 		boolean mayWrite =
 				("POST".equals(httpMethod) || "PUT".equals(httpMethod) ||
-						"PATCH".equals(httpMethod) || "DELETE".equals(httpMethod));
+						"PATCH".equals(httpMethod) || "QUERY".equals(httpMethod) || "DELETE".equals(httpMethod));
 
 		connection.setDoInput(true);
 		connection.setInstanceFollowRedirects("GET".equals(httpMethod));

--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/RequestMethod.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/RequestMethod.java
@@ -26,7 +26,7 @@ import org.springframework.util.Assert;
  * {@link RequestMapping#method()} attribute of the {@link RequestMapping} annotation.
  *
  * <p>Note that, by default, {@link org.springframework.web.servlet.DispatcherServlet}
- * supports GET, HEAD, POST, PUT, PATCH, and DELETE only. DispatcherServlet will
+ * supports GET, HEAD, POST, PUT, PATCH, QUERY, and DELETE only. DispatcherServlet will
  * process TRACE and OPTIONS with the default HttpServlet behavior unless explicitly
  * told to dispatch those request types as well: Check out the "dispatchOptionsRequest"
  * and "dispatchTraceRequest" properties, switching them to "true" if necessary.
@@ -39,7 +39,7 @@ import org.springframework.util.Assert;
  */
 public enum RequestMethod {
 
-	GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE;
+	GET, HEAD, POST, PUT, PATCH, QUERY, DELETE, OPTIONS, TRACE;
 
 
 	/**
@@ -57,6 +57,7 @@ public enum RequestMethod {
 			case "POST" -> POST;
 			case "PUT" -> PUT;
 			case "PATCH" -> PATCH;
+			case "QUERY" -> QUERY;
 			case "DELETE" -> DELETE;
 			case "OPTIONS" -> OPTIONS;
 			case "TRACE" -> TRACE;
@@ -89,6 +90,7 @@ public enum RequestMethod {
 			case POST -> HttpMethod.POST;
 			case PUT -> HttpMethod.PUT;
 			case PATCH -> HttpMethod.PATCH;
+			case QUERY -> HttpMethod.QUERY;
 			case DELETE -> HttpMethod.DELETE;
 			case OPTIONS -> HttpMethod.OPTIONS;
 			case TRACE -> HttpMethod.TRACE;

--- a/spring-web/src/main/java/org/springframework/web/client/RestClient.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestClient.java
@@ -114,6 +114,15 @@ public interface RestClient {
 	RequestBodyUriSpec patch();
 
 	/**
+	 * Start building an HTTP QUERY request.
+	 * @return a spec for specifying the target URL
+	 * @see <a href="https://www.rfc-editor.org/rfc/rfc10008.html">RFC 10008</a>
+	 */
+	default RequestBodyUriSpec query() {
+		return method(HttpMethod.QUERY);
+	}
+
+	/**
 	 * Start building an HTTP DELETE request.
 	 * @return a spec for specifying the target URL
 	 */

--- a/spring-web/src/main/java/org/springframework/web/filter/FormContentFilter.java
+++ b/spring-web/src/main/java/org/springframework/web/filter/FormContentFilter.java
@@ -56,7 +56,7 @@ import org.springframework.util.StringUtils;
  */
 public class FormContentFilter extends OncePerRequestFilter {
 
-	private static final List<String> HTTP_METHODS = Arrays.asList("PUT", "PATCH", "DELETE");
+	private static final List<String> HTTP_METHODS = Arrays.asList("PUT", "PATCH", "QUERY", "DELETE");
 
 	private FormHttpMessageConverter formConverter = new FormHttpMessageConverter();
 

--- a/spring-web/src/test/java/org/springframework/http/HttpMethodTests.java
+++ b/spring-web/src/test/java/org/springframework/http/HttpMethodTests.java
@@ -44,12 +44,12 @@ class HttpMethodTests {
 	void values() {
 		HttpMethod[] values = HttpMethod.values();
 		assertThat(values).containsExactly(HttpMethod.GET, HttpMethod.HEAD, HttpMethod.POST, HttpMethod.PUT,
-				HttpMethod.PATCH, HttpMethod.DELETE, HttpMethod.OPTIONS, HttpMethod.TRACE);
+				HttpMethod.PATCH, HttpMethod.QUERY, HttpMethod.DELETE, HttpMethod.OPTIONS, HttpMethod.TRACE);
 
 		// check defensive copy
 		values[0] = HttpMethod.POST;
 		assertThat(HttpMethod.values()).containsExactly(HttpMethod.GET, HttpMethod.HEAD, HttpMethod.POST, HttpMethod.PUT,
-				HttpMethod.PATCH, HttpMethod.DELETE, HttpMethod.OPTIONS, HttpMethod.TRACE);
+				HttpMethod.PATCH, HttpMethod.QUERY, HttpMethod.DELETE, HttpMethod.OPTIONS, HttpMethod.TRACE);
 	}
 
 	@Test
@@ -62,6 +62,10 @@ class HttpMethodTests {
 
 		get = HttpMethod.valueOf("get");
 		assertThat(get).isSameAs(HttpMethod.GET);
+
+		HttpMethod query = HttpMethod.valueOf("QUERY");
+		assertThat(query).isSameAs(HttpMethod.QUERY);
+		assertThat(HttpMethod.valueOf("query")).isSameAs(HttpMethod.QUERY);
 
 		HttpMethod foo = HttpMethod.valueOf("foo");
 		HttpMethod other = HttpMethod.valueOf("foo");

--- a/spring-web/src/test/java/org/springframework/http/client/AbstractHttpRequestFactoryTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/AbstractHttpRequestFactoryTests.java
@@ -160,7 +160,7 @@ abstract class AbstractHttpRequestFactoryTests extends AbstractMockWebServerTest
 
 	protected void assertHttpMethod(String path, HttpMethod method) throws Exception {
 		ClientHttpRequest request = factory.createRequest(URI.create(baseUrl + "/methods/" + path), method);
-		if (method == HttpMethod.POST || method == HttpMethod.PUT || method == HttpMethod.PATCH) {
+		if (method == HttpMethod.POST || method == HttpMethod.PUT || method == HttpMethod.PATCH || method == HttpMethod.QUERY) {
 			if (request instanceof StreamingHttpOutputMessage streamingRequest) {
 				streamingRequest.setBody(outputStream -> outputStream.write(32));
 			}

--- a/spring-web/src/test/java/org/springframework/web/cors/CorsConfigurationTests.java
+++ b/spring-web/src/test/java/org/springframework/web/cors/CorsConfigurationTests.java
@@ -402,6 +402,10 @@ class CorsConfigurationTests {
 		config.addAllowedMethod("POST");
 		assertThat(config.checkHttpMethod(HttpMethod.GET)).containsExactly(HttpMethod.GET, HttpMethod.POST);
 		assertThat(config.checkHttpMethod(HttpMethod.POST)).containsExactly(HttpMethod.GET, HttpMethod.POST);
+
+		config.addAllowedMethod("QUERY");
+		assertThat(config.checkHttpMethod(HttpMethod.QUERY))
+				.containsExactly(HttpMethod.GET, HttpMethod.POST, HttpMethod.QUERY);
 	}
 
 	@Test
@@ -409,6 +413,7 @@ class CorsConfigurationTests {
 		CorsConfiguration config = new CorsConfiguration();
 		assertThat(config.checkHttpMethod(null)).isNull();
 		assertThat(config.checkHttpMethod(HttpMethod.DELETE)).isNull();
+		assertThat(config.checkHttpMethod(HttpMethod.QUERY)).isNull();
 
 		config.setAllowedMethods(new ArrayList<>());
 		assertThat(config.checkHttpMethod(HttpMethod.POST)).isNull();

--- a/spring-web/src/test/java/org/springframework/web/filter/FormContentFilterTests.java
+++ b/spring-web/src/test/java/org/springframework/web/filter/FormContentFilterTests.java
@@ -58,14 +58,14 @@ class FormContentFilterTests {
 
 
 	@Test
-	void wrapPutPatchAndDeleteOnly() throws Exception {
+	void wrapPutPatchQueryAndDeleteOnly() throws Exception {
 		for (HttpMethod method : HttpMethod.values()) {
 			MockHttpServletRequest request = new MockHttpServletRequest(method.name(), "/");
 			request.setContent("foo=bar".getBytes(StandardCharsets.ISO_8859_1));
 			request.setContentType("application/x-www-form-urlencoded; charset=ISO-8859-1");
 			this.filterChain = new MockFilterChain();
 			this.filter.doFilter(request, this.response, this.filterChain);
-			if (method == HttpMethod.PUT || method == HttpMethod.PATCH || method == HttpMethod.DELETE) {
+			if (method == HttpMethod.PUT || method == HttpMethod.PATCH || method == HttpMethod.QUERY || method == HttpMethod.DELETE) {
 				assertThat(this.filterChain.getRequest()).isNotSameAs(request);
 			}
 			else {

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
@@ -112,6 +112,15 @@ public interface WebClient {
 	RequestBodyUriSpec patch();
 
 	/**
+	 * Start building an HTTP QUERY request.
+	 * @return a spec for specifying the target URL
+	 * @see <a href="https://www.rfc-editor.org/rfc/rfc10008.html">RFC 10008</a>
+	 */
+	default RequestBodyUriSpec query() {
+		return method(HttpMethod.QUERY);
+	}
+
+	/**
 	 * Start building an HTTP DELETE request.
 	 * @return a spec for specifying the target URL
 	 */

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractMessageReaderArgumentResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/result/method/annotation/AbstractMessageReaderArgumentResolver.java
@@ -74,7 +74,7 @@ import org.springframework.web.server.UnsupportedMediaTypeStatusException;
 public abstract class AbstractMessageReaderArgumentResolver extends HandlerMethodArgumentResolverSupport {
 
 	private static final Set<HttpMethod> SUPPORTED_METHODS =
-			Set.of(HttpMethod.POST, HttpMethod.PUT, HttpMethod.PATCH);
+			Set.of(HttpMethod.POST, HttpMethod.PUT, HttpMethod.PATCH, HttpMethod.QUERY);
 
 
 	private final List<HttpMessageReader<?>> messageReaders;

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/RequestMappingHandlerMappingTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/result/method/annotation/RequestMappingHandlerMappingTests.java
@@ -202,6 +202,11 @@ class RequestMappingHandlerMappingTests {
 		assertComposedAnnotationMapping(RequestMethod.PATCH);
 	}
 
+	@Test
+	void queryMapping() {
+		assertComposedAnnotationMapping(RequestMethod.QUERY);
+	}
+
 	@Test  // gh-32049
 	void httpExchangeWithMultipleAnnotationsAtClassLevel() {
 		this.handlerMapping.afterPropertiesSet();
@@ -571,6 +576,10 @@ class RequestMappingHandlerMappingTests {
 
 		@PatchMapping("/patch")
 		public void patch() {
+		}
+
+		@RequestMapping(path = "/query", method = RequestMethod.QUERY)
+		public void query() {
 		}
 	}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodArgumentResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/mvc/method/annotation/AbstractMessageConverterMethodArgumentResolver.java
@@ -74,7 +74,8 @@ public abstract class AbstractMessageConverterMethodArgumentResolver implements 
 	protected enum ConverterType { BASE, GENERIC, SMART };
 
 
-	private static final Set<HttpMethod> SUPPORTED_METHODS = Set.of(HttpMethod.POST, HttpMethod.PUT, HttpMethod.PATCH);
+	private static final Set<HttpMethod> SUPPORTED_METHODS =
+			Set.of(HttpMethod.POST, HttpMethod.PUT, HttpMethod.PATCH, HttpMethod.QUERY);
 
 	private static final Object NO_VALUE = new Object();
 

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMappingTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/RequestMappingHandlerMappingTests.java
@@ -255,6 +255,11 @@ class RequestMappingHandlerMappingTests {
 		assertComposedAnnotationMapping(RequestMethod.PATCH);
 	}
 
+	@Test
+	void queryMapping() {
+		assertComposedAnnotationMapping(RequestMethod.QUERY);
+	}
+
 	@Test  // gh-32049
 	void httpExchangeWithMultipleAnnotationsAtClassLevel() throws NoSuchMethodException {
 		RequestMappingHandlerMapping mapping = createMapping();
@@ -630,6 +635,10 @@ class RequestMappingHandlerMappingTests {
 
 		@PatchMapping("/patch")
 		public void patch() {
+		}
+
+		@RequestMapping(path = "/query", method = RequestMethod.QUERY)
+		public void query() {
 		}
 
 	}

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ServletAnnotationControllerHandlerMethodTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/mvc/method/annotation/ServletAnnotationControllerHandlerMethodTests.java
@@ -895,6 +895,21 @@ class ServletAnnotationControllerHandlerMethodTests extends AbstractServletHandl
 	}
 
 	@PathPatternsParameterizedTest
+	void httpQuery(boolean usePathPatterns) throws Exception {
+		initDispatcherServlet(RequestResponseBodyController.class, usePathPatterns);
+
+		MockHttpServletRequest request = new MockHttpServletRequest("QUERY", "/something");
+		String requestBody = "Hello query!";
+		request.setContent(requestBody.getBytes(StandardCharsets.UTF_8));
+		request.addHeader("Content-Type", "text/plain; charset=utf-8");
+		request.addHeader("Accept", "text/*, */*");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		getServlet().service(request, response);
+		assertThat(response.getStatus()).isEqualTo(200);
+		assertThat(response.getContentAsString()).isEqualTo(requestBody);
+	}
+
+	@PathPatternsParameterizedTest
 	void responseBodyNoAcceptableMediaType(boolean usePathPatterns) throws Exception {
 		initDispatcherServlet(RequestResponseBodyProducesController.class, usePathPatterns, wac -> {
 			RootBeanDefinition adapterDef = new RootBeanDefinition(RequestMappingHandlerAdapter.class);
@@ -3135,6 +3150,12 @@ class ServletAnnotationControllerHandlerMethodTests extends AbstractServletHandl
 		@RequestMapping(value = "/something", method = RequestMethod.PATCH)
 		@ResponseBody
 		public String handlePartialUpdate(@RequestBody String content) throws IOException {
+			return content;
+		}
+
+		@RequestMapping(value = "/something", method = RequestMethod.QUERY)
+		@ResponseBody
+		public String handleQuery(@RequestBody String content) throws IOException {
 			return content;
 		}
 	}


### PR DESCRIPTION
Add support for the HTTP QUERY method across Spring's HTTP infrastructure. This change introduces QUERY as a standard HTTP method and integrates it with the relevant request mapping, client, server, and test infrastructure while preserving its safe and idempotent semantics. Includes tests covering QUERY method handling and request processing.