### PR TITLE
Update to NullAway 0.14.0 and fix new warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 	id 'com.github.bjornvester.xjc' version '1.8.2' apply false
 	id 'com.gradleup.shadow' version "9.2.2" apply false
 	id 'me.champeau.jmh' version '0.7.2' apply false
-	id 'io.spring.nullability' version '0.0.14' apply false
+	id 'io.spring.nullability' version '0.0.15' apply false
 }
 
 ext {

--- a/gradle/spring-module.gradle
+++ b/gradle/spring-module.gradle
@@ -117,6 +117,10 @@ publishing {
 	}
 }
 
+nullability {
+	nullAwayVersion = "0.14.0"
+}
+
 // Disable publication of test fixture artifacts.
 components.java.withVariantsFromConfiguration(configurations.testFixturesApiElements) { skip() }
 components.java.withVariantsFromConfiguration(configurations.testFixturesRuntimeElements) { skip() }

--- a/gradle/spring-module.gradle
+++ b/gradle/spring-module.gradle
@@ -117,10 +117,6 @@ publishing {
 	}
 }
 
-nullability {
-	nullAwayVersion = "0.14.0"
-}
-
 // Disable publication of test fixture artifacts.
 components.java.withVariantsFromConfiguration(configurations.testFixturesApiElements) { skip() }
 components.java.withVariantsFromConfiguration(configurations.testFixturesRuntimeElements) { skip() }

--- a/spring-context-support/src/main/java/org/springframework/scheduling/quartz/SimpleThreadPoolTaskExecutor.java
+++ b/spring-context-support/src/main/java/org/springframework/scheduling/quartz/SimpleThreadPoolTaskExecutor.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 
+import org.jspecify.annotations.Nullable;
 import org.quartz.SchedulerConfigException;
 import org.quartz.simpl.SimpleThreadPool;
 
@@ -83,7 +84,7 @@ public class SimpleThreadPoolTaskExecutor extends SimpleThreadPool
 	}
 
 	@Override
-	public <T> Future<T> submit(Callable<T> task) {
+	public <T extends @Nullable Object> Future<T> submit(Callable<T> task) {
 		FutureTask<T> future = new FutureTask<>(task);
 		execute(future);
 		return future;

--- a/spring-context/src/main/java/org/springframework/scheduling/concurrent/ConcurrentTaskExecutor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/concurrent/ConcurrentTaskExecutor.java
@@ -165,7 +165,7 @@ public class ConcurrentTaskExecutor implements AsyncTaskExecutor, SchedulingTask
 	}
 
 	@Override
-	public <T> Future<T> submit(Callable<T> task) {
+	public <T extends @Nullable Object> Future<T> submit(Callable<T> task) {
 		return this.adaptedExecutor.submit(task);
 	}
 
@@ -208,7 +208,7 @@ public class ConcurrentTaskExecutor implements AsyncTaskExecutor, SchedulingTask
 		}
 
 		@Override
-		public <T> Future<T> submit(Callable<T> task) {
+		public <T extends @Nullable Object> Future<T> submit(Callable<T> task) {
 			return super.submit(ManagedTaskBuilder.buildManagedTask(task, task.toString()));
 		}
 	}

--- a/spring-context/src/main/java/org/springframework/scheduling/concurrent/ConcurrentTaskScheduler.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/concurrent/ConcurrentTaskScheduler.java
@@ -211,7 +211,7 @@ public class ConcurrentTaskScheduler extends ConcurrentTaskExecutor implements T
 	}
 
 	@Override
-	public <T> Future<T> submit(Callable<T> task) {
+	public <T extends @Nullable Object> Future<T> submit(Callable<T> task) {
 		return super.submit(new DelegatingErrorHandlingCallable<>(task, this.errorHandler));
 	}
 

--- a/spring-context/src/main/java/org/springframework/scheduling/concurrent/SimpleAsyncTaskScheduler.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/concurrent/SimpleAsyncTaskScheduler.java
@@ -262,7 +262,7 @@ public class SimpleAsyncTaskScheduler extends SimpleAsyncTaskExecutor implements
 	}
 
 	@Override
