### PR TITLE
Include enum array attributes in TypeNotPresentException probing

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/annotation/AttributeMethods.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AttributeMethods.java
@@ -81,7 +81,8 @@ final class AttributeMethods {
 				foundNestedAnnotation = true;
 			}
 			ReflectionUtils.makeAccessible(method);
-			this.canThrowTypeNotPresentException[i] = (type == Class.class || type == Class[].class || type.isEnum());
+			this.canThrowTypeNotPresentException[i] = (type == Class.class || type == Class[].class ||
+					type.isEnum() || (type.isArray() && type.componentType().isEnum()));
 		}
 		this.hasDefaultValueMethod = foundDefaultValueMethod;
 		this.hasNestedAnnotation = foundNestedAnnotation;

--- a/spring-core/src/test/java/org/springframework/core/annotation/AttributeMethodsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/AttributeMethodsTests.java
@@ -90,6 +90,18 @@ class AttributeMethodsTests {
 	}
 
 	@Test
+	void canThrowTypeNotPresentExceptionWhenHasEnumArrayAttributeReturnsTrue() {
+		AttributeMethods methods = AttributeMethods.forAnnotationType(EnumArrayValue.class);
+		assertThat(methods.canThrowTypeNotPresentException(0)).isTrue();
+	}
+
+	@Test
+	void canThrowTypeNotPresentExceptionWhenHasNonEnumArrayAttributeReturnsFalse() {
+		AttributeMethods methods = AttributeMethods.forAnnotationType(StringArrayValue.class);
+		assertThat(methods.canThrowTypeNotPresentException(0)).isFalse();
+	}
+
+	@Test
 	void canThrowTypeNotPresentExceptionWhenNotClassOrClassArrayAttributeReturnsFalse() {
 		AttributeMethods methods = AttributeMethods.forAnnotationType(ValueOnly.class);
 		assertThat(methods.canThrowTypeNotPresentException(0)).isFalse();
@@ -137,6 +149,38 @@ class AttributeMethodsTests {
 	void validateWhenDoesNotHaveTypeNotPresentExceptionThrowsNothing() {
 		ClassValue annotation = mockAnnotation(ClassValue.class);
 		given(annotation.value()).willReturn((Class) InputStream.class);
+		AttributeMethods attributes = AttributeMethods.forAnnotationType(annotation.annotationType());
+		attributes.validate(annotation);
+	}
+
+	@Test
+	void isValidWhenHasEnumConstantNotPresentExceptionReturnsFalse() {
+		EnumArrayValue annotation = mockAnnotation(EnumArrayValue.class);
+		given(annotation.value()).willThrow(new EnumConstantNotPresentException(ExampleEnum.class, "MISSING"));
+		AttributeMethods attributes = AttributeMethods.forAnnotationType(annotation.annotationType());
+		assertThat(attributes.canLoad(annotation, getClass())).isFalse();
+	}
+
+	@Test
+	void isValidWhenDoesNotHaveEnumConstantNotPresentExceptionReturnsTrue() {
+		EnumArrayValue annotation = mockAnnotation(EnumArrayValue.class);
+		given(annotation.value()).willReturn(new ExampleEnum[] {ExampleEnum.ONE});
+		AttributeMethods attributes = AttributeMethods.forAnnotationType(annotation.annotationType());
+		assertThat(attributes.canLoad(annotation, getClass())).isTrue();
+	}
+
+	@Test
+	void validateWhenHasEnumConstantNotPresentExceptionThrowsException() {
+		EnumArrayValue annotation = mockAnnotation(EnumArrayValue.class);
+		given(annotation.value()).willThrow(new EnumConstantNotPresentException(ExampleEnum.class, "MISSING"));
+		AttributeMethods attributes = AttributeMethods.forAnnotationType(annotation.annotationType());
+		assertThatIllegalStateException().isThrownBy(() -> attributes.validate(annotation));
+	}
+
+	@Test
+	void validateWhenDoesNotHaveEnumConstantNotPresentExceptionThrowsNothing() {
+		EnumArrayValue annotation = mockAnnotation(EnumArrayValue.class);
+		given(annotation.value()).willReturn(new ExampleEnum[] {ExampleEnum.ONE});
 		AttributeMethods attributes = AttributeMethods.forAnnotationType(annotation.annotationType());
 		attributes.validate(annotation);
 	}
@@ -205,6 +249,26 @@ class AttributeMethodsTests {
 		String two();
 
 		String three() default "3";
+
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface EnumArrayValue {
+
+		ExampleEnum[] value();
+
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface StringArrayValue {
+
+		String[] value();
+
+	}
+
+	enum ExampleEnum {
+
+		ONE
 
 	}
 


### PR DESCRIPTION
## Overview

`AttributeMethods` marks attributes whose values may fail to resolve at runtime (`Class`, `Class[]`, and enum types) so that `canLoad()` and `validate()` can probe them, allowing annotations that cannot be safely loaded to be filtered during scanning. Enum array attributes are missing from this check, while the adjacent nested-annotation detection already covers both the scalar and array cases.

## Problem

An annotation attribute of an enum array type whose bytecode references a constant that no longer exists in the enum loaded at runtime (a binary-incompatible classpath, for example partially upgraded dependencies) is not probed, so the annotation passes `canLoad()`:

- `MergedAnnotations` reports the annotation as present, while a single-enum attribute in the same situation is filtered with a warning log.
- `asMap()` returns a map containing the `EnumConstantNotPresentException` instance as the attribute value, silently corrupting `AnnotationAttributes`-based consumers.
- Typed access such as `getEnumArray(..)` or invoking the attribute on a synthesized annotation throws a raw `EnumConstantNotPresentException`.

The single-enum case has been covered since the check was introduced, so scalar and array attributes of the same type currently behave inconsistently.

## Fix

Extend the `canThrowTypeNotPresentException` computation with `type.isArray() && type.componentType().isEnum()`, mirroring the nested-annotation idiom on the adjacent line. Such annotations are now filtered during scanning exactly like their single-enum counterparts: `isPresent()` returns `false` with a warning log, and typed access follows the regular missing-annotation contract instead of leaking the raw exception.

The probe adds the same kind of cost as the existing `Class[]` probing, and only for enum array attributes. The scope of this change is intentionally limited to enum arrays.

Tests cover the probe flag, `canLoad()` and `validate()` for both the failing and the healthy case, and a non-enum array guard verifying the new condition does not widen the probe to other array types.
