### PR TITLE
Update `MockCookie#parse(String)` validation

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/web/MockCookie.java
+++ b/spring-test/src/main/java/org/springframework/mock/web/MockCookie.java
@@ -132,7 +132,7 @@ public class MockCookie extends Cookie {
 	 * @return the created cookie
 	 */
 	public static MockCookie parse(String setCookieHeader) {
-		Assert.notNull(setCookieHeader, "Set-Cookie header must not be null");
+		Assert.hasText(setCookieHeader, "Set-Cookie header must not be null or empty");
 		String[] cookieParts = setCookieHeader.split("\\s*=\\s*", 2);
 		Assert.isTrue(cookieParts.length == 2, () -> "Invalid Set-Cookie header '" + setCookieHeader + "'");
 

--- a/spring-test/src/test/java/org/springframework/mock/web/MockCookieTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockCookieTests.java
@@ -121,13 +121,11 @@ class MockCookieTests {
 			.withMessageContaining("Set-Cookie header must not be null or empty");
 	}
 
-	@Test
-	void parseEmptyHeader() {
+	@ParameterizedTest
+	@ValueSource(strings = {"", "  "})
+	void parseEmptyHeader(String header) {
 		assertThatIllegalArgumentException()
-			.isThrownBy(() -> MockCookie.parse(""))
-			.withMessageContaining("Set-Cookie header must not be null or empty");
-		assertThatIllegalArgumentException()
-			.isThrownBy(() -> MockCookie.parse("  "))
+			.isThrownBy(() -> MockCookie.parse(header))
 			.withMessageContaining("Set-Cookie header must not be null or empty");
 	}
 

--- a/spring-test/src/test/java/org/springframework/mock/web/MockCookieTests.java
+++ b/spring-test/src/test/java/org/springframework/mock/web/MockCookieTests.java
@@ -118,7 +118,17 @@ class MockCookieTests {
 	void parseNullHeader() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> MockCookie.parse(null))
-			.withMessageContaining("Set-Cookie header must not be null");
+			.withMessageContaining("Set-Cookie header must not be null or empty");
+	}
+
+	@Test
+	void parseEmptyHeader() {
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> MockCookie.parse(""))
+			.withMessageContaining("Set-Cookie header must not be null or empty");
+		assertThatIllegalArgumentException()
+			.isThrownBy(() -> MockCookie.parse("  "))
+			.withMessageContaining("Set-Cookie header must not be null or empty");
 	}
 
 	@Test

--- a/spring-web/src/testFixtures/java/org/springframework/web/testfixture/servlet/MockCookie.java
+++ b/spring-web/src/testFixtures/java/org/springframework/web/testfixture/servlet/MockCookie.java
@@ -132,7 +132,7 @@ public class MockCookie extends Cookie {
 	 * @return the created cookie
 	 */
 	public static MockCookie parse(String setCookieHeader) {
-		Assert.notNull(setCookieHeader, "Set-Cookie header must not be null");
+		Assert.hasText(setCookieHeader, "Set-Cookie header must not be null or empty");
 		String[] cookieParts = setCookieHeader.split("\\s*=\\s*", 2);
 		Assert.isTrue(cookieParts.length == 2, () -> "Invalid Set-Cookie header '" + setCookieHeader + "'");
 


### PR DESCRIPTION
https://github.com/spring-projects/spring-framework/blob/68e6acd37ed0c12e395ef96d170971028e727383/spring-test/src/main/java/org/springframework/mock/web/MockCookie.java#L130-L132

Based on the Javadoc, I think it should throw `Set-Cookie header must not be null or empty` instead of `Invalid Set-Cookie header ''` when setCookieHeader is empty.