### PR TITLE
Rethrow IOException as ResourceAccessException in RestClient response…

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/client/DefaultRestClient.java
+++ b/spring-web/src/main/java/org/springframework/web/client/DefaultRestClient.java
@@ -231,16 +231,19 @@ final class DefaultRestClient implements RestClient {
 			return RestClientUtils.readWithMessageConverters(
 					clientResponse, this.messageConverters, bodyType, bodyClass, hints);
 		}
+		catch (RestClientException ex) {
+			throw ex;
+		}
 		catch (UncheckedIOException | IOException exc) {
-			Throwable cause;
+			IOException cause;
 			if (exc instanceof UncheckedIOException uncheckedIOException) {
-				cause = uncheckedIOException.getCause();
+				IOException unwrapped = uncheckedIOException.getCause();
+				cause = (unwrapped != null ? unwrapped : new IOException(uncheckedIOException.getMessage(), uncheckedIOException));
 			}
 			else {
-				cause = exc;
+				cause = (IOException) exc;
 			}
-			throw new RestClientException("Error while extracting response for type [" +
-					ResolvableType.forType(bodyType) + "] and content type [" + RestClientUtils.getContentType(clientResponse) + "]", cause);
+			throw new ResourceAccessException("I/O error while reading response: " + cause.getMessage(), cause);
 		}
 	}
 

--- a/spring-web/src/main/java/org/springframework/web/client/RestClientUtils.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestClientUtils.java
@@ -109,7 +109,10 @@ abstract class RestClientUtils {
 				}
 			}
 		}
-		catch (IOException | HttpMessageNotReadableException ex) {
+		catch (IOException ex) {
+			throw new ResourceAccessException("I/O error while reading response: " + ex.getMessage(), ex);
+		}
+		catch (HttpMessageNotReadableException ex) {
 			throw new RestClientException("Error while extracting response for type [" +
 					ResolvableType.forType(bodyType) + "] and content type [" + contentType + "]", ex);
 		}

--- a/spring-web/src/test/java/org/springframework/web/client/DefaultRestClientTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/DefaultRestClientTests.java
@@ -40,6 +40,7 @@ import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.ClientHttpResponse;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -147,6 +148,49 @@ class DefaultRestClientTests {
 	}
 
 
+	/**
+	 * Regression test for <a href="https://github.com/spring-projects/spring-framework/issues/37078">gh-37078</a>.
+	 * An IOException (e.g. SocketTimeoutException) that occurs while reading the response body
+	 * must be rethrown as a {@link ResourceAccessException} — not masked as a generic
+	 * {@code RestClientException} with a misleading content-type error message.
+	 */
+	@Test
+	void ioExceptionDuringBodyReadIsRewrappedAsResourceAccessException() throws IOException {
+		mockSentRequest(HttpMethod.GET, URL);
+		mockResponseStatus(HttpStatus.OK);
+
+		HttpHeaders responseHeaders = new HttpHeaders();
+		responseHeaders.setContentType(MediaType.APPLICATION_JSON);
+		responseHeaders.setContentLength(42L);
+		given(this.response.getHeaders()).willReturn(responseHeaders);
+
+		// Simulate a SocketTimeoutException thrown during response body read
+		java.net.SocketTimeoutException timeout = new java.net.SocketTimeoutException("Read timed out");
+		given(this.response.getBody()).willThrow(timeout);
+
+		assertThatExceptionOfType(ResourceAccessException.class)
+				.isThrownBy(() -> this.client.get().uri(URL).retrieve().body(String.class))
+				.withCauseInstanceOf(java.net.SocketTimeoutException.class)
+				.withMessageContaining("I/O error while reading response");
+	}
+
+	/**
+	 * Complementary test: a genuine deserialization failure (content-type mismatch or
+	 * {@link org.springframework.http.converter.HttpMessageNotReadableException}) must
+	 * still surface as a {@link RestClientException} with the content-type diagnostic.
+	 */
+	@Test
+	void deserializationFailureKeepsContentTypeDiagnosticMessage() throws IOException {
+		mockSentRequest(HttpMethod.GET, URL);
+		mockResponseStatus(HttpStatus.OK);
+		// Body is plain text but client requests JSON deserialization into a non-String type
+		mockResponseBody(BODY, MediaType.TEXT_PLAIN);
+
+		assertThatExceptionOfType(UnknownContentTypeException.class)
+				.isThrownBy(() -> this.client.get().uri(URL).retrieve().body(java.util.List.class));
+	}
+
+
 	private void mockSentRequest(HttpMethod method, String uri) throws IOException {
 		given(this.requestFactory.createRequest(URI.create(uri), method)).willReturn(this.request);
 		given(this.request.getHeaders()).willReturn(new HttpHeaders());
@@ -176,3 +220,4 @@ class DefaultRestClientTests {
 	}
 
 }
+


### PR DESCRIPTION
… reading

readWithMessageConverters in DefaultRestClient and RestClientUtils was catching IOException (e.g. SocketTimeoutException) together with HttpMessageNotReadableException and wrapping both in a generic RestClientException with the misleading message:

  'Error while extracting response for type [...] and content type [...]'

This caused developers to investigate content-type mismatches when the actual issue was a network I/O failure, making debugging significantly harder.

Fix: split the combined catch so that:
- IOException / UncheckedIOException → ResourceAccessException, which is the semantically correct exception already used elsewhere in RestClient and RestTemplate for low-level I/O failures.
- HttpMessageNotReadableException → RestClientException with the original content-type diagnostic message (unchanged behavior).

Closes gh-37078