### PR TITLE
Add @QueryMapping, @QueryExchange, and client/router DSL shortcuts for HTTP QUERY method

### DIFF
--- a/spring-test/src/main/java/org/springframework/mock/http/server/reactive/MockServerHttpRequest.java
+++ b/spring-test/src/main/java/org/springframework/mock/http/server/reactive/MockServerHttpRequest.java
@@ -185,6 +185,16 @@ public final class MockServerHttpRequest extends AbstractServerHttpRequest {
 	}
 
 	/**
+	 * HTTP QUERY variant. See {@link #get(String, Object...)} for general info.
+	 * @param urlTemplate a URL template; the resulting URL will be encoded
+	 * @param uriVars zero or more URI variables
+	 * @return the created builder
+	 */
+	public static BodyBuilder query(String urlTemplate, @Nullable Object... uriVars) {
+		return method(HttpMethod.QUERY, urlTemplate, uriVars);
+	}
+
+	/**
 	 * Create a builder with the given HTTP method and a {@link URI}.
 	 * @param method the HTTP method (GET, POST, etc)
 	 * @param url the URL

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
@@ -168,6 +168,11 @@ class DefaultWebTestClient implements WebTestClient {
 	}
 
 	@Override
+	public RequestBodyUriSpec query() {
+		return methodInternal(HttpMethod.QUERY);
+	}
+
+	@Override
 	public RequestBodyUriSpec method(HttpMethod httpMethod) {
 		return methodInternal(httpMethod);
 	}

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/WebTestClient.java
@@ -147,6 +147,13 @@ public interface WebTestClient {
 	RequestHeadersUriSpec<?> options();
 
 	/**
+	 * Prepare an HTTP QUERY request.
+	 * @return a spec for specifying the target URL
+	 * @since 7.1
+	 */
+	RequestBodyUriSpec query();
+
+	/**
 	 * Prepare a request for the specified {@code HttpMethod}.
 	 * @return a spec for specifying the target URL
 	 */

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/assertj/MockMvcTester.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/assertj/MockMvcTester.java
@@ -334,6 +334,21 @@ public final class MockMvcTester {
 	}
 
 	/**
+	 * Prepare an HTTP QUERY request.
+	 * <p>The returned builder can be wrapped in {@code assertThat} to enable
+	 * assertions on the result. For multi-statements assertions, use
+	 * {@link MockMvcRequestBuilder#exchange() exchange()} to assign the
+	 * result. To control the time to wait for asynchronous request to complete
+	 * on a per-request basis, use
+	 * {@link MockMvcRequestBuilder#exchange(Duration) exchange(Duration)}.
+	 * @return a request builder for specifying the target URI
+	 * @since 7.1
+	 */
+	public MockMvcRequestBuilder query() {
+		return method(HttpMethod.QUERY);
+	}
+
+	/**
 	 * Prepare a request for the specified {@code HttpMethod}.
 	 * <p>The returned builder can be wrapped in {@code assertThat} to enable
 	 * assertions on the result. For multi-statements assertions, use

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/DefaultRestTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/DefaultRestTestClient.java
@@ -120,6 +120,11 @@ class DefaultRestTestClient implements RestTestClient {
 	}
 
 	@Override
+	public RequestBodyUriSpec query() {
+		return methodInternal(HttpMethod.QUERY);
+	}
+
+	@Override
 	public RequestHeadersUriSpec<?> options() {
 		return methodInternal(HttpMethod.OPTIONS);
 	}

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/client/RestTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/client/RestTestClient.java
@@ -120,6 +120,13 @@ public interface RestTestClient {
 	RequestHeadersUriSpec<?> delete();
 
 	/**
+	 * Prepare an HTTP QUERY request.
+	 * @return a spec for specifying the target URL
+	 * @since 7.1
+	 */
+	RequestBodyUriSpec query();
+
+	/**
 	 * Prepare an HTTP OPTIONS request.
 	 * @return a spec for specifying the target URL
 	 */

