### PR TITLE
Reject write methods not starting with "set" in `Property`

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/convert/Property.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/Property.java
@@ -150,12 +150,11 @@ public final class Property {
 			return StringUtils.uncapitalize(this.readMethod.getName().substring(index));
 		}
 		else if (this.writeMethod != null) {
-			int index = this.writeMethod.getName().indexOf("set");
-			if (index == -1) {
+			String methodName = this.writeMethod.getName();
+			if (!methodName.startsWith("set")) {
 				throw new IllegalArgumentException("Not a setter method");
 			}
-			index += 3;
-			return StringUtils.uncapitalize(this.writeMethod.getName().substring(index));
+			return StringUtils.uncapitalize(methodName.substring(3));
 		}
 		else {
 			throw new IllegalStateException("Property is neither readable nor writable");

--- a/spring-core/src/test/java/org/springframework/core/convert/PropertyTests.java
+++ b/spring-core/src/test/java/org/springframework/core/convert/PropertyTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.core.convert;
+
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * Tests for {@link Property} setter name resolution.
+ *
+ * @author Junhyeong Kim
+ */
+class PropertyTests {
+
+	@Test
+	void resolveNameForSetter() throws Exception {
+		assertThat(writeProperty("setName").getName()).isEqualTo("name");
+	}
+
+	@Test  // no "set" token at all: rejected before and after this change
+	void rejectNonSetterWriteMethod() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> writeProperty("updateName"))
+				.withMessage("Not a setter method");
+	}
+
+	@Test  // "set" embedded mid-name: formerly accepted and resolved to "x"
+	void rejectWriteMethodEmbeddingSetInName() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> writeProperty("offsetX"))
+				.withMessage("Not a setter method");
+	}
+
+	@Test  // "set" at the end of the name: formerly accepted and resolved to ""
+	void rejectWriteMethodEndingWithSetToken() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> writeProperty("upset"))
+				.withMessage("Not a setter method");
+	}
+
+
+	private static Property writeProperty(String writeMethodName) throws Exception {
+		Method writeMethod = TestBean.class.getMethod(writeMethodName, String.class);
+		return new Property(TestBean.class, null, writeMethod);
+	}
+
+
+	@SuppressWarnings("unused")
+	static class TestBean {
+
+		public void setName(String name) {
+		}
+
+		public void updateName(String name) {
+		}
+
+		public void offsetX(String value) {
+		}
+
+		public void upset(String value) {
+		}
+	}
+
+}


### PR DESCRIPTION
## Overview

`org.springframework.core.convert.Property#resolveName()` derives a property
name from a write `Method` when no explicit name is given. It located the
`set` prefix with `String#indexOf`, which matches the token **anywhere** in
the method name.

## Problem

A write method whose name merely contains `set` is silently accepted and
resolves to a meaningless property name derived from whatever follows the
token:

| write method | current result | note |
| --- | --- | --- |
| `setName(String)` | `name` | intended behavior |
| `offsetX(String)` | `x` | not a setter, silently accepted |
| `upset(String)` | `""` (empty) | not a setter, empty name |
| `updateName(String)` | `IllegalArgumentException` | no `set` token at all |

An empty or wrong name then misleads `Property#getField()` and any consumer of
`Property#getName()`. Only names with no `set` token at all were rejected.

## Fix

Match the `set` prefix only at the start of the method name via `startsWith`.
Write methods that are not setters now consistently throw the existing
`IllegalArgumentException("Not a setter method")` instead of silently
producing a wrong name.

This was originally bundled into gh-36911 and has been extracted into this
dedicated PR as requested there, since it is a behavior change: write methods
that embed `set` mid-name were previously accepted and now throw.

## Note on impact

A remaining known gap, unchanged by this PR: a write method whose name starts
with `set` followed by a lowercase letter (for example `settle(String)`)
resolves to the stripped remainder (`tle`) before and after this change, since
prefix matching alone cannot tell it apart from a setter.

New exceptions surface at `Property` construction time for write methods
that are not setters (previously `offsetX`/`upset` shapes constructed
successfully with a wrong name). Framework-internal call sites are largely
unaffected: spring-beans passes an explicit property name, and SpEL searches
for `set`-prefixed methods — with one exotic exception: SpEL's Kotlin support
can surface a `@JvmName`-renamed setter, whose name previously either already
threw (no `set` token anywhere) or resolved to a coincidental name (`set`
mid-name) and now consistently throws. gh-37123 passes verified property
names explicitly at those SpEL call sites, which takes them off this code
path entirely.

## Tests

`PropertyTests` covers the intact `setName` happy path, the previously
rejected `updateName` shape, and the two newly rejected shapes (`offsetX`,
`upset`), asserting the exception message as well.

Note: gh-36911 also adds a `PropertyTests` class on its branch; whichever PR
lands second will be rebased to merge the two test classes.
