### PR TITLE
Accept @Nullable contextPath in ServerHttpRequest.Builder

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/reactive/DefaultServerHttpRequestBuilder.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/DefaultServerHttpRequestBuilder.java
@@ -103,7 +103,7 @@ class DefaultServerHttpRequestBuilder implements ServerHttpRequest.Builder {
 	}
 
 	@Override
-	public ServerHttpRequest.Builder contextPath(String contextPath) {
+	public ServerHttpRequest.Builder contextPath(@Nullable String contextPath) {
 		this.contextPath = contextPath;
 		return this;
 	}

--- a/spring-web/src/main/java/org/springframework/http/server/reactive/ServerHttpRequest.java
+++ b/spring-web/src/main/java/org/springframework/http/server/reactive/ServerHttpRequest.java
@@ -146,8 +146,11 @@ public interface ServerHttpRequest extends HttpRequest, ReactiveHttpInputMessage
 		 * contextPath} and it must match the start of the path of the URI of
 		 * the request. That means changing the contextPath, implies also
 		 * changing the path via {@link #path(String)}.
+		 * <p>A {@code null} value is treated the same as an empty string and
+		 * results in an empty context path.
 		 */
-		Builder contextPath(String contextPath);
+		Builder contextPath(@Nullable String contextPath);
+
 
 		/**
 		 * Set or override the specified header values under the given name.

--- a/spring-web/src/test/java/org/springframework/http/server/reactive/DefaultServerHttpRequestBuilderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/server/reactive/DefaultServerHttpRequestBuilderTests.java
@@ -91,6 +91,15 @@ class DefaultServerHttpRequestBuilderTests {
 		return mock;
 	}
 
+	@org.junit.jupiter.api.Test
+	void contextPathNullable() {
+		ServerHttpRequest request = MockServerHttpRequest.get("/foo/bar").contextPath("/foo").build();
+		assertThat(request.getPath().contextPath().value()).isEqualTo("/foo");
+
+		ServerHttpRequest mutated = request.mutate().contextPath(null).build();
+		assertThat(mutated.getPath().contextPath().value()).isEmpty();
+	}
+
 	static Arguments initHeader(String description, MultiValueMap<String, String> headerMap) {
 		headerMap.add("CaseInsensitive", "unmodified");
 		return argumentSet(description, headerMap, true);
@@ -111,3 +120,4 @@ class DefaultServerHttpRequestBuilderTests {
 	}
 
 }
+


### PR DESCRIPTION
Mark the `contextPath` parameter as `@Nullable` in both the `ServerHttpRequest.Builder` interface and `DefaultServerHttpRequestBuilder` implementation.

Previously, although `DefaultServerHttpRequestBuilder` handled null values internally (e.g., in `MutatedServerHttpRequest` and `DefaultRequestPath.initContextPath()`), the public interface lacked the `@Nullable` annotation. In a `@NullMarked` package, this caused compile-time validation issues (such as under NullAway) for callers trying to pass `null` to reset/clear the context path.

Closes gh-37098