--- a/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockMvcRequestBuilders.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/request/MockMvcRequestBuilders.java
@@ -176,6 +176,25 @@ public abstract class MockMvcRequestBuilders {
 	}
 
 	/**
+	 * Create a {@link MockHttpServletRequestBuilder} for a QUERY request.
+	 * @param uriTemplate a URI template; the resulting URI will be encoded
+	 * @param uriVariables zero or more URI variables
+	 * @since 7.1
+	 */
+	public static MockHttpServletRequestBuilder query(String uriTemplate, @Nullable Object... uriVariables) {
+		return new MockHttpServletRequestBuilder(HttpMethod.QUERY).uri(uriTemplate, uriVariables);
+	}
+
+	/**
+	 * Create a {@link MockHttpServletRequestBuilder} for a QUERY request.
+	 * @param uri the URI
+	 * @since 7.1
+	 */
+	public static MockHttpServletRequestBuilder query(URI uri) {
+		return new MockHttpServletRequestBuilder(HttpMethod.QUERY).uri(uri);
+	}
+
+	/**
 	 * Create a {@link MockHttpServletRequestBuilder} for a request with the given HTTP method.
 	 * @param method the HTTP method (GET, POST, etc.)
 	 * @param uriTemplate a URI template; the resulting URI will be encoded

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/client/RestTestClientTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/client/RestTestClientTests.java
@@ -57,7 +57,7 @@ class RestTestClientTests {
 	class HttpMethods {
 
 		@ParameterizedTest
-		@ValueSource(strings = {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"})
+		@ValueSource(strings = {"GET", "POST", "PUT", "DELETE", "PATCH", "QUERY", "HEAD"})
 		void method(String method) {
 			RestTestClientTests.this.client.method(HttpMethod.valueOf(method)).uri("/test")
 					.exchange()
@@ -120,6 +120,14 @@ class RestTestClientTests {
 					.expectStatus().isOk()
 					.expectHeader().valueEquals("Allow", "GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS,QUERY")
 					.expectBody().isEmpty();
+		}
+
+		@Test
+		void testQuery() {
+			RestTestClientTests.this.client.query().uri("/test")
+					.exchange()
+					.expectStatus().isOk()
+					.expectBody().jsonPath("$.method").isEqualTo("QUERY");
 		}
 
 	}

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilderTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/request/MockHttpServletRequestBuilderTests.java
@@ -31,6 +31,8 @@ import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.Cookie;
 import org.assertj.core.api.ThrowingConsumer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -418,18 +420,21 @@ class MockHttpServletRequestBuilderTests {
 		assertThat(request.getParameterMap().get("foo")).containsExactly("bar", "baz");
 	}
 
-	@Test
-	void requestParameterFromRequestBodyFormData() {
+	@ValueSource(strings = {"POST", "QUERY"})
+	@ParameterizedTest()
+	void requestParameterFromRequestBodyFormData(String methodName) {
 		String contentType = "application/x-www-form-urlencoded;charset=UTF-8";
 		String body = "name+1=value+1&name+2=value+A&name+2=value+B&name+3";
 
-		MockHttpServletRequest request = new MockHttpServletRequestBuilder(POST).uri("/foo")
+		HttpMethod method = HttpMethod.valueOf(methodName);
+		MockHttpServletRequest request = new MockHttpServletRequestBuilder(method).uri("/foo")
 				.contentType(contentType).content(body.getBytes(UTF_8))
 				.buildRequest(this.servletContext);
 
 		assertThat(request.getParameterMap().get("name 1")).containsExactly("value 1");
 		assertThat(request.getParameterMap().get("name 2")).containsExactly("value A", "value B");
 		assertThat(request.getParameterMap().get("name 3")).containsExactly((String) null);
+
 	}
 
 	@Test

--- a/spring-web/src/main/java/org/springframework/http/RequestEntity.java
+++ b/spring-web/src/main/java/org/springframework/http/RequestEntity.java
@@ -385,6 +385,27 @@ public class RequestEntity<T> extends HttpEntity<T> {
 	}
 
 	/**
+	 * Create an HTTP QUERY builder with the given url.
+	 * @param url the URL
+	 * @return the created builder
+	 * @since 7.1
+	 */
+	public static BodyBuilder query(URI url) {
+		return method(HttpMethod.QUERY, url);
+	}
+
+	/**
+	 * Create an HTTP QUERY builder with the given string base uri template.
+	 * @param uriTemplate the uri template to use
+	 * @param uriVariables variables to expand the URI template with
+	 * @return the created builder
+	 * @since 7.1
+	 */
+	public static BodyBuilder query(String uriTemplate, Object... uriVariables) {
+		return method(HttpMethod.QUERY, uriTemplate, uriVariables);
+	}
+
+	/**
 	 * Create an HTTP PUT builder with the given url.
 	 * @param url the URL
 	 * @return the created builder

--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/DeleteMapping.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/DeleteMapping.java
@@ -44,6 +44,7 @@ import org.springframework.core.annotation.AliasFor;
  * @see PostMapping
  * @see PutMapping
  * @see PatchMapping
+ * @see QueryMapping
  * @see RequestMapping
  */
 @Target(ElementType.METHOD)

--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/PatchMapping.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/PatchMapping.java
@@ -44,6 +44,7 @@ import org.springframework.core.annotation.AliasFor;
  * @see PostMapping
  * @see PutMapping
  * @see DeleteMapping
+ * @see QueryMapping
  * @see RequestMapping
  */
 @Target(ElementType.METHOD)

--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/PostMapping.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/PostMapping.java
@@ -44,6 +44,7 @@ import org.springframework.core.annotation.AliasFor;
  * @see PutMapping
  * @see DeleteMapping
  * @see PatchMapping
+ * @see QueryMapping
  * @see RequestMapping
  */
 @Target(ElementType.METHOD)

--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/PutMapping.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/PutMapping.java
@@ -44,6 +44,7 @@ import org.springframework.core.annotation.AliasFor;
  * @see PostMapping
  * @see DeleteMapping
  * @see PatchMapping
+ * @see QueryMapping
  * @see RequestMapping
  */
 @Target(ElementType.METHOD)

