### PR TITLE
Avoid unnecessary allocations for cached annotation mappings

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationTypeMappings.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationTypeMappings.java
@@ -46,6 +46,7 @@ import org.springframework.util.ConcurrentReferenceHashMap;
  *
  * @author Phillip Webb
  * @author Sam Brannen
+ * @author Greg Taube
  * @since 5.2
  * @see AnnotationTypeMapping
  */
@@ -178,7 +179,7 @@ final class AnnotationTypeMappings {
 	 * @return type mappings for the annotation type
 	 */
 	static AnnotationTypeMappings forAnnotationType(Class<? extends Annotation> annotationType) {
-		return forAnnotationType(annotationType, new HashSet<>());
+		return forAnnotationType(annotationType, RepeatableContainers.standardRepeatables(), AnnotationFilter.PLAIN);
 	}
 
 	/**
@@ -208,7 +209,15 @@ final class AnnotationTypeMappings {
 	static AnnotationTypeMappings forAnnotationType(Class<? extends Annotation> annotationType,
 			RepeatableContainers repeatableContainers, AnnotationFilter annotationFilter) {
 
-		return forAnnotationType(annotationType, repeatableContainers, annotationFilter, new HashSet<>());
+		if (repeatableContainers == RepeatableContainers.standardRepeatables()) {
+			return standardRepeatablesCache.computeIfAbsent(annotationFilter,
+					key -> new Cache(repeatableContainers, key)).get(annotationType);
+		}
+		if (repeatableContainers == RepeatableContainers.none()) {
+			return noRepeatablesCache.computeIfAbsent(annotationFilter,
+					key -> new Cache(repeatableContainers, key)).get(annotationType);
+		}
+		return new AnnotationTypeMappings(repeatableContainers, annotationFilter, annotationType, new HashSet<>());
 	}
 
 	/**
@@ -275,6 +284,17 @@ final class AnnotationTypeMappings {
 		 * @return a new or existing {@link AnnotationTypeMappings} instance
 		 */
 		AnnotationTypeMappings get(Class<? extends Annotation> annotationType,
+				Set<Class<? extends Annotation>> visitedAnnotationTypes) {
+
+			return getOrCreate(annotationType, visitedAnnotationTypes);
+		}
+
+		AnnotationTypeMappings get(Class<? extends Annotation> annotationType) {
+			AnnotationTypeMappings result = this.mappings.get(annotationType);
+			return (result != null ? result : getOrCreate(annotationType, new HashSet<>()));
+		}
+
+		private AnnotationTypeMappings getOrCreate(Class<? extends Annotation> annotationType,
 				Set<Class<? extends Annotation>> visitedAnnotationTypes) {
 
 			AnnotationTypeMappings result = this.mappings.get(annotationType);

--- a/spring-core/src/main/java/org/springframework/core/annotation/AnnotationTypeMappings.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AnnotationTypeMappings.java
@@ -209,13 +209,9 @@ final class AnnotationTypeMappings {
 	static AnnotationTypeMappings forAnnotationType(Class<? extends Annotation> annotationType,
 			RepeatableContainers repeatableContainers, AnnotationFilter annotationFilter) {
 
-		if (repeatableContainers == RepeatableContainers.standardRepeatables()) {
-			return standardRepeatablesCache.computeIfAbsent(annotationFilter,
-					key -> new Cache(repeatableContainers, key)).get(annotationType);
-		}
-		if (repeatableContainers == RepeatableContainers.none()) {
-			return noRepeatablesCache.computeIfAbsent(annotationFilter,
-					key -> new Cache(repeatableContainers, key)).get(annotationType);
+		Cache cache = getCache(repeatableContainers, annotationFilter);
+		if (cache != null) {
+			return cache.get(annotationType);
 		}
 		return new AnnotationTypeMappings(repeatableContainers, annotationFilter, annotationType, new HashSet<>());
 	}
@@ -236,16 +232,26 @@ final class AnnotationTypeMappings {
 			RepeatableContainers repeatableContainers, AnnotationFilter annotationFilter,
 			Set<Class<? extends Annotation>> visitedAnnotationTypes) {
 
-		if (repeatableContainers == RepeatableContainers.standardRepeatables()) {
-			return standardRepeatablesCache.computeIfAbsent(annotationFilter,
-					key -> new Cache(repeatableContainers, key)).get(annotationType, visitedAnnotationTypes);
-		}
-		if (repeatableContainers == RepeatableContainers.none()) {
-			return noRepeatablesCache.computeIfAbsent(annotationFilter,
-					key -> new Cache(repeatableContainers, key)).get(annotationType, visitedAnnotationTypes);
+		Cache cache = getCache(repeatableContainers, annotationFilter);
+		if (cache != null) {
+			return cache.get(annotationType, visitedAnnotationTypes);
 		}
 		return new AnnotationTypeMappings(repeatableContainers, annotationFilter, annotationType,
 				visitedAnnotationTypes);
+	}
+
+	private static @Nullable Cache getCache(
+			RepeatableContainers repeatableContainers, AnnotationFilter annotationFilter) {
+
+		if (repeatableContainers == RepeatableContainers.standardRepeatables()) {
+			return standardRepeatablesCache.computeIfAbsent(annotationFilter,
+					key -> new Cache(repeatableContainers, key));
+		}
+		if (repeatableContainers == RepeatableContainers.none()) {
+			return noRepeatablesCache.computeIfAbsent(annotationFilter,
+					key -> new Cache(repeatableContainers, key));
+		}
+		return null;
 	}
 
 	static void clearCache() {

--- a/spring-core/src/test/java/org/springframework/core/annotation/AnnotationTypeMappingsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/AnnotationTypeMappingsTests.java
@@ -48,6 +48,13 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 class AnnotationTypeMappingsTests {
 
 	@Test
+	void forAnnotationTypeWhenCalledTwiceReturnsCachedInstance() {
+		AnnotationTypeMappings first = AnnotationTypeMappings.forAnnotationType(SimpleAnnotation.class);
+		AnnotationTypeMappings second = AnnotationTypeMappings.forAnnotationType(SimpleAnnotation.class);
+		assertThat(second).isSameAs(first);
+	}
+
+	@Test
 	void forAnnotationTypeWhenNoMetaAnnotationsReturnsMappings() {
 		AnnotationTypeMappings mappings = AnnotationTypeMappings.forAnnotationType(SimpleAnnotation.class);
 		assertThat(mappings.size()).isEqualTo(1);


### PR DESCRIPTION
`AnnotationTypeMappings.forAnnotationType(...)` currently creates a new
`HashSet` for visited annotation types before checking whether the mappings are
already cached. Cached lookups therefore allocate a set that is never used.

This change adds a cache-hit path that defers creation of the visited set until
a cache miss. Mapping creation and recursive annotation handling continue to
use the same visited-set logic.

## Benchmarks

I measured 20 million cached mapping lookups after 2 million warmup lookups on
JDK 26.0.2 with compact object headers and `-XX:TieredStopAtLevel=1`. Limiting
tiered compilation models the cold/C1-compiled startup path where JFR showed
the allocation; fully warmed C2 can scalar-replace it.

| | Baseline | This change | Difference |
|---|---:|---:|---:|
| Median time | 153.676 ns/op | 140.448 ns/op | -8.6% |
| Allocated | 72 bytes/op | 16 bytes/op | -77.8% |

I also patched only these two generated class files into Spring Core 7.0.8 and
recorded startup of a large Kotlin/Spring Boot application with 409 dependency
jars and 191 Spring Data repositories. JFR allocation samples changed as
follows:

| | Baseline | This change | Difference |
|---|---:|---:|---:|
| `HashSet` from `AnnotationTypeMappings` | 121.84 MiB | 0 MiB | -100% |
| Total sampled startup allocation | 9,216.72 MiB | 9,018.28 MiB | -2.15% |

Wall-clock application startup was too noisy to make an end-to-end timing
claim, so the timing result above is limited to the isolated cached lookup.

## Verification

`./gradlew :spring-core:check` passes, including the JDK 21 and JDK 24 test
suites, multi-release JAR validation, architecture checks, and checkstyle.
