### PR TITLE
Handle MIME type parameter names case-insensitively

### DIFF
--- a/spring-core/src/main/java/org/springframework/util/MimeType.java
+++ b/spring-core/src/main/java/org/springframework/util/MimeType.java
@@ -486,9 +486,9 @@ public class MimeType implements Comparable<MimeType>, Serializable {
 	/**
 	 * Determine if the parameters in this {@code MimeType} and the supplied
 	 * {@code MimeType} are equal, performing case-insensitive comparisons
-	 * for {@link Charset Charsets} and disregarding quoting of parameter
-	 * values, so that, for example, {@code spring="framework"} and
-	 * {@code spring=framework} are considered equal.
+	 * for parameter names and {@link Charset Charsets}, and disregarding
+	 * quoting of parameter values, so that, for example, {@code spring="framework"}
+	 * and {@code spring=framework} are considered equal.
 	 * @since 4.2
 	 */
 	private boolean parametersAreEqual(MimeType other) {
@@ -501,7 +501,7 @@ public class MimeType implements Comparable<MimeType>, Serializable {
 			if (!other.parameters.containsKey(key)) {
 				return false;
 			}
-			if (PARAM_CHARSET.equals(key)) {
+			if (PARAM_CHARSET.equalsIgnoreCase(key)) {
 				if (!ObjectUtils.nullSafeEquals(getCharset(), other.getCharset())) {
 					return false;
 				}
@@ -528,15 +528,15 @@ public class MimeType implements Comparable<MimeType>, Serializable {
 
 	/**
 	 * Compute a hash code for the parameters map, consistent with
-	 * {@link #parametersAreEqual}: normalizing {@link Charset Charsets} and
-	 * disregarding quoting of parameter values.
+	 * {@link #parametersAreEqual}: normalizing parameter names and
+	 * {@link Charset Charsets}, and disregarding quoting of parameter values.
 	 */
 	private int parametersHashCode() {
 		int result = 0;
 		for (Map.Entry<String, String> entry : this.parameters.entrySet()) {
 			String key = entry.getKey();
-			Object value = (PARAM_CHARSET.equals(key) ? getCharset() : unquote(entry.getValue()));
-			result += key.hashCode() ^ ObjectUtils.nullSafeHashCode(value);
+			Object value = (PARAM_CHARSET.equalsIgnoreCase(key) ? getCharset() : unquote(entry.getValue()));
+			result += key.toLowerCase(Locale.ROOT).hashCode() ^ ObjectUtils.nullSafeHashCode(value);
 		}
 		return result;
 	}
@@ -602,7 +602,7 @@ public class MimeType implements Comparable<MimeType>, Serializable {
 			if (comp != 0) {
 				return comp;
 			}
-			if (PARAM_CHARSET.equals(thisAttribute)) {
+			if (PARAM_CHARSET.equalsIgnoreCase(thisAttribute)) {
 				Charset thisCharset = getCharset();
 				Charset otherCharset = other.getCharset();
 				if (thisCharset != otherCharset) {

--- a/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
+++ b/spring-core/src/test/java/org/springframework/util/MimeTypeTests.java
@@ -545,6 +545,28 @@ class MimeTypeTests {
 		assertThat(m2.compareTo(m1)).isEqualTo(0);
 	}
 
+	@Test
+	void equalsIsCaseInsensitiveForParameterNames() {
+		MimeType m1 = new MimeType("text", "plain", singletonMap("Spring", "framework"));
+		MimeType m2 = new MimeType("text", "plain", singletonMap("spring", "framework"));
+		assertThat(m1).isEqualTo(m2);
+		assertThat(m2).isEqualTo(m1);
+		assertThat(m1).hasSameHashCodeAs(m2);
+		assertThat(m1.compareTo(m2)).isEqualTo(0);
+		assertThat(m2.compareTo(m1)).isEqualTo(0);
+	}
+
+	@Test
+	void equalsIsCaseInsensitiveForCharsetParameterName() {
+		MimeType m1 = new MimeType("text", "plain", singletonMap("Charset", "UTF-8"));
+		MimeType m2 = new MimeType("text", "plain", singletonMap("charset", "utf-8"));
+		assertThat(m1).isEqualTo(m2);
+		assertThat(m2).isEqualTo(m1);
+		assertThat(m1).hasSameHashCodeAs(m2);
+		assertThat(m1.compareTo(m2)).isEqualTo(0);
+		assertThat(m2.compareTo(m1)).isEqualTo(0);
+	}
+
 	@Test // gh-36729
 	void equalsIgnoresParameterValueQuoting() {
 		MimeType m1 = MimeTypeUtils.parseMimeType("text/plain; spring=\"framework\"");

--- a/spring-web/src/main/java/org/springframework/http/MediaType.java
+++ b/spring-web/src/main/java/org/springframework/http/MediaType.java
@@ -503,7 +503,7 @@ public class MediaType extends MimeType implements Serializable {
 	@Override
 	protected void checkParameters(String parameter, String value) {
 		super.checkParameters(parameter, value);
-		if (PARAM_QUALITY_FACTOR.equals(parameter)) {
+		if (PARAM_QUALITY_FACTOR.equalsIgnoreCase(parameter)) {
 			String unquotedValue = unquote(value);
 			double d = Double.parseDouble(unquotedValue);
 			Assert.isTrue(d >= 0D && d <= 1D,
@@ -651,7 +651,7 @@ public class MediaType extends MimeType implements Serializable {
 			return this;
 		}
 		Map<String, String> params = new LinkedHashMap<>(getParameters());
-		params.remove(PARAM_QUALITY_FACTOR);
+		params.keySet().removeIf(PARAM_QUALITY_FACTOR::equalsIgnoreCase);
 		return new MediaType(this, params);
 	}
 

--- a/spring-web/src/test/java/org/springframework/http/MediaTypeTests.java
+++ b/spring-web/src/test/java/org/springframework/http/MediaTypeTests.java
@@ -136,6 +136,12 @@ class MediaTypeTests {
 	}
 
 	@Test
+	void parseMediaTypeIllegalQualityFactorWithUpperCaseParameterName() {
+		assertThatExceptionOfType(InvalidMediaTypeException.class).isThrownBy(() ->
+				MediaType.parseMediaType("audio/basic;Q=1.1"));
+	}
+
+	@Test
 	void parseMediaTypeIllegalCharset() {
 		assertThatExceptionOfType(InvalidMediaTypeException.class).isThrownBy(() ->
 				MediaType.parseMediaType("text/html; charset=foo-bar"));
@@ -291,6 +297,18 @@ class MediaTypeTests {
 		assertThat(MediaType.TEXT_PLAIN.isConcrete()).as("text/plain not concrete").isTrue();
 		assertThat(MediaType.ALL.isConcrete()).as("*/* concrete").isFalse();
 		assertThat(new MediaType("text", "*").isConcrete()).as("text/* concrete").isFalse();
+	}
+
+	@Test
+	void removeQualityValue() {
+		assertThat(MediaType.parseMediaType("audio/basic;q=0.8").removeQualityValue())
+				.isEqualTo(MediaType.parseMediaType("audio/basic"));
+	}
+
+	@Test
+	void removeQualityValueWithUpperCaseParameterName() {
+		assertThat(MediaType.parseMediaType("audio/basic;Q=0.8").removeQualityValue())
+				.isEqualTo(MediaType.parseMediaType("audio/basic"));
 	}
 
 	@Test  // gh-26127


### PR DESCRIPTION
`MimeType` keeps parameters in a `LinkedCaseInsensitiveMap`, so `equals()` matches names case-insensitively. `parametersHashCode()` hashes the raw key, so it doesn't — which breaks the `equals`/`hashCode` contract:

```java
MimeType a = MimeType.valueOf("text/plain;FOO=bar");
MimeType b = MimeType.valueOf("text/plain;foo=bar");

a.equals(b);                            // true
a.hashCode() == b.hashCode();           // false
new HashSet<>(List.of(a)).contains(b);  // false
```

The charset branch in `equals`, `hashCode` and `compareTo` keys off `PARAM_CHARSET.equals(key)`, so a parameter spelled `Charset` skips it and is compared as an opaque string, even though the constructor already resolved it through the same case-insensitive map:

```java
MimeType.valueOf("text/plain;charset=UTF-8").equals(MimeType.valueOf("text/plain;charset=utf-8")); // true
MimeType.valueOf("text/plain;Charset=UTF-8").equals(MimeType.valueOf("text/plain;Charset=utf-8")); // false
```

`MediaType` has the same assumption in two more places: an out-of-range quality value escapes validation when spelled `Q=1.1`, and `removeQualityValue()` leaves a `Q=` parameter in place.

Fix is six lines — `equalsIgnoreCase` in the four comparisons, and a normalized key before hashing.

Two behavior changes, both bringing the uppercase spelling in line with the lowercase one: `Charset=UTF-8` now equals `Charset=utf-8`, and `Q=1.1` is now rejected at parse time. Four tests added, each failing before the change; `spring-core`, `-web`, `-webmvc`, `-webflux`, `-messaging` and `-test` suites pass.