--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/QueryMapping.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/QueryMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-present the original author or authors.
+ * Copyright 2026-present the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,33 +25,33 @@ import java.lang.annotation.Target;
 import org.springframework.core.annotation.AliasFor;
 
 /**
- * Annotation for mapping HTTP {@code GET} requests onto specific handler
+ * Annotation for mapping HTTP {@code QUERY} requests onto specific handler
  * methods.
  *
- * <p>Specifically, {@code @GetMapping} is a <em>composed annotation</em> that
- * acts as a shortcut for {@code @RequestMapping(method = RequestMethod.GET)}.
+ * <p>Specifically, {@code @QueryMapping} is a <em>composed annotation</em> that
+ * acts as a shortcut for {@code @RequestMapping(method = RequestMethod.QUERY)}.
  *
  * <p><strong>NOTE:</strong> This annotation cannot be used in conjunction with
  * other {@code @RequestMapping} annotations that are declared on the same method.
  * If multiple {@code @RequestMapping} annotations are detected on the same method,
  * a warning will be logged, and only the first mapping will be used. This applies
  * to {@code @RequestMapping} as well as composed {@code @RequestMapping} annotations
- * such as {@code @PutMapping}, {@code @PostMapping}, etc.
+ * such as {@code @GetMapping}, {@code @PutMapping}, etc.
  *
- * @author Sam Brannen
- * @since 4.3
- * @see PostMapping
+ * @author Mario Ruiz
+ * @since 7.1
+ * @see GetMapping
  * @see PutMapping
+ * @see PostMapping
  * @see DeleteMapping
  * @see PatchMapping
- * @see QueryMapping
  * @see RequestMapping
  */
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
-@RequestMapping(method = RequestMethod.GET)
-public @interface GetMapping {
+@RequestMapping(method = RequestMethod.QUERY)
+public @interface QueryMapping{
 
 	/**
 	 * Alias for {@link RequestMapping#name}.
@@ -85,7 +85,6 @@ public @interface GetMapping {
 
 	/**
 	 * Alias for {@link RequestMapping#consumes}.
-	 * @since 4.3.5
 	 */
 	@AliasFor(annotation = RequestMapping.class)
 	String[] consumes() default {};

--- a/spring-web/src/main/java/org/springframework/web/bind/annotation/RequestMapping.java
+++ b/spring-web/src/main/java/org/springframework/web/bind/annotation/RequestMapping.java
@@ -51,8 +51,8 @@ import org.springframework.core.annotation.AliasFor;
  * at the method level. In most cases, at the method level applications will
  * prefer to use one of the HTTP method specific variants
  * {@link GetMapping @GetMapping}, {@link PostMapping @PostMapping},
- * {@link PutMapping @PutMapping}, {@link DeleteMapping @DeleteMapping}, or
- * {@link PatchMapping @PatchMapping}.
+ * {@link PutMapping @PutMapping}, {@link DeleteMapping @DeleteMapping},
+ * {@link PatchMapping @PatchMapping}, or {@link QueryMapping @QueryMapping}.
  *
  * <p><strong>NOTE:</strong> This annotation cannot be used in conjunction with
  * other {@code @RequestMapping} annotations that are declared on the same element
@@ -75,6 +75,7 @@ import org.springframework.core.annotation.AliasFor;
  * @see PutMapping
  * @see DeleteMapping
  * @see PatchMapping
+ * @see QueryMapping
  */
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Retention(RetentionPolicy.RUNTIME)
@@ -125,7 +126,7 @@ public @interface RequestMapping {
 
 	/**
 	 * The HTTP request methods to map to, narrowing the primary mapping:
-	 * GET, POST, HEAD, OPTIONS, PUT, PATCH, DELETE, TRACE.
+	 * GET, POST, HEAD, OPTIONS, PUT, PATCH, DELETE, TRACE, QUERY.
 	 * <p><b>Supported at the type level as well as at the method level!</b>
 	 * When used at the type level, all method-level mappings inherit this
 	 * HTTP method restriction.

--- a/spring-web/src/main/java/org/springframework/web/client/DefaultRestClient.java
+++ b/spring-web/src/main/java/org/springframework/web/client/DefaultRestClient.java
@@ -194,6 +194,11 @@ final class DefaultRestClient implements RestClient {
 	}
 
 	@Override
+	public RequestBodyUriSpec query() {
+		return methodInternal(HttpMethod.QUERY);
+	}
+
+	@Override
 	public RequestBodyUriSpec method(HttpMethod method) {
 		Assert.notNull(method, "HttpMethod must not be null");
 		return methodInternal(method);

--- a/spring-web/src/main/java/org/springframework/web/client/RestClient.java
+++ b/spring-web/src/main/java/org/springframework/web/client/RestClient.java
@@ -126,6 +126,13 @@ public interface RestClient {
 	RequestHeadersUriSpec<?> options();
 
 	/**
+	 * Start building an HTTP QUERY request.
+	 * @return a spec for specifying the target URL
+	 * @since 7.1
+	 */
+	RequestBodyUriSpec query();
+
+	/**
 	 * Start building a request for the given {@code HttpMethod}.
 	 * @return a spec for specifying the target URL
 	 */

--- a/spring-web/src/main/java/org/springframework/web/service/annotation/HttpExchange.java
+++ b/spring-web/src/main/java/org/springframework/web/service/annotation/HttpExchange.java
@@ -51,6 +51,7 @@ import org.springframework.web.util.UriBuilderFactory;
  * <li>{@link PutExchange}
  * <li>{@link PatchExchange}
  * <li>{@link DeleteExchange}
+ * <li>{@link QueryExchange}
  * </ul>
  *
  * <p>Supported method arguments:

--- a/spring-web/src/main/java/org/springframework/web/service/annotation/QueryExchange.java
+++ b/spring-web/src/main/java/org/springframework/web/service/annotation/QueryExchange.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2024-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.web.service.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.core.annotation.AliasFor;
+
+
+/**
+ * Shortcut for {@link HttpExchange @HttpExchange} for HTTP QUERY requests.
+ *
+ * @author Mario Ruiz
+ * @since 7.1
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@HttpExchange(method = "QUERY")
+public @interface QueryExchange {
+	/**
+	 * Alias for {@link HttpExchange#value}.
+	 */
+	@AliasFor(annotation = HttpExchange.class)
+	String value() default "";
+
+	/**
+	 * Alias for {@link HttpExchange#url()}.
+	 */
+	@AliasFor(annotation = HttpExchange.class)
+	String url() default "";
+
+	/**
+	 * Alias for {@link HttpExchange#contentType()}.
+	 */
+	@AliasFor(annotation = HttpExchange.class)
+	String contentType() default "";
+
+	/**
+	 * Alias for {@link HttpExchange#accept()}.
+	 */
+	@AliasFor(annotation = HttpExchange.class)
+	String[] accept() default {};
+
+	/**
+	 * Alias for {@link HttpExchange#headers()}.
+	 */
+	@AliasFor(annotation = HttpExchange.class)
+	String[] headers() default {};
+
+	/**
+	 * Alias for {@link HttpExchange#version()}.
+	 */
+	@AliasFor(annotation = HttpExchange.class)
+	String version() default "";
+}

--- a/spring-web/src/main/kotlin/org/springframework/web/client/RestOperationsExtensions.kt
+++ b/spring-web/src/main/kotlin/org/springframework/web/client/RestOperationsExtensions.kt
@@ -20,6 +20,7 @@ package org.springframework.web.client
 
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
 import org.springframework.http.RequestEntity
 import org.springframework.http.ResponseEntity
@@ -291,3 +292,44 @@ inline fun <reified T : Any> RestOperations.exchange(url: URI, method: HttpMetho
 @Throws(RestClientException::class)
 inline fun <reified T : Any> RestOperations.exchange(requestEntity: RequestEntity<*>): ResponseEntity<T> =
 		exchange(requestEntity, object : ParameterizedTypeReference<T>() {})
+
+/**
+ * Extension for [RestOperations] providing a `queryForEntity<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. Like the original Java method, this
+ * extension is subject to type erasure. Use [exchange] if you need to retain actual
+ * generic type arguments.
+ *
+ * @author Mario Ruiz
+ * @since 7.1
+ */
+@Throws(RestClientException::class)
+inline fun <reified T : Any> RestOperations.queryForEntity(url: String, request: Any? = null,
+														  vararg uriVariables: Any?): ResponseEntity<T> =
+	exchange(url = url, method =  HttpMethod.QUERY, requestEntity = HttpEntity(request, null as (HttpHeaders?) ), uriVariables= uriVariables)
+
+/**
+ * Extension for [RestOperations] providing a `queryForEntity<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. Like the original Java method, this
+ * extension is subject to type erasure. Use [exchange] if you need to retain actual
+ * generic type arguments.
+ *
+ * @author Mario Ruiz
+ * @since 7.1
+ */
+@Throws(RestClientException::class)
+inline fun <reified T : Any> RestOperations.queryForEntity(url: String, request: Any? = null,
+														  uriVariables: Map<String, *>): ResponseEntity<T> =
+	exchange(url = url, method =  HttpMethod.QUERY, requestEntity = HttpEntity(request, null as (HttpHeaders?) ), uriVariables= uriVariables)
+
+/**
+ * Extension for [RestOperations] providing a `queryForEntity<Foo>(...)`
+ * variant leveraging Kotlin reified type parameters. Like the original Java method, this
+ * extension is subject to type erasure. Use [exchange] if you need to retain actual
+ * generic type arguments.
+ *
+ * @author Mario Ruiz
+ * @since 7.1
+ */
+@Throws(RestClientException::class)
+inline fun <reified T: Any> RestOperations.queryForEntity(url: URI, request: Any? = null): ResponseEntity<T> =
+	exchange(url = url, method =  HttpMethod.QUERY, requestEntity = HttpEntity(request, null as (HttpHeaders?) ))

--- a/spring-web/src/test/java/org/springframework/web/bind/annotation/ControllerMappingReflectiveProcessorTests.java
+++ b/spring-web/src/test/java/org/springframework/web/bind/annotation/ControllerMappingReflectiveProcessorTests.java
@@ -213,6 +213,11 @@ class ControllerMappingReflectiveProcessorTests {
 		void post(@RequestBody Request request) {
 		}
 
+		@QueryMapping
+		Response query(@RequestBody Request request) {
+			return new Response("response");
+		}
+
 		@PostMapping
 		void postForm(@ModelAttribute Request request) {
 		}
@@ -245,6 +250,17 @@ class ControllerMappingReflectiveProcessorTests {
 
 		@PostMapping
 		void postPartToConvert(@RequestPart Request request) {
+		}
+
+		@QueryMapping
+		HttpEntity<Response> querytHttpEntity(HttpEntity<Request> entity) {
+			return new HttpEntity<>(new Response("response"));
+		}
+
+		@QueryMapping
+		@SuppressWarnings({"rawtypes", "unchecked"})
+		HttpEntity queryRawHttpEntity(HttpEntity entity) {
+			return new HttpEntity(new Response("response"));
 		}
 
 	}

--- a/spring-web/src/test/java/org/springframework/web/client/RestTemplateTests.java
+++ b/spring-web/src/test/java/org/springframework/web/client/RestTemplateTests.java
@@ -42,6 +42,7 @@ import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.client.ClientHttpRequest;
 import org.springframework.http.client.ClientHttpRequestFactory;
@@ -73,6 +74,7 @@ import static org.springframework.http.HttpMethod.OPTIONS;
 import static org.springframework.http.HttpMethod.PATCH;
 import static org.springframework.http.HttpMethod.POST;
 import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.HttpMethod.QUERY;
 import static org.springframework.http.MediaType.parseMediaType;
 
 /**
@@ -457,6 +459,46 @@ class RestTemplateTests {
 
 		ResponseEntity<String> result = template.postForEntity("https://example.com", null, String.class);
 		assertThat(result.hasBody()).as("Invalid POST result").isFalse();
+		assertThat(result.getHeaders().getContentType()).as("Invalid Content-Type").isEqualTo(MediaType.TEXT_PLAIN);
+		assertThat(requestHeaders.getContentLength()).as("Invalid content length").isEqualTo(0);
+		assertThat(result.getStatusCode()).as("Invalid status code").isEqualTo(HttpStatus.OK);
+
+		verify(response).close();
+	}
+
+	@Test
+	void queryForEntity() throws Exception {
+		mockTextPlainHttpMessageConverter();
+		HttpHeaders requestHeaders = new HttpHeaders();
+		mockSentRequest(QUERY, "https://example.com", requestHeaders);
+		mockResponseStatus(HttpStatus.OK);
+		String expected = "42";
+		mockResponseBody(expected, MediaType.TEXT_PLAIN);
+
+		ResponseEntity<String> result = template.exchange(RequestEntity.query("https://example.com").body("Hello World"), String.class);
+		assertThat(result.getBody()).as("Invalid QUERY result").isEqualTo(expected);
+		assertThat(result.getHeaders().getContentType()).as("Invalid Content-Type").isEqualTo(MediaType.TEXT_PLAIN);
+		assertThat(requestHeaders.getFirst("Accept")).as("Invalid Accept header").isEqualTo(MediaType.TEXT_PLAIN_VALUE);
+		assertThat(result.getStatusCode()).as("Invalid status code").isEqualTo(HttpStatus.OK);
+
+		verify(response).close();
+	}
+
+	@Test
+	void queryForEntityNull() throws Exception {
+		mockTextPlainHttpMessageConverter();
+		HttpHeaders requestHeaders = new HttpHeaders();
+		mockSentRequest(QUERY, "https://example.com", requestHeaders);
+		mockResponseStatus(HttpStatus.OK);
+		HttpHeaders responseHeaders = new HttpHeaders();
+		responseHeaders.setContentType(MediaType.TEXT_PLAIN);
+		responseHeaders.setContentLength(10);
+		given(response.getHeaders()).willReturn(responseHeaders);
+		given(response.getBody()).willReturn(InputStream.nullInputStream());
+		given(converter.read(String.class, response)).willReturn(null);
+
+		ResponseEntity<String> result = template.exchange("https://example.com",QUERY, null, String.class);
+		assertThat(result.hasBody()).as("Invalid QUERY result").isFalse();
 		assertThat(result.getHeaders().getContentType()).as("Invalid Content-Type").isEqualTo(MediaType.TEXT_PLAIN);
 		assertThat(requestHeaders.getContentLength()).as("Invalid content length").isEqualTo(0);
 		assertThat(result.getStatusCode()).as("Invalid status code").isEqualTo(HttpStatus.OK);

--- a/spring-web/src/testFixtures/java/org/springframework/web/testfixture/method/MvcAnnotationPredicates.java
+++ b/spring-web/src/testFixtures/java/org/springframework/web/testfixture/method/MvcAnnotationPredicates.java
@@ -113,6 +113,10 @@ public class MvcAnnotationPredicates {
 		return new RequestMappingPredicate(path).method(RequestMethod.HEAD);
 	}
 
+	public static RequestMappingPredicate queryMapping(String... path) {
+		return new RequestMappingPredicate(path).method(RequestMethod.QUERY);
+	}
+
 
 	public static class ModelAttributePredicate implements Predicate<MethodParameter> {
 

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultWebClient.java
@@ -178,6 +178,11 @@ final class DefaultWebClient implements WebClient {
 	}
 
 	@Override
+	public RequestBodyUriSpec query() {
+		return methodInternal(HttpMethod.QUERY);
+	}
+
+	@Override
 	public RequestBodyUriSpec method(HttpMethod httpMethod) {
 		return methodInternal(httpMethod);
 	}

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/WebClient.java
@@ -124,6 +124,13 @@ public interface WebClient {
 	RequestHeadersUriSpec<?> options();
 
 	/**
+	 * Start building an HTTP QUERY request.
+	 * @return a spec for specifying the target URL
+	 * @since 7.1
+	 */
+	RequestBodyUriSpec query();
+
+	/**
 	 * Start building a request for the given {@code HttpMethod}.
 	 * @return a spec for specifying the target URL
 	 */

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/RequestPredicates.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/RequestPredicates.java
@@ -289,6 +289,19 @@ public abstract class RequestPredicates {
 	}
 
 	/**
+	 * Return a {@code RequestPredicate} that matches if request's HTTP method is {@code QUERY}
+	 * and the given {@code pattern} matches against the request path.
+	 * @param pattern the path pattern to match against
+	 * @return a predicate that matches if the request method is QUERY and if the given pattern
+	 * matches against the request path
+	 * @since 7.1
+	 * @see org.springframework.web.util.pattern.PathPattern
+	 */
+	public static RequestPredicate QUERY(String pattern) {
+		return method(HttpMethod.QUERY).and(path(pattern));
+	}
+
+	/**
 	 * Return a {@code RequestPredicate} that matches if the request's path has the given extension.
 	 * @param extension the path extension to match against, ignoring case
 	 * @return a predicate that matches if the request's path has the given file extension

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/RouterFunctionBuilder.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/RouterFunctionBuilder.java
@@ -248,6 +248,30 @@ class RouterFunctionBuilder implements RouterFunctions.Builder {
 		return add(RequestPredicates.OPTIONS(pattern).and(predicate), function);
 	}
 
+	// QUERY
+
+	@Override
+	public RouterFunctions.Builder QUERY(HandlerFunction<ServerResponse> handlerFunction) {
+		return add(RequestPredicates.method(HttpMethod.QUERY), handlerFunction);
+	}
+
+	@Override
+	public RouterFunctions.Builder QUERY(RequestPredicate predicate, HandlerFunction<ServerResponse> handlerFunction) {
+		return add(RequestPredicates.method(HttpMethod.QUERY).and(predicate), handlerFunction);
+	}
+
+	@Override
+	public RouterFunctions.Builder QUERY(String pattern, HandlerFunction<ServerResponse> handlerFunction) {
+		return add(RequestPredicates.QUERY(pattern), handlerFunction);
+	}
+
+	@Override
+	public RouterFunctions.Builder QUERY(String pattern, RequestPredicate predicate,
+			HandlerFunction<ServerResponse> handlerFunction) {
+
+		return add(RequestPredicates.QUERY(pattern).and(predicate), handlerFunction);
+	}
+
 	// other
 
 	@Override

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/RouterFunctions.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/server/RouterFunctions.java
@@ -743,6 +743,59 @@ public abstract class RouterFunctions {
 				String pattern, RequestPredicate predicate, HandlerFunction<T> handlerFunction);
 
 		/**
+		 * Adds a route to the given handler function that handles HTTP {@code QUERY} requests.
+		 * @param handlerFunction the handler function to handle all {@code QUERY} requests
+		 * @return this builder
+		 * @since 7.1
+		 */
+		Builder QUERY(HandlerFunction<ServerResponse> handlerFunction);
+
+		/**
+		 * Adds a route to the given handler function that handles all HTTP {@code QUERY} requests
+		 * that match the given pattern.
+		 * @param pattern the pattern to match to
+		 * @param handlerFunction the handler function to handle all {@code QUERY} requests that
+		 * match {@code pattern}
+		 * @return this builder
+		 * @since 7.1
+		 * @see org.springframework.web.util.pattern.PathPattern
+		 */
+		Builder QUERY(String pattern, HandlerFunction<ServerResponse> handlerFunction);
+
+		/**
+		 * Adds a route to the given handler function that handles all HTTP {@code QUERY} requests
+		 * that match the given predicate.
+		 * @param predicate predicate to match
+		 * @param handlerFunction the handler function to handle all {@code QUERY} requests that
+		 * match {@code predicate}
+		 * @return this builder
+		 * @since 7.1
+		 * @see RequestPredicates
+		 */
+		Builder QUERY(RequestPredicate predicate, HandlerFunction<ServerResponse> handlerFunction);
+
+		/**
+		 * Adds a route to the given handler function that handles all HTTP {@code QUERY} requests
+		 * that match the given pattern and predicate.
+		 * <p>For instance, the following example routes QUERY requests for "/user" that contain JSON
+		 * to the {@code addUser} method in {@code userController}:
+		 * <pre class="code">
+		 * RouterFunction&lt;ServerResponse&gt; route =
+		 *   RouterFunctions.route()
+		 *     .QUERY("/user", RequestPredicates.contentType(MediaType.APPLICATION_JSON), userController::addUser)
+		 *     .build();
+		 * </pre>
+		 * @param pattern the pattern to match to
+		 * @param predicate additional predicate to match
+		 * @param handlerFunction the handler function to handle all {@code QUERY} requests that
+		 * match {@code pattern}
+		 * @return this builder
+		 * @since 7.1
+		 * @see org.springframework.web.util.pattern.PathPattern
+		 */
+		Builder QUERY(String pattern, RequestPredicate predicate, HandlerFunction<ServerResponse> handlerFunction);
+
+		/**
 		 * Adds a route to the given handler function that handles all
 		 * requests that match the given predicate.
 		 * @param predicate the request predicate to match

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/server/RequestPredicatesTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/server/RequestPredicatesTests.java
@@ -90,7 +90,7 @@ class RequestPredicatesTests {
 
 	@Test
 	void methods() {
-		RequestPredicate predicate = RequestPredicates.methods(HttpMethod.GET, HttpMethod.HEAD);
+		RequestPredicate predicate = RequestPredicates.methods(HttpMethod.GET, HttpMethod.HEAD, HttpMethod.QUERY);
 		MockServerHttpRequest mockRequest = MockServerHttpRequest.get("https://example.com").build();
 		ServerRequest request = new DefaultServerRequest(MockServerWebExchange.from(mockRequest), Collections.emptyList());
 		assertThat(predicate.test(request)).isTrue();

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/RequestPredicates.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/RequestPredicates.java
@@ -288,6 +288,19 @@ public abstract class RequestPredicates {
 	}
 
 	/**
+	 * Return a {@code RequestPredicate} that matches if request's HTTP method is {@code QUERY}
+	 * and the given {@code pattern} matches against the request path.
+	 * @param pattern the path pattern to match against
+	 * @return a predicate that matches if the request method is QUERY and if the given pattern
+	 * matches against the request path
+	 * @since 7.1
+	 * @see org.springframework.web.util.pattern.PathPattern
+	 */
+	public static RequestPredicate QUERY(String pattern) {
+		return method(HttpMethod.QUERY).and(path(pattern));
+	}
+
+	/**
 	 * Return a {@code RequestPredicate} that matches if the request's path has the given extension.
 	 * @param extension the path extension to match against, ignoring case
 	 * @return a predicate that matches if the request's path has the given file extension

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/RouterFunctionBuilder.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/RouterFunctionBuilder.java
@@ -246,6 +246,30 @@ class RouterFunctionBuilder implements RouterFunctions.Builder {
 		return add(RequestPredicates.OPTIONS(pattern).and(predicate), function);
 	}
 
+	// QUERY
+
+	@Override
+	public RouterFunctions.Builder QUERY(HandlerFunction<ServerResponse> handlerFunction) {
+		return add(RequestPredicates.method(HttpMethod.QUERY), handlerFunction);
+	}
+
+	@Override
+	public RouterFunctions.Builder QUERY(RequestPredicate predicate, HandlerFunction<ServerResponse> handlerFunction) {
+		return add(RequestPredicates.method(HttpMethod.QUERY).and(predicate), handlerFunction);
+	}
+
+	@Override
+	public RouterFunctions.Builder QUERY(String pattern, HandlerFunction<ServerResponse> handlerFunction) {
+		return add(RequestPredicates.QUERY(pattern), handlerFunction);
+	}
+
+	@Override
+	public RouterFunctions.Builder QUERY(String pattern, RequestPredicate predicate,
+			HandlerFunction<ServerResponse> handlerFunction) {
+
+		return add(RequestPredicates.QUERY(pattern).and(predicate), handlerFunction);
+	}
+
 	// other
 
 	@Override

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/function/RouterFunctions.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/function/RouterFunctions.java
@@ -656,6 +656,59 @@ public abstract class RouterFunctions {
 				String pattern, RequestPredicate predicate, HandlerFunction<T> handlerFunction);
 
 		/**
+		 * Adds a route to the given handler function that handles HTTP {@code QUERY} requests.
+		 * @param handlerFunction the handler function to handle all {@code QUERY} requests
+		 * @return this builder
+		 * @since 7.1
+		 */
+		Builder QUERY(HandlerFunction<ServerResponse> handlerFunction);
+
+		/**
+		 * Adds a route to the given handler function that handles all HTTP {@code QUERY} requests
+		 * that match the given pattern.
+		 * @param pattern the pattern to match to
+		 * @param handlerFunction the handler function to handle all {@code QUERY} requests that
+		 * match {@code pattern}
+		 * @return this builder
+		 * @since 7.1
+		 * @see org.springframework.web.util.pattern.PathPattern
+		 */
+		Builder QUERY(String pattern, HandlerFunction<ServerResponse> handlerFunction);
+
+		/**
+		 * Adds a route to the given handler function that handles all HTTP {@code QUERY} requests
+		 * that match the given predicate.
+		 * @param predicate predicate to match
+		 * @param handlerFunction the handler function to handle all {@code QUERY} requests that
+		 * match {@code predicate}
+		 * @return this builder
+		 * @since 7.1
+		 * @see RequestPredicates
+		 */
+		Builder QUERY(RequestPredicate predicate, HandlerFunction<ServerResponse> handlerFunction);
+
+		/**
+		 * Adds a route to the given handler function that handles all HTTP {@code QUERY} requests
+		 * that match the given pattern and predicate.
+		 * <p>For instance, the following example routes QUERY requests for "/user" that contain JSON
+		 * to the {@code addUser} method in {@code userController}:
+		 * <pre class="code">
+		 * RouterFunction&lt;ServerResponse&gt; route =
+		 *   RouterFunctions.route()
+		 *     .QUERY("/user", RequestPredicates.contentType(MediaType.APPLICATION_JSON), userController::addUser)
+		 *     .build();
+		 * </pre>
+		 * @param pattern the pattern to match to
+		 * @param predicate additional predicate to match
+		 * @param handlerFunction the handler function to handle all {@code QUERY} requests that
+		 * match {@code pattern}
+		 * @return this builder
+		 * @since 7.1
+		 * @see org.springframework.web.util.pattern.PathPattern
+		 */
+		Builder QUERY(String pattern, RequestPredicate predicate, HandlerFunction<ServerResponse> handlerFunction);
+
+		/**
 		 * Adds a route to the given handler function that handles all requests
 		 * that match the given predicate.
 		 * @param predicate the request predicate to match

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/function/RequestPredicatesTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/function/RequestPredicatesTests.java
@@ -80,10 +80,11 @@ class RequestPredicatesTests {
 
 	@Test
 	void methods() {
-		RequestPredicate predicate = RequestPredicates.methods(HttpMethod.GET, HttpMethod.HEAD);
+		RequestPredicate predicate = RequestPredicates.methods(HttpMethod.GET, HttpMethod.HEAD, HttpMethod.QUERY);
 		assertThat(predicate.test(initRequest("GET", "https://example.com"))).isTrue();
 		assertThat(predicate.test(initRequest("HEAD", "https://example.com"))).isTrue();
 		assertThat(predicate.test(initRequest("POST", "https://example.com"))).isFalse();
+		assertThat(predicate.test(initRequest("QUERY", "https://example.com"))).isTrue();
 	}
 
 	@Test
@@ -108,6 +109,9 @@ class RequestPredicatesTests {
 
 		predicate = RequestPredicates.OPTIONS("/p*");
 		assertThat(predicate.test(initRequest("OPTIONS", "/path"))).isTrue();
+
+		predicate = RequestPredicates.QUERY("/p*");
+		assertThat(predicate.test(initRequest("QUERY", "/path"))).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
This is a follow-up of #34993. This PR introduces composed annotations and convenience DSL shortcut methods across Spring Framework client abstractions and functional web routers. I create this expecting iteration and discussion, since these changes were pulled back in the prior PR.

## Summary of changes
    
### 1. Composed Mapping Annotations
  - `@QueryMapping`: Shortcut annotation for `@RequestMapping(method = RequestMethod.QUERY)`.
  - `@QueryExchange`: Shortcut annotation for HTTP Interface declarations `@HttpExchange(method = "QUERY")`.
  - Updated Javadoc cross-references across `@GetMapping`, `@PostMapping`, `@PutMapping`, `@DeleteMapping`, `@PatchMapping`, `@RequestMapping`, and `@HttpExchange`.

### 2. HTTP Client & Test Builder Shortcuts
  - `RestClient` & `DefaultRestClient`: Added `.query()` request builder method.
  - `WebClient` & `DefaultWebClient`: Added `.query()` request builder method.
  - `RequestEntity`: Added `RequestEntity.query(URI)` factory methods.
  - `RestTestClient` & `WebTestClient`: Added `.query()` shortcuts.
  - `MockMvc`: Added `MockMvcRequestBuilders.query(...)` and `MockMvcTester.query(...)`.
  - `MockServerHttpRequest`: Added `MockServerHttpRequest.query(url)` factory method.
  - `RestOperationsExtensions.kt`: Added Kotlin `queryForEntity(...)` extension methods.

### 3. Functional Router Shortcuts
  - `RouterFunctions.Builder` (WebFlux & MVC): Added `QUERY(...)` route builder methods matching `GET()`, `POST()`, `PUT()`, `DELETE()`, `PATCH()`, and `OPTIONS()`.
  - `RequestPredicates` (WebFlux & MVC): Added `RequestPredicates.QUERY(pattern)` helper predicates.