### PR TITLE
Fix busy-spin in SubscriberInputStream await()

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/io/buffer/SubscriberInputStream.java
+++ b/spring-core/src/main/java/org/springframework/core/io/buffer/SubscriberInputStream.java
@@ -18,6 +18,7 @@ package org.springframework.core.io.buffer;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.util.ConcurrentModificationException;
 import java.util.Objects;
 import java.util.Queue;
@@ -228,6 +229,9 @@ final class SubscriberInputStream extends InputStream implements Subscriber<Data
 			this.closed = true;
 			requiredSubscriber().cancel();
 			cleanAndFinalize();
+			if (ex instanceof IOException ioEx) {
+				throw ioEx;
+			}
 			throw Exceptions.propagate(ex);
 		}
 		finally {
@@ -284,6 +288,9 @@ final class SubscriberInputStream extends InputStream implements Subscriber<Data
 			this.closed = true;
 			requiredSubscriber().cancel();
 			cleanAndFinalize();
+			if (ex instanceof IOException ioEx) {
+				throw ioEx;
+			}
 			throw Exceptions.propagate(ex);
 		}
 		finally {
@@ -291,7 +298,7 @@ final class SubscriberInputStream extends InputStream implements Subscriber<Data
 		}
 	}
 
-	private DataBuffer getNextOrAwait() {
+	private DataBuffer getNextOrAwait() throws InterruptedIOException {
 		if (this.available == null || this.available.readableByteCount() == 0) {
 			discard(this.available);
 			this.available = null;
@@ -378,7 +385,7 @@ final class SubscriberInputStream extends InputStream implements Subscriber<Data
 		DataBufferUtils.release(buffer);
 	}
 
-	private void await() {
+	private void await() throws InterruptedIOException {
 		Thread toUnpark = Thread.currentThread();
 
 		while (true) {
@@ -391,10 +398,23 @@ final class SubscriberInputStream extends InputStream implements Subscriber<Data
 				throw new IllegalStateException("Only one (Virtual)Thread can await!");
 			}
 
-			if (this.parkedThread.compareAndSet( null, toUnpark)) {
+			if (this.parkedThread.compareAndSet(null, toUnpark) || this.parkedThread.get() == toUnpark) {
 				LockSupport.park();
 				// we don't just break here because park() can wake up spuriously
 				// if we got a proper resume, get() == READY and the loop will quit above
+				// if we woke up spuriously, the reference is still ours and we park again
+			}
+
+			// park() also returns on interruption, without a resume() having set READY,
+			// in which case the loop could otherwise neither park again nor exit.
+			// Honor the cancellation, unless data arrived concurrently: then deliver it
+			// first and let the restored interrupt status surface on the next await() call.
+			if (Thread.interrupted()) {
+				Thread.currentThread().interrupt();
+				if (this.parkedThread.get() != READY) {
+					this.parkedThread.lazySet(null);
+					throw new InterruptedIOException("Interrupted while awaiting data");
+				}
 			}
 		}
 		// clear the resume indicator so that the next await call will park without a resume()

--- a/spring-web/src/main/java/org/springframework/http/client/SubscriberInputStream.java
+++ b/spring-web/src/main/java/org/springframework/http/client/SubscriberInputStream.java
@@ -18,6 +18,7 @@ package org.springframework.http.client;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InterruptedIOException;
 import java.util.ConcurrentModificationException;
 import java.util.Objects;
 import java.util.Queue;
@@ -249,6 +250,9 @@ final class SubscriberInputStream<T> extends InputStream implements Flow.Subscri
 			this.closed = true;
 			requiredSubscriber().cancel();
 			cleanAndFinalize();
+			if (ex instanceof IOException ioEx) {
+				throw ioEx;
+			}
 			throw Exceptions.propagate(ex);
 		}
 		finally {
@@ -307,6 +311,9 @@ final class SubscriberInputStream<T> extends InputStream implements Flow.Subscri
 			this.closed = true;
 			requiredSubscriber().cancel();
 			cleanAndFinalize();
+			if (ex instanceof IOException ioEx) {
+				throw ioEx;
+			}
 			throw Exceptions.propagate(ex);
 		}
 		finally {
@@ -314,7 +321,7 @@ final class SubscriberInputStream<T> extends InputStream implements Flow.Subscri
 		}
 	}
 
-	byte[] getNextOrAwait() {
+	byte[] getNextOrAwait() throws InterruptedIOException {
 		if (this.available == null || this.available.length - this.position == 0) {
 			this.available = null;
 
@@ -407,7 +414,7 @@ final class SubscriberInputStream<T> extends InputStream implements Flow.Subscri
 		}
 	}
 
-	private void await() {
+	private void await() throws InterruptedIOException {
 		Thread toUnpark = Thread.currentThread();
 
 		while (true) {
@@ -420,10 +427,23 @@ final class SubscriberInputStream<T> extends InputStream implements Flow.Subscri
 				throw new IllegalStateException("Only one (Virtual)Thread can await!");
 			}
 
-			if (this.parkedThread.compareAndSet( null, toUnpark)) {
+			if (this.parkedThread.compareAndSet(null, toUnpark) || this.parkedThread.get() == toUnpark) {
 				LockSupport.park();
 				// we don't just break here because park() can wake up spuriously
 				// if we got a proper resume, get() == READY and the loop will quit above
+				// if we woke up spuriously, the reference is still ours and we park again
+			}
+
+			// park() also returns on interruption, without a resume() having set READY,
+			// in which case the loop could otherwise neither park again nor exit.
+			// Honor the cancellation, unless data arrived concurrently: then deliver it
+			// first and let the restored interrupt status surface on the next await() call.
+			if (Thread.interrupted()) {
+				Thread.currentThread().interrupt();
+				if (this.parkedThread.get() != READY) {
+					this.parkedThread.lazySet(null);
+					throw new InterruptedIOException("Interrupted while awaiting data");
+				}
 			}
 		}
 		// clear the resume indicator so that the next await call will park without a resume()

--- a/spring-web/src/test/java/org/springframework/http/client/SubscriberInputStreamTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/SubscriberInputStreamTests.java
@@ -17,6 +17,7 @@
 package org.springframework.http.client;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.io.OutputStreamWriter;
 import java.util.ArrayList;
 import java.util.List;
@@ -24,6 +25,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.Test;
 
@@ -231,6 +234,50 @@ class SubscriberInputStreamTests {
 
 		assertThat(sb.toString()).isEqualTo("");
 		assertThat(savedEx).hasMessage("boom");
+	}
+
+	@Test // gh-37159
+	void interruptWhileAwaitingData() throws InterruptedException {
+		CountDownLatch reading = new CountDownLatch(1);
+		AtomicReference<Throwable> savedEx = new AtomicReference<>();
+		AtomicBoolean interruptStatus = new AtomicBoolean();
+
+		// A publisher that never emits, so that read() parks in await()
+		Flow.Publisher<byte[]> publisher = subscriber -> subscriber.onSubscribe(new Flow.Subscription() {
+			@Override
+			public void request(long n) {
+			}
+			@Override
+			public void cancel() {
+			}
+		});
+
+		Thread reader = new Thread(() -> {
+			try (SubscriberInputStream<byte[]> is = new SubscriberInputStream<>(s -> s, s -> {}, 1)) {
+				publisher.subscribe(is);
+				reading.countDown();
+				is.read();
+			}
+			catch (Throwable ex) {
+				savedEx.set(ex);
+				interruptStatus.set(Thread.currentThread().isInterrupted());
+			}
+		});
+		reader.start();
+
+		reading.await();
+		for (int i = 0; i < 100 && reader.getState() != Thread.State.WAITING; i++) {
+			Thread.sleep(20);
+		}
+		assertThat(reader.getState()).isEqualTo(Thread.State.WAITING);
+
+		reader.interrupt();
+		reader.join(5000);
+
+		assertThat(reader.isAlive()).as("read() did not return after interrupt").isFalse();
+		assertThat(savedEx.get()).isInstanceOf(InterruptedIOException.class)
+				.hasMessage("Interrupted while awaiting data");
+		assertThat(interruptStatus).as("interrupt status restored").isTrue();
 	}
 
 }


### PR DESCRIPTION
`SubscriberInputStream.await()` parks the reader with `LockSupport.park()` after storing the current thread in `parkedThread`. When `park()` returns without `resume()` having set `READY` — spurious wakeup or interrupt — the reference still points to the current thread, so the loop can neither exit nor park again (`compareAndSet(null, ...)` always fails). The thread spins at 100% CPU until the next upstream signal. And since `park()` doesn't consume the interrupt flag, every later `await()` call on that thread spins the same way.

The interrupt case is easy to hit through Spring MVC async handling: both the async timeout and a client disconnect cancel the task with `Future.cancel(true)` (`CallableInterceptorChain#cancelTask`). With `StreamingResponseBody` proxying a slow upstream, the worker is usually parked in `await()` at that moment.

On virtual threads a spinning thread never yields its carrier, so a few cancelled streaming requests can starve the whole scheduler — we traced a production outage (liveness probe kills) to this.

Reproduced on JDK 21 and 24: after the interrupt the thread stays `RUNNABLE`, burning a full core (~13M loop iterations in 200ms).

## Fix

- Park again when the wakeup was spurious and the reference is still ours.
- On interrupt, restore the interrupt status, clear the reference, and propagate the cancellation as an `InterruptedIOException` — unless data arrived concurrently, in which case it is delivered first and the thread stays interrupted for the next call. The `read()` methods rethrow `IOException`s as-is instead of wrapping them, so the interruption surfaces to callers as a regular `IOException`.

Applied to both near-duplicate classes (spring-web and spring-core), with a regression test that fails on the old code.

Related: #35978 fixed a separate defect in `resume()` in this class; the `await()` interrupt path wasn't covered by it.
