### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/release-train-build.yml
+++ b/.github/workflows/release-train-build.yml
@@ -36,13 +36,13 @@ jobs:
         fi
     - name: "Set up Java"
       id: "set-up-java"
-      uses: "actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95" # v5.6.0
+      uses: "actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c" # v6.0.0
       with:
         distribution: "liberica"
         java-version: "25"
     - name: "Check Out Code"
       id: "check-out-code"
-      uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v7.0.0
+      uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v6.0.0
     - name: "Build Release"
       id: "build-release"
       uses: "./.github/actions/release-train-build"
@@ -55,13 +55,13 @@ jobs:
         RELEASE_TRAIN_MAVEN_REPOSITORY_USERNAME: "${{ secrets.RELEASE_TRAIN_PARTICIPANT_MAVEN_REPOSITORY_USERNAME }}"
     - name: "Upload Deployment Repository"
       id: "upload-deployment-repository"
-      uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7.0.1
+      uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v6.0.0
       with:
         name: "deployment-repository"
         path: "deployment-repository/**"
     - name: "Upload Deployment Spec"
       id: "upload-deployment-spec"
-      uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7.0.1
+      uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v6.0.0
       with:
         archive: "false"
         if-no-files-found: "ignore"
@@ -69,7 +69,7 @@ jobs:
         path: ".github/actions/release-train-build/deployment-spec.yml"
     - name: "Save Build System Caches"
       id: "save-build-system-caches"
-      uses: "actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9" # v6.1.0
+      uses: "actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9" # v6.0.0
       with:
         key: "release-train-${{ inputs.callback-ref }}-${{ github.ref_name }}"
         path: |-

--- a/.github/workflows/release-train-test.yml
+++ b/.github/workflows/release-train-test.yml
@@ -36,16 +36,16 @@ jobs:
         fi
     - name: "Set up Java"
       id: "set-up-java"
-      uses: "actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95" # v5.6.0
+      uses: "actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c" # v6.0.0
       with:
         distribution: "liberica"
         java-version: "25"
     - name: "Check Out Code"
       id: "check-out-code"
-      uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v7.0.0
+      uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v6.0.0
     - name: "Restore Build System Caches"
       id: "restore-build-system-caches"
-      uses: "actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9" # v6.1.0
+      uses: "actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9" # v6.0.0
       with:
         key: "release-train-${{ inputs.callback-ref }}-${{ github.ref_name }}"
         path: |-
@@ -78,7 +78,7 @@ jobs:
     - name: "Upload Build System Reports"
       id: "upload-build-system-reports"
       if: "${{ failure() }}"
-      uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7.0.1
+      uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v6.0.0
       with:
         name: "build-system-reports"
         path: "**/build/reports"

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -38,23 +38,23 @@ jobs:
     runs-on: ${{ vars.UBUNTU_SMALL || 'ubuntu-latest' }}
     steps:
       - name: Check Out Release Verification Tests
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
         with:
           ref: 'v0.0.3'
           repository: spring-projects/spring-framework-release-verification
           token: ${{ secrets.token }}
       - name: Check Out Send Notification Action
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6.0.0
         with:
           path: send-notification
           sparse-checkout: .github/actions/send-notification
       - name: Set Up Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'liberica'
           java-version: 17
       - name: Set Up Gradle
-        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+        uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.0.0
         with:
           cache-provider: basic
           cache-read-only: false


### PR DESCRIPTION
Upgrade all active workflow references to `actions/setup-java` v6. SHA-pinned references now use the v6.0.0 release SHA, while the semantic reference uses `v6`.

Tests were not run (workflow-only change).