### PR TITLE
Ensure parsing/toString symmetry in ContentDisposition name

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
+++ b/spring-web/src/main/java/org/springframework/http/ContentDisposition.java
@@ -172,7 +172,7 @@ public final class ContentDisposition {
 			sb.append(this.type);
 		}
 		if (this.name != null) {
-			sb.append("; name=\"").append(this.name).append('\"');
+			sb.append("; name=\"").append(encodeQuotedPairs(this.name)).append('\"');
 		}
 		if (this.filename != null) {
 			if (this.charset == null || StandardCharsets.US_ASCII.equals(this.charset)) {
@@ -253,7 +253,7 @@ public final class ContentDisposition {
 						part.substring(eqIndex + 2, part.length() - 1) :
 						part.substring(eqIndex + 1));
 				if (attribute.equals("name") ) {
-					name = value;
+					name = (value.indexOf('\\') != -1 ? decodeQuotedPairs(value) : value);
 				}
 				else if (attribute.equals("filename*") ) {
 					int idx1 = value.indexOf('\'');

--- a/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
+++ b/spring-web/src/test/java/org/springframework/http/ContentDispositionTests.java
@@ -360,6 +360,17 @@ class ContentDispositionTests {
 							.build()
 							.toString());
 		}
+
+		@Test
+		void formatAndParseWithNameWithQuotes() {
+			ContentDisposition cd = ContentDisposition.formData()
+					.name("foo\"bar\\baz")
+					.build();
+			assertThat(cd.toString()).isEqualTo("form-data; name=\"foo\\\"bar\\\\baz\"");
+
+			ContentDisposition parsed = ContentDisposition.parse("form-data; name=\"foo\\\"bar\\\\baz\"");
+			assertThat(parsed.getName()).isEqualTo("foo\"bar\\baz");
+		}
 	}
 
 }


### PR DESCRIPTION
Closes gh-37064

### Overview
Currently, the parsing/`toString()` process for the `name` parameter in `ContentDisposition` is not symmetric when it comes to quoted-pairs (characters like `\"` and `\\`). 

While `ContentDisposition` already correctly encodes and decodes quoted-pairs for the `filename` parameter, the `name` parameter was written and read as a raw quoted string. As a result, formatting a name containing a quote or backslash produces malformed HTTP headers, and parsing them back yields corrupted names containing unescaped backslashes.

### Changes
- **Formatting**: Updated `ContentDisposition.toString()` to encode the `name` parameter using `encodeQuotedPairs(this.name)`.
- **Parsing**: Updated `ContentDisposition.parse()` to decode the parsed `name` value using `decodeQuotedPairs(value)` if a backslash is present.
- **Testing**: Added `formatAndParseWithNameWithQuotes` in `ContentDispositionTests` to assert formatting and parsing symmetry under nested quotes and backslashes.
