### PR TITLE
Avoid infinite recursion in `KotlinDetector.hasSerializableAnnotation`

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/KotlinDetector.java
+++ b/spring-core/src/main/java/org/springframework/core/KotlinDetector.java
@@ -18,6 +18,8 @@ package org.springframework.core;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
+import java.util.IdentityHashMap;
 
 import org.jspecify.annotations.Nullable;
 
@@ -141,6 +143,10 @@ public abstract class KotlinDetector {
 	 * @since 7.0
 	 */
 	public static boolean hasSerializableAnnotation(ResolvableType type) {
+		return hasSerializableAnnotation(type, new IdentityHashMap<>());
+	}
+
+	private static boolean hasSerializableAnnotation(ResolvableType type, IdentityHashMap<Type, Boolean> visitedTypes) {
 		Class<?> resolvedClass = type.resolve();
 		if (KOTLIN_SERIALIZABLE == null || resolvedClass == null) {
 			return false;
@@ -148,12 +154,31 @@ public abstract class KotlinDetector {
 		if (resolvedClass.isAnnotationPresent(KOTLIN_SERIALIZABLE)) {
 			return true;
 		}
-		for (ResolvableType genericType : type.getGenerics()) {
-			if (hasSerializableAnnotation(genericType)) {
-				return true;
-			}
+
+		Type sourceType = type.getType();
+		if (markVisited(visitedTypes, sourceType)) {
+			// Already visited - short circuit.
+			return false;
 		}
-		return false;
+
+		try {
+			for (ResolvableType genericType : type.getGenerics()) {
+				if (hasSerializableAnnotation(genericType, visitedTypes)) {
+					return true;
+				}
+			}
+			return false;
+		}
+		finally {
+			// `visitedTypes` are for cycle detection only, not global memoization.
+			visitedTypes.remove(sourceType);
+		}
+	}
+
+	@SuppressWarnings("ConstantValue")
+	private static boolean markVisited(IdentityHashMap<Type, Boolean> visitedTypes, Type type) {
+		// JSpecify based nullability analysis thinks that `put` always returns a non-null value
+		return visitedTypes.put(type, Boolean.TRUE) != null;
 	}
 
 }

--- a/spring-core/src/test/kotlin/org/springframework/core/KotlinDetectorTests.kt
+++ b/spring-core/src/test/kotlin/org/springframework/core/KotlinDetectorTests.kt
@@ -68,6 +68,15 @@ class KotlinDetectorTests {
 		Assertions.assertThat(KotlinDetector.hasSerializableAnnotation(ResolvableType.NONE)).isFalse()
 	}
 
+	@Test
+	fun hasSerializableAnnotationWithRecursiveGeneric() {
+		Assertions.assertThat(KotlinDetector.hasSerializableAnnotation(
+			ResolvableType.forClass(RecursiveGeneric::class.java))).isFalse()
+	}
+
+	// Real life example: Guava's `ImmutableEnumSet`.
+	class RecursiveGeneric<T : RecursiveGeneric<T>>
+
 	@JvmInline
 	value class ValueClass(val value: String)
 


### PR DESCRIPTION
## Overview

`KotlinDetector.hasSerializableAnnotation` recursively inspects generic types but did not account for self-referential generic bounds. Types such as Guava's `ImmutableEnumSet`, whose type parameter ultimately refers back to itself, therefore caused a `StackOverflowError` instead of returning whether Kotlin's `@Serializable` annotation is present.

This change tracks the underlying Java types by identity along the active traversal path. Repeated types short-circuit the current branch without invoking potentially recursive `ResolvableType.equals()` or `hashCode()` implementations, while removing types as the traversal unwinds preserves detection in separate and nested generic branches.

**AI use disclosure:** Assisted by Codex (5.6 Sol Extra High), edited and verified by hand.

Closes #37127.

## Changes

- Add identity-based cycle detection to `KotlinDetector.hasSerializableAnnotation`.
- Add a focused regression test using a minimal self-referential generic type without an external test dependency.

## Testing

- `./gradlew spring-core:test --tests org.springframework.core.KotlinDetectorTests`
- `./gradlew spring-core:checkstyleMain spring-core:checkstyleTest`