-	public <T> Future<T> submit(Callable<T> task) {
+	public <T extends @Nullable Object> Future<T> submit(Callable<T> task) {
 		return super.submit(new DelegatingErrorHandlingCallable<>(task, this.errorHandler));
 	}
 

--- a/spring-context/src/main/java/org/springframework/scheduling/concurrent/ThreadPoolTaskExecutor.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/concurrent/ThreadPoolTaskExecutor.java
@@ -401,7 +401,7 @@ public class ThreadPoolTaskExecutor extends ExecutorConfigurationSupport
 	}
 
 	@Override
-	public <T> Future<T> submit(Callable<T> task) {
+	public <T extends @Nullable Object> Future<T> submit(Callable<T> task) {
 		ExecutorService executor = getThreadPoolExecutor();
 		try {
 			return executor.submit(task);

--- a/spring-context/src/main/java/org/springframework/scheduling/concurrent/ThreadPoolTaskScheduler.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/concurrent/ThreadPoolTaskScheduler.java
@@ -336,7 +336,7 @@ public class ThreadPoolTaskScheduler extends ExecutorConfigurationSupport
 	}
 
 	@Override
-	public <T> Future<T> submit(Callable<T> task) {
+	public <T extends @Nullable Object> Future<T> submit(Callable<T> task) {
 		ExecutorService executor = getScheduledExecutor();
 		try {
 			return executor.submit(new DelegatingErrorHandlingCallable<>(task, this.errorHandler));

--- a/spring-core/src/main/java/org/springframework/core/convert/converter/ConvertingComparator.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/converter/ConvertingComparator.java
@@ -69,6 +69,7 @@ public class ConvertingComparator<S, T extends @Nullable Object> implements Comp
 	 * @param conversionService the conversion service
 	 * @param targetType the target type
 	 */
+	@SuppressWarnings("NullAway") // Retain support for comparators that handle a null conversion result
 	public ConvertingComparator(
 			Comparator<T> comparator, ConversionService conversionService, Class<? extends T> targetType) {
 

--- a/spring-core/src/main/java/org/springframework/core/convert/support/CharacterToNumberFactory.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/CharacterToNumberFactory.java
@@ -43,7 +43,7 @@ import org.springframework.util.NumberUtils;
 final class CharacterToNumberFactory implements ConverterFactory<Character, Number> {
 
 	@Override
-	public <T extends Number> Converter<Character, @Nullable T> getConverter(Class<T> targetType) {
+	public <T extends Number> Converter<Character, ? extends @Nullable T> getConverter(Class<T> targetType) {
 		return new CharacterToNumber<>(targetType);
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/convert/support/NumberToNumberConverterFactory.java
+++ b/spring-core/src/main/java/org/springframework/core/convert/support/NumberToNumberConverterFactory.java
@@ -45,7 +45,7 @@ import org.springframework.util.NumberUtils;
 final class NumberToNumberConverterFactory implements ConverterFactory<Number, Number>, ConditionalConverter {
 
 	@Override
-	public <T extends Number> Converter<Number, @Nullable T> getConverter(Class<T> targetType) {
+	public <T extends Number> Converter<Number, ? extends @Nullable T> getConverter(Class<T> targetType) {
 		return new NumberToNumber<>(targetType);
 	}
 

--- a/spring-core/src/main/java/org/springframework/core/task/SimpleAsyncTaskExecutor.java
+++ b/spring-core/src/main/java/org/springframework/core/task/SimpleAsyncTaskExecutor.java
@@ -345,7 +345,7 @@ public class SimpleAsyncTaskExecutor extends CustomizableThreadCreator
 
 	@SuppressWarnings("deprecation")
 	@Override
-	public <T> Future<T> submit(Callable<T> task) {
+	public <T extends @Nullable Object> Future<T> submit(Callable<T> task) {
 		FutureTask<T> future = new FutureTask<>(task);
 		execute(future, TIMEOUT_INDEFINITE);
 		return future;

--- a/spring-core/src/main/java/org/springframework/core/task/support/TaskExecutorAdapter.java
+++ b/spring-core/src/main/java/org/springframework/core/task/support/TaskExecutorAdapter.java
@@ -113,7 +113,7 @@ public class TaskExecutorAdapter implements AsyncTaskExecutor {
 	}
 
 	@Override
-	public <T> Future<T> submit(Callable<T> task) {
+	public <T extends @Nullable Object> Future<T> submit(Callable<T> task) {
 		try {
 			if (this.taskDecorator == null &&
 					this.concurrentExecutor instanceof ExecutorService executorService) {

--- a/spring-core/src/main/java/org/springframework/util/LinkedCaseInsensitiveMap.java
+++ b/spring-core/src/main/java/org/springframework/util/LinkedCaseInsensitiveMap.java
@@ -48,7 +48,7 @@ import org.jspecify.annotations.Nullable;
  * @since 3.0
  * @param <V> the value type
  */
-public class LinkedCaseInsensitiveMap<V> implements Map<String, V>, Serializable, Cloneable {
+public class LinkedCaseInsensitiveMap<V extends @Nullable Object> implements Map<String, V>, Serializable, Cloneable {
 
 	@Serial
 	private static final long serialVersionUID = -1797561627545787622L;

--- a/spring-core/src/main/java/org/springframework/util/comparator/InstanceComparator.java
+++ b/spring-core/src/main/java/org/springframework/util/comparator/InstanceComparator.java
@@ -37,7 +37,7 @@ import org.springframework.util.Assert;
  * @param <T> the type of objects that may be compared by this comparator
  * @see Comparator#thenComparing(Comparator)
  */
-public class InstanceComparator<T> implements Comparator<T> {
+public class InstanceComparator<T extends @Nullable Object> implements Comparator<T> {
 
 	private final Class<?>[] instanceOrder;
 

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/JdbcTemplate.java
@@ -502,7 +502,7 @@ public class JdbcTemplate extends JdbcAccessor implements JdbcOperations {
 	}
 
 	@Override
-	public <T> Stream<T> queryForStream(String sql, RowMapper<T> rowMapper) throws DataAccessException {
+	public <T extends @Nullable Object> Stream<T> queryForStream(String sql, RowMapper<T> rowMapper) throws DataAccessException {
 		class StreamStatementCallback implements StatementCallback<Stream<T>>, SqlProvider {
 			@Override
 			public Stream<T> doInStatement(Statement stmt) throws SQLException {

--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplate.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/namedparam/NamedParameterJdbcTemplate.java
@@ -232,7 +232,7 @@ public class NamedParameterJdbcTemplate implements NamedParameterJdbcOperations 
 	}
 
 	@Override
-	public <T> List<T> query(String sql, RowMapper<T> rowMapper) throws DataAccessException {
+	public <T extends @Nullable Object> List<T> query(String sql, RowMapper<T> rowMapper) throws DataAccessException {
 		return query(sql, EmptySqlParameterSource.INSTANCE, rowMapper);
 	}
 

--- a/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
+++ b/spring-test/src/main/java/org/springframework/test/web/reactive/server/DefaultWebTestClient.java
@@ -487,12 +487,12 @@ class DefaultWebTestClient implements WebTestClient {
 		}
 
 		@Override
-		public <E> ListBodySpec<E> expectBodyList(Class<E> elementType) {
+		public <E extends @Nullable Object> ListBodySpec<E> expectBodyList(Class<E> elementType) {
 			return getListBodySpec(this.response.bodyToFlux(elementType));
 		}
 
 		@Override
-		public <E> ListBodySpec<E> expectBodyList(ParameterizedTypeReference<E> elementType) {
+		public <E extends @Nullable Object> ListBodySpec<E> expectBodyList(ParameterizedTypeReference<E> elementType) {
 			Flux<E> flux = this.response.bodyToFlux(elementType);
 			return getListBodySpec(flux);
 		}


### PR DESCRIPTION
Most of the new warnings concern making upper bounds of type variables `@Nullable` for consistency, and the fixes are straightforward.  There is one case where we suppress a warning, as I'm unsure of the desired fix; I will add a more detailed PR comment on that change.