### PR TITLE
Ignore invalid SSE retry field

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/ServerSentEventHttpMessageReader.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/ServerSentEventHttpMessageReader.java
@@ -163,7 +163,10 @@ public class ServerSentEventHttpMessageReader implements HttpMessageReader<Objec
 					sseBuilder.event(line.substring(6).trim());
 				}
 				else if (line.startsWith("retry:")) {
-					sseBuilder.retry(Duration.ofMillis(Long.parseLong(line.substring(6).trim())));
+					Long retry = parseRetry(line.substring(6).trim());
+					if (retry != null) {
+						sseBuilder.retry(Duration.ofMillis(retry));
+					}
 				}
 				else if (line.startsWith(":")) {
 					comment = (comment != null ? comment : new StringBuilder());
@@ -185,6 +188,34 @@ public class ServerSentEventHttpMessageReader implements HttpMessageReader<Objec
 		}
 		else {
 			return decodedData;
+		}
+	}
+
+	/**
+	 * Parse the value of a {@code retry} field, which is to be ignored unless it
+	 * consists solely of ASCII digits and fits into a {@code long}.
+	 * @return the reconnection time in milliseconds, or {@code null} to ignore the field
+	 * @see <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation">
+	 * HTML Living Standard: interpreting an event stream</a>
+	 */
+	private static @Nullable Long parseRetry(String value) {
+		// Long#parseLong is more lenient than the spec: it accepts a leading sign and
+		// non-ASCII digits, so "-1", "+5000" and "\u0665\u0660\u0660\u0660" would all parse.
+		if (value.isEmpty()) {
+			return null;
+		}
+		for (int i = 0; i < value.length(); i++) {
+			char ch = value.charAt(i);
+			if (ch < '0' || ch > '9') {
+				return null;
+			}
+		}
+		try {
+			return Long.parseLong(value);
+		}
+		catch (NumberFormatException ex) {
+			// Too large for a long: ignore the field rather than failing the stream.
+			return null;
 		}
 	}
 

--- a/spring-web/src/test/java/org/springframework/http/codec/ServerSentEventHttpMessageReaderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/ServerSentEventHttpMessageReaderTests.java
@@ -137,6 +137,34 @@ class ServerSentEventHttpMessageReaderTests extends AbstractLeakCheckingTests {
 				.verify();
 	}
 
+	@Test
+	@SuppressWarnings("rawtypes")
+	void ignoreInvalidRetry() {
+		MockServerHttpRequest request = MockServerHttpRequest.post("/")
+				.body(Mono.just(stringBuffer(
+						"retry:none\ndata:foo\n\n" +
+								"retry:\ndata:bar\n\n" +
+								"retry:-1\ndata:baz\n\n" +
+								"retry:+5000\ndata:qux\n\n" +
+								// Arabic-Indic digits: accepted by Long#parseLong, not by the spec.
+								"retry:\u0665\u0660\u0660\u0660\ndata:quux\n\n" +
+								"retry:99999999999999999999\ndata:corge\n\n")));
+
+		Flux<ServerSentEvent> events = this.reader
+				.read(ResolvableType.forClassWithGenerics(ServerSentEvent.class, String.class),
+						request, Collections.emptyMap()).cast(ServerSentEvent.class);
+
+		StepVerifier.create(events)
+				.expectNext(ServerSentEvent.builder().data("foo").build())
+				.expectNext(ServerSentEvent.builder().data("bar").build())
+				.expectNext(ServerSentEvent.builder().data("baz").build())
+				.expectNext(ServerSentEvent.builder().data("qux").build())
+				.expectNext(ServerSentEvent.builder().data("quux").build())
+				.expectNext(ServerSentEvent.builder().data("corge").build())
+				.expectComplete()
+				.verify();
+	}
+
 	@Test // gh-35412
 	void emptyLines() {
 		MockServerHttpRequest request = MockServerHttpRequest.post("/")


### PR DESCRIPTION
The [SSE spec](https://html.spec.whatwg.org/multipage/server-sent-events.html#event-stream-interpretation) says a `retry` field must be ignored unless its value is only ASCII digits. `ServerSentEventHttpMessageReader` passes it straight to `Long.parseLong`, so one malformed field kills the whole stream:

```
retry:none
data:foo

```
```
NumberFormatException: For input string: "none"
```

Same for an empty `retry:` and for a value too large for a `long`. A client can't control what the server sends, so an unusable reconnection hint takes down an otherwise healthy subscription — and `retry` is a hint the reader never acts on itself.

This ignores the field in those cases. Test added; it fails before the change. `spring-web` and `spring-webflux` suites pass.
