### PR TITLE
Migrate ReflectivePropertyAccessor to use Property's four param constructor to avoid unneeded resolveName() call

### DIFF
--- a/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectivePropertyAccessor.java
+++ b/spring-expression/src/main/java/org/springframework/expression/spel/support/ReflectivePropertyAccessor.java
@@ -149,7 +149,7 @@ public class ReflectivePropertyAccessor implements PropertyAccessor {
 		if (method != null) {
 			// Treat it like a property...
 			// The readerCache will only contain gettable properties (let's not worry about setters for now).
-			Property property = new Property(type, method, null);
+			Property property = new Property(type, method, null, name);
 			TypeDescriptor typeDescriptor = new TypeDescriptor(property);
 			Method methodToInvoke = ClassUtils.getPubliclyAccessibleMethodIfPossible(method, type);
 			this.readerCache.put(cacheKey, new InvokerPair(methodToInvoke, typeDescriptor));
@@ -193,7 +193,7 @@ public class ReflectivePropertyAccessor implements PropertyAccessor {
 				if (method != null) {
 					// Treat it like a property...
 					// The readerCache will only contain gettable properties (let's not worry about setters for now).
-					Property property = new Property(type, method, null);
+					Property property = new Property(type, method, null, name);
 					TypeDescriptor typeDescriptor = new TypeDescriptor(property);
 					methodToInvoke = ClassUtils.getPubliclyAccessibleMethodIfPossible(method, type);
 					invoker = new InvokerPair(methodToInvoke, typeDescriptor);
@@ -251,7 +251,7 @@ public class ReflectivePropertyAccessor implements PropertyAccessor {
 		Method method = findSetterForProperty(name, type, target);
 		if (method != null) {
 			// Treat it like a property
-			Property property = new Property(type, null, method);
+			Property property = new Property(type, null, method, name);
 			TypeDescriptor typeDescriptor = new TypeDescriptor(property);
 			method = ClassUtils.getPubliclyAccessibleMethodIfPossible(method, type);
 			this.writerCache.put(cacheKey, method);


### PR DESCRIPTION
This PR implements the constructor migration mentioned in #37123. Since we already know the name of the property in `ReflectivePropertyAccessor`, `Property`'s four argument constructor is used to avoid the `resolveName()` call.