### PR TITLE
Cache generic bean type lookups

### DIFF
--- a/spring-beans/src/jmh/java/org/springframework/beans/factory/DefaultListableBeanFactoryBenchmark.java
+++ b/spring-beans/src/jmh/java/org/springframework/beans/factory/DefaultListableBeanFactoryBenchmark.java
@@ -30,11 +30,13 @@ import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.beans.testfixture.beans.LifecycleBean;
 import org.springframework.beans.testfixture.beans.TestBean;
+import org.springframework.core.ResolvableType;
 
 /**
  * Benchmark for retrieving various bean types from the {@link DefaultListableBeanFactory}.
  *
  * @author Brian Clozel
+ * @author Greg Taube
  */
 @BenchmarkMode(Mode.Throughput)
 public class DefaultListableBeanFactoryBenchmark {
@@ -133,10 +135,39 @@ public class DefaultListableBeanFactoryBenchmark {
 		return state.beanFactory.getBean(B.class);
 	}
 
+	@State(Scope.Benchmark)
+	public static class GenericTypeLookupState extends Shared {
+
+		public ResolvableType type;
+
+		@Setup
+		public void setup() {
+			this.beanFactory = new DefaultListableBeanFactory();
+			this.beanFactory.registerBeanDefinition("generic", new RootBeanDefinition(StringGenericType.class));
+			for (int i = 0; i < 1000; i++) {
+				this.beanFactory.registerBeanDefinition("a" + i, new RootBeanDefinition(A.class));
+			}
+			this.beanFactory.freezeConfiguration();
+			this.type = ResolvableType.forClassWithGenerics(GenericType.class, String.class);
+			this.beanFactory.getBeanNamesForType(this.type);
+		}
+	}
+
+	@Benchmark
+	public Object genericTypeLookup(GenericTypeLookupState state) {
+		return state.beanFactory.getBeanNamesForType(state.type);
+	}
+
 	static class A {
 	}
 
 	static class B {
+	}
+
+	interface GenericType<T> {
+	}
+
+	static class StringGenericType implements GenericType<String> {
 	}
 
 }

--- a/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/support/DefaultListableBeanFactory.java
@@ -122,6 +122,7 @@ import org.springframework.util.StringUtils;
  * @author Phillip Webb
  * @author Stephane Nicoll
  * @author Sebastien Deleuze
+ * @author Greg Taube
  * @since 16 April 2001
  * @see #registerBeanDefinition
  * @see #addBeanPostProcessor
@@ -201,6 +202,12 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 
 	/** Map of singleton-only bean names, keyed by dependency type. */
 	private final Map<Class<?>, String[]> singletonBeanNamesByType = new ConcurrentHashMap<>(64);
+
+	/** Map of singleton and non-singleton bean names, keyed by generic dependency type. */
+	private final Map<ResolvableType, String[]> allBeanNamesByResolvableType = new ConcurrentHashMap<>(64);
+
+	/** Map of singleton-only bean names, keyed by generic dependency type. */
+	private final Map<ResolvableType, String[]> singletonBeanNamesByResolvableType = new ConcurrentHashMap<>(64);
 
 	/** List of bean definition names, in registration order. */
 	private volatile List<String> beanDefinitionNames = new ArrayList<>(256);
@@ -588,9 +595,20 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 		if (resolved != null && !type.hasGenerics()) {
 			return getBeanNamesForType(resolved, includeNonSingletons, allowEagerInit);
 		}
-		else {
+		if (!isConfigurationFrozen() || resolved == null || !allowEagerInit) {
 			return doGetBeanNamesForType(type, includeNonSingletons, allowEagerInit);
 		}
+		Map<ResolvableType, String[]> cache = (includeNonSingletons ? this.allBeanNamesByResolvableType :
+				this.singletonBeanNamesByResolvableType);
+		String[] resolvedBeanNames = cache.get(type);
+		if (resolvedBeanNames != null) {
+			return resolvedBeanNames;
+		}
+		resolvedBeanNames = doGetBeanNamesForType(type, includeNonSingletons, true);
+		if (isCacheSafe(type)) {
+			cache.put(type, resolvedBeanNames);
+		}
+		return resolvedBeanNames;
 	}
 
 	@Override
@@ -1476,6 +1494,10 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 		Predicate<Class<?>> filter = (beanType -> beanType != Object.class && beanType.isInstance(singletonObject));
 		this.allBeanNamesByType.keySet().removeIf(filter);
 		this.singletonBeanNamesByType.keySet().removeIf(filter);
+		Predicate<ResolvableType> resolvableFilter = (beanType -> beanType.resolve() != Object.class &&
+				beanType.isInstance(singletonObject));
+		this.allBeanNamesByResolvableType.keySet().removeIf(resolvableFilter);
+		this.singletonBeanNamesByResolvableType.keySet().removeIf(resolvableFilter);
 
 		if (this.primaryBeanNamesWithType.containsKey(beanName) && singletonObject.getClass() != NullBean.class) {
 			Class<?> beanType = (singletonObject instanceof FactoryBean<?> fb ?
@@ -1544,6 +1566,28 @@ public class DefaultListableBeanFactory extends AbstractAutowireCapableBeanFacto
 	private void clearByTypeCache() {
 		this.allBeanNamesByType.clear();
 		this.singletonBeanNamesByType.clear();
+		this.allBeanNamesByResolvableType.clear();
+		this.singletonBeanNamesByResolvableType.clear();
+	}
+
+	private boolean isCacheSafe(ResolvableType type) {
+		return isCacheSafe(type, Collections.newSetFromMap(new IdentityHashMap<>()));
+	}
+
+	private boolean isCacheSafe(ResolvableType type, Set<Object> seen) {
+		if (!seen.add(type.getType())) {
+			return true;
+		}
+		Class<?> resolved = type.resolve();
+		if (resolved == null || !ClassUtils.isCacheSafe(resolved, getBeanClassLoader())) {
+			return false;
+		}
+		for (ResolvableType generic : type.getGenerics()) {
+			if (!isCacheSafe(generic, seen)) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 

--- a/spring-beans/src/test/java/org/springframework/beans/factory/DefaultListableBeanFactoryTests.java
+++ b/spring-beans/src/test/java/org/springframework/beans/factory/DefaultListableBeanFactoryTests.java
@@ -115,6 +115,7 @@ import static org.mockito.Mockito.verify;
  * @author Phillip Webb
  * @author Stephane Nicoll
  * @author Yanming Zhou
+ * @author Greg Taube
  */
 class DefaultListableBeanFactoryTests {
 
@@ -3263,6 +3264,53 @@ class DefaultListableBeanFactoryTests {
 		assertThat(lbf.getBeanNamesForType(Object.class)).containsExactly(StringUtils.addStringToArray(allBeanNames, "bd3"));
 	}
 
+	@Test
+	void cachesBeanNamesForGenericType() {
+		lbf.registerBeanDefinition("cityRepository", new RootBeanDefinition(CityRepository.class));
+		lbf.freezeConfiguration();
+
+		ResolvableType repositoryType = ResolvableType.forClassWithGenerics(Repository.class, City.class, Long.class);
+		String[] beanNames = lbf.getBeanNamesForType(repositoryType);
+
+		assertThat(lbf.getBeanNamesForType(repositoryType)).isSameAs(beanNames);
+
+		lbf.registerSingleton("testBean", new TestBean());
+		assertThat(lbf.getBeanNamesForType(repositoryType)).isSameAs(beanNames);
+
+		lbf.registerSingleton("anotherCityRepository", new CityRepository());
+		assertThat(lbf.getBeanNamesForType(repositoryType)).containsExactly("cityRepository", "anotherCityRepository")
+				.isNotSameAs(beanNames);
+	}
+
+	@Test
+	void cachesSingletonBeanNamesForGenericType() {
+		RootBeanDefinition beanDefinition = new RootBeanDefinition(CityRepository.class);
+		beanDefinition.setScope(BeanDefinition.SCOPE_PROTOTYPE);
+		lbf.registerBeanDefinition("cityRepository", beanDefinition);
+		lbf.freezeConfiguration();
+
+		ResolvableType repositoryType = ResolvableType.forClassWithGenerics(Repository.class, City.class, Long.class);
+		String[] beanNames = lbf.getBeanNamesForType(repositoryType, false, true);
+
+		assertThat(lbf.getBeanNamesForType(repositoryType, false, true)).isSameAs(beanNames);
+
+		lbf.registerSingleton("anotherCityRepository", new CityRepository());
+		assertThat(lbf.getBeanNamesForType(repositoryType, false, true)).containsExactly("anotherCityRepository")
+				.isNotSameAs(beanNames);
+	}
+
+	@Test
+	void cachesBeanNamesForRecursiveGenericType() {
+		lbf.registerBeanDefinition("recursive", new RootBeanDefinition(RecursiveImpl.class));
+		lbf.freezeConfiguration();
+
+		ResolvableType recursiveType = ResolvableType.forClass(Recursive.class);
+		String[] beanNames = lbf.getBeanNamesForType(recursiveType);
+
+		assertThat(beanNames).containsExactly("recursive");
+		assertThat(lbf.getBeanNamesForType(recursiveType)).isSameAs(beanNames);
+	}
+
 
 	private int registerBeanDefinitions(Properties p) {
 		return registerBeanDefinitions(p, null);
@@ -3567,6 +3615,14 @@ class DefaultListableBeanFactoryTests {
 	public record City(String name) {}
 
 	public static class CityRepository implements Repository<City, Long> {}
+
+
+	public interface Recursive<T extends Recursive<T>> {
+	}
+
+
+	public static class RecursiveImpl implements Recursive<RecursiveImpl> {
+	}
 
 
 	public static class LazyInitFactory implements FactoryBean<Object> {


### PR DESCRIPTION
Repeated `getBeanNamesForType(ResolvableType)` calls currently rescan every bean definition even after configuration is frozen. This differs from the `Class` overload, which caches its results.

This showed up in an allocation profile of a large Spring Boot application. Its startup made 271 generic type queries for only 51 distinct types; 220 were repeated after configuration had been frozen. In particular, creating seven `HttpSecurity` instances repeated the same top-level `Customizer<T>` lookups.

A backport of this change into the application's Spring Framework 7.0.8 dependency reduced sampled allocation under `doGetBeanNamesForType` from an average of 490.1 MiB to 308.3 MiB (-37.1%). Allocation below `isTypeMatch` and `ResolvableType` fell from 283.3 MiB to 112.8 MiB (-60.2%). Whole-application startup time was too noisy to claim a reliable improvement because Hibernate query parsing and concurrent JIT compilation dominate that measurement.

The included JMH benchmark performs a repeated generic lookup in a frozen bean factory containing 1,001 bean definitions. On JDK 25.0.4, Apple Silicon:

| | Throughput | Allocation |
| --- | ---: | ---: |
| Before | 32,333 ops/s | 192,648 B/op |
| After | 422,750,679 ops/s | approximately 0 B/op |

The new caches mirror the existing raw-type caches. They are used only for frozen configuration with eager initialization allowed, reject keys containing classes that are unsafe for the bean class loader, invalidate matching entries when a singleton appears, and are cleared with the other by-type caches. Tests cover both all-bean and singleton-only caches, invalidation by matching and nonmatching singletons, and recursive generic bounds.
