### PR TITLE
Extend TypeNotPresentException probing to nested annotations

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/annotation/AttributeMethods.java
+++ b/spring-core/src/main/java/org/springframework/core/annotation/AttributeMethods.java
@@ -77,11 +77,13 @@ final class AttributeMethods {
 			if (!foundDefaultValueMethod && (method.getDefaultValue() != null)) {
 				foundDefaultValueMethod = true;
 			}
-			if (!foundNestedAnnotation && (type.isAnnotation() || (type.isArray() && type.componentType().isAnnotation()))) {
+			boolean nestedAnnotation = (type.isAnnotation() || (type.isArray() && type.componentType().isAnnotation()));
+			if (!foundNestedAnnotation && nestedAnnotation) {
 				foundNestedAnnotation = true;
 			}
 			ReflectionUtils.makeAccessible(method);
-			this.canThrowTypeNotPresentException[i] = (type == Class.class || type == Class[].class || type.isEnum());
+			this.canThrowTypeNotPresentException[i] = (type == Class.class || type == Class[].class ||
+					type.isEnum() || nestedAnnotation);
 		}
 		this.hasDefaultValueMethod = foundDefaultValueMethod;
 		this.hasNestedAnnotation = foundNestedAnnotation;
@@ -104,7 +106,10 @@ final class AttributeMethods {
 		for (int i = 0; i < size(); i++) {
 			if (canThrowTypeNotPresentException(i)) {
 				try {
-					AnnotationUtils.invokeAnnotationMethod(get(i), annotation);
+					Object value = AnnotationUtils.invokeAnnotationMethod(get(i), annotation);
+					if (!canLoadNestedAnnotations(value, source)) {
+						return false;
+					}
 				}
 				catch (IllegalStateException ex) {
 					// Plain invocation failure to expose -> leave up to attribute retrieval
@@ -116,6 +121,20 @@ final class AttributeMethods {
 						failureLogger.log("Failed to introspect meta-annotation @" +
 								annotation.annotationType().getSimpleName(), source, ex);
 					}
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	private boolean canLoadNestedAnnotations(@Nullable Object value, AnnotatedElement source) {
+		if (value instanceof Annotation nested) {
+			return forAnnotationType(nested.annotationType()).canLoad(nested, source);
+		}
+		if (value instanceof Annotation[] nestedArray) {
+			for (Annotation nested : nestedArray) {
+				if (!forAnnotationType(nested.annotationType()).canLoad(nested, source)) {
 					return false;
 				}
 			}
@@ -138,7 +157,8 @@ final class AttributeMethods {
 		for (int i = 0; i < size(); i++) {
 			if (canThrowTypeNotPresentException(i)) {
 				try {
-					AnnotationUtils.invokeAnnotationMethod(get(i), annotation);
+					Object value = AnnotationUtils.invokeAnnotationMethod(get(i), annotation);
+					validateNestedAnnotations(value);
 				}
 				catch (IllegalStateException ex) {
 					throw ex;
@@ -148,6 +168,17 @@ final class AttributeMethods {
 							"Could not obtain annotation attribute value for " + get(i).getName() +
 							" declared on @" + ClassUtils.getCanonicalName(annotation.annotationType()), ex);
 				}
+			}
+		}
+	}
+
+	private void validateNestedAnnotations(@Nullable Object value) {
+		if (value instanceof Annotation nested) {
+			forAnnotationType(nested.annotationType()).validate(nested);
+		}
+		else if (value instanceof Annotation[] nestedArray) {
+			for (Annotation nested : nestedArray) {
+				forAnnotationType(nested.annotationType()).validate(nested);
 			}
 		}
 	}

--- a/spring-core/src/test/java/org/springframework/core/annotation/AttributeMethodsTests.java
+++ b/spring-core/src/test/java/org/springframework/core/annotation/AttributeMethodsTests.java
@@ -90,6 +90,18 @@ class AttributeMethodsTests {
 	}
 
 	@Test
+	void canThrowTypeNotPresentExceptionWhenHasAnnotationAttributeReturnsTrue() {
+		AttributeMethods methods = AttributeMethods.forAnnotationType(NestedValue.class);
+		assertThat(methods.canThrowTypeNotPresentException(0)).isTrue();
+	}
+
+	@Test
+	void canThrowTypeNotPresentExceptionWhenHasAnnotationArrayAttributeReturnsTrue() {
+		AttributeMethods methods = AttributeMethods.forAnnotationType(NestedArrayValue.class);
+		assertThat(methods.canThrowTypeNotPresentException(0)).isTrue();
+	}
+
+	@Test
 	void canThrowTypeNotPresentExceptionWhenNotClassOrClassArrayAttributeReturnsFalse() {
 		AttributeMethods methods = AttributeMethods.forAnnotationType(ValueOnly.class);
 		assertThat(methods.canThrowTypeNotPresentException(0)).isFalse();
@@ -139,6 +151,117 @@ class AttributeMethodsTests {
 		given(annotation.value()).willReturn((Class) InputStream.class);
 		AttributeMethods attributes = AttributeMethods.forAnnotationType(annotation.annotationType());
 		attributes.validate(annotation);
+	}
+
+	@Test
+	void isValidWhenNestedAnnotationHasEnumConstantNotPresentExceptionReturnsFalse() {
+		EnumValueInner inner = mockBrokenEnumValueInner();
+		NestedValue annotation = mockAnnotation(NestedValue.class);
+		given(annotation.value()).willReturn(inner);
+		AttributeMethods attributes = AttributeMethods.forAnnotationType(annotation.annotationType());
+		assertThat(attributes.canLoad(annotation, getClass())).isFalse();
+	}
+
+	@Test
+	void isValidWhenNestedAnnotationDoesNotHaveEnumConstantNotPresentExceptionReturnsTrue() {
+		EnumValueInner inner = mockHealthyEnumValueInner();
+		NestedValue annotation = mockAnnotation(NestedValue.class);
+		given(annotation.value()).willReturn(inner);
+		AttributeMethods attributes = AttributeMethods.forAnnotationType(annotation.annotationType());
+		assertThat(attributes.canLoad(annotation, getClass())).isTrue();
+	}
+
+	@Test
+	void validateWhenNestedAnnotationHasEnumConstantNotPresentExceptionThrowsException() {
+		EnumValueInner inner = mockBrokenEnumValueInner();
+		NestedValue annotation = mockAnnotation(NestedValue.class);
+		given(annotation.value()).willReturn(inner);
+		AttributeMethods attributes = AttributeMethods.forAnnotationType(annotation.annotationType());
+		assertThatIllegalStateException().isThrownBy(() -> attributes.validate(annotation))
+				.withMessageContaining("EnumValueInner")
+				.withCauseInstanceOf(EnumConstantNotPresentException.class);
+	}
+
+	@Test
+	void validateWhenNestedAnnotationDoesNotHaveEnumConstantNotPresentExceptionThrowsNothing() {
+		EnumValueInner inner = mockHealthyEnumValueInner();
+		NestedValue annotation = mockAnnotation(NestedValue.class);
+		given(annotation.value()).willReturn(inner);
+		AttributeMethods attributes = AttributeMethods.forAnnotationType(annotation.annotationType());
+		attributes.validate(annotation);
+	}
+
+	@Test
+	void isValidWhenNestedAnnotationArrayHasEnumConstantNotPresentExceptionReturnsFalse() {
+		EnumValueInner inner = mockBrokenEnumValueInner();
+		NestedArrayValue annotation = mockAnnotation(NestedArrayValue.class);
+		given(annotation.value()).willReturn(new EnumValueInner[] {inner});
+		AttributeMethods attributes = AttributeMethods.forAnnotationType(annotation.annotationType());
+		assertThat(attributes.canLoad(annotation, getClass())).isFalse();
+	}
+
+	@Test
+	void isValidWhenNestedAnnotationArrayDoesNotHaveEnumConstantNotPresentExceptionReturnsTrue() {
+		EnumValueInner inner = mockHealthyEnumValueInner();
+		NestedArrayValue annotation = mockAnnotation(NestedArrayValue.class);
+		given(annotation.value()).willReturn(new EnumValueInner[] {inner});
+		AttributeMethods attributes = AttributeMethods.forAnnotationType(annotation.annotationType());
+		assertThat(attributes.canLoad(annotation, getClass())).isTrue();
+	}
+
+	@Test
+	void isValidWhenNestedAnnotationArrayIsEmptyReturnsTrue() {
+		NestedArrayValue annotation = mockAnnotation(NestedArrayValue.class);
+		given(annotation.value()).willReturn(new EnumValueInner[0]);
+		AttributeMethods attributes = AttributeMethods.forAnnotationType(annotation.annotationType());
+		assertThat(attributes.canLoad(annotation, getClass())).isTrue();
+	}
+
+	@Test
+	void validateWhenNestedAnnotationArrayHasEnumConstantNotPresentExceptionThrowsException() {
+		EnumValueInner inner = mockBrokenEnumValueInner();
+		NestedArrayValue annotation = mockAnnotation(NestedArrayValue.class);
+		given(annotation.value()).willReturn(new EnumValueInner[] {inner});
+		AttributeMethods attributes = AttributeMethods.forAnnotationType(annotation.annotationType());
+		assertThatIllegalStateException().isThrownBy(() -> attributes.validate(annotation))
+				.withMessageContaining("EnumValueInner")
+				.withCauseInstanceOf(EnumConstantNotPresentException.class);
+	}
+
+	@Test
+	void isValidWhenDeeplyNestedAnnotationHasEnumConstantNotPresentExceptionReturnsFalse() {
+		EnumValueInner inner = mockBrokenEnumValueInner();
+		NestedValue nested = mockAnnotation(NestedValue.class);
+		given(nested.value()).willReturn(inner);
+		DeepNestedValue annotation = mockAnnotation(DeepNestedValue.class);
+		given(annotation.value()).willReturn(nested);
+		AttributeMethods attributes = AttributeMethods.forAnnotationType(annotation.annotationType());
+		assertThat(attributes.canLoad(annotation, getClass())).isFalse();
+	}
+
+	@Test
+	void validateWhenDeeplyNestedAnnotationHasEnumConstantNotPresentExceptionThrowsException() {
+		EnumValueInner inner = mockBrokenEnumValueInner();
+		NestedValue nested = mockAnnotation(NestedValue.class);
+		given(nested.value()).willReturn(inner);
+		DeepNestedValue annotation = mockAnnotation(DeepNestedValue.class);
+		given(annotation.value()).willReturn(nested);
+		AttributeMethods attributes = AttributeMethods.forAnnotationType(annotation.annotationType());
+		assertThatIllegalStateException().isThrownBy(() -> attributes.validate(annotation))
+				.withMessageContaining("EnumValueInner")
+				.withCauseInstanceOf(EnumConstantNotPresentException.class);
+	}
+
+	private EnumValueInner mockBrokenEnumValueInner() {
+		EnumValueInner inner = mockAnnotation(EnumValueInner.class);
+		given(inner.value()).willThrow(new EnumConstantNotPresentException(ExampleEnum.class, "MISSING"));
+		return inner;
+	}
+
+	private EnumValueInner mockHealthyEnumValueInner() {
+		EnumValueInner inner = mockAnnotation(EnumValueInner.class);
+		given(inner.value()).willReturn(ExampleEnum.ONE);
+		return inner;
 	}
 
 	private List<Method> getAll(AttributeMethods attributes) {
@@ -205,6 +328,40 @@ class AttributeMethodsTests {
 		String two();
 
 		String three() default "3";
+
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface EnumValueInner {
+
+		ExampleEnum value();
+
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface NestedValue {
+
+		EnumValueInner value();
+
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface NestedArrayValue {
+
+		EnumValueInner[] value();
+
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface DeepNestedValue {
+
+		NestedValue value();
+
+	}
+
+	enum ExampleEnum {
+
+		ONE
 
 	}
 


### PR DESCRIPTION
## Overview

`AttributeMethods` probes `Class`, `Class[]`, and enum attributes so that annotations whose values cannot be resolved at runtime are filtered during scanning instead of failing later. Annotation-typed attributes are not probed, and probing them by invocation alone would not be sufficient: the JDK returns the nested annotation proxy successfully and only throws when one of the nested annotation's own attributes is accessed.

## Problem

An annotation whose nested annotation member references a constant or type that no longer exists at runtime (a binary-incompatible classpath, for example partially upgraded dependencies) passes `canLoad()` unprobed:

- `MergedAnnotations` reports the annotation as present, while the same corruption in a direct attribute is filtered with a warning log.
- `asMap()` returns the corrupted nested annotation proxy as an attribute value, deferring the failure into `AnnotationAttributes` consumers.
- Typed or synthesized access throws a raw `EnumConstantNotPresentException` from deep inside scanning or user code.

## Fix

`canLoad()` and `validate()` now capture the probed value and recurse into annotation and annotation array attribute values, applying the same probing to the nested annotation's own attributes. The probe flag computation marks annotation-typed attributes, reusing the adjacent nested-annotation detection idiom. Recursion terminates structurally because the JLS forbids cyclic annotation member types.

Behavior notes:

- A corrupted nested member now hides the entire outer annotation from scanning, matching the existing all-or-nothing semantics for direct `Class` and enum attributes ("true if all values are present"). The warning log names the actual failing annotation.
- `validate()` propagates the `IllegalStateException` raised for the failing nested attribute without re-wrapping, so the message identifies the innermost failing annotation.
- Annotations whose nested annotation type itself is missing from the classpath fail earlier, during `getDeclaredAnnotations()` parsing, and are out of scope for this probing.

Cost, measured with a `canLoad()` microbenchmark (before/after, best of 5 x 500k iterations): existing probes are unchanged (enum attribute 25ns before and after); annotation-typed attributes add roughly 50-70ns per `canLoad()` invocation, dominated by the added reflective read; the scanner's per-element caching bounds repetition on regular `Class`/`Member` sources.

Tests cover the probe flag for annotation and annotation array attributes, `canLoad()` and `validate()` for failing and healthy nested annotations, annotation arrays including the empty array, and two-level nesting; the failure assertions pin the exception message and cause to the innermost annotation.

This change is complementary to #37153 (enum array attributes) and overlaps with it only on the flag computation line.
