### PR TITLE
fix(web): fallback to normalized URL path if URI template is unavailable

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/observation/DefaultClientRequestObservationConvention.java
+++ b/spring-web/src/main/java/org/springframework/http/client/observation/DefaultClientRequestObservationConvention.java
@@ -102,6 +102,13 @@ public class DefaultClientRequestObservationConvention implements ClientRequestO
 		if (context.getUriTemplate() != null) {
 			return KeyValue.of(LowCardinalityKeyNames.URI, extractPath(context.getUriTemplate()));
 		}
+		if (context.getCarrier() != null) {
+			String path = context.getCarrier().getURI().getPath();
+			if (StringUtils.hasText(path)) {
+				return KeyValue.of(LowCardinalityKeyNames.URI, path);
+			}
+			return KeyValue.of(LowCardinalityKeyNames.URI, "/");
+		}
 		return URI_NONE;
 	}
 

--- a/spring-web/src/test/java/org/springframework/http/client/observation/DefaultClientRequestObservationConventionTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/observation/DefaultClientRequestObservationConventionTests.java
@@ -115,8 +115,18 @@ class DefaultClientRequestObservationConventionTests {
 		ClientRequestObservationContext context = createContext(
 				new MockClientHttpRequest(HttpMethod.GET, "/resource/42"), response);
 		assertThat(this.observationConvention.getLowCardinalityKeyValues(context))
-				.contains(KeyValue.of("method", "GET"), KeyValue.of("client.name", "none"), KeyValue.of("uri", "none"));
+				.contains(KeyValue.of("method", "GET"), KeyValue.of("client.name", "none"), KeyValue.of("uri", "/resource/42"));
 		assertThat(this.observationConvention.getHighCardinalityKeyValues(context)).contains(KeyValue.of("http.url", "/resource/42"));
+	}
+
+	@Test
+	// gh-36547
+	void fallBackToPathWhenUriTemplateIsMissing() {
+		ClientRequestObservationContext context = createContext(
+				new MockClientHttpRequest(HttpMethod.GET, "https://example.org/resource/42?query=123"), response);
+		assertThat(this.observationConvention.getLowCardinalityKeyValues(context))
+				.contains(KeyValue.of("method", "GET"), KeyValue.of("client.name", "example.org"), KeyValue.of("uri", "/resource/42"));
+		assertThat(this.observationConvention.getHighCardinalityKeyValues(context)).contains(KeyValue.of("http.url", "https://example.org/resource/42?query=123"));
 	}
 
 	@Test

--- a/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientRequestObservationConvention.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/function/client/DefaultClientRequestObservationConvention.java
@@ -106,7 +106,11 @@ public class DefaultClientRequestObservationConvention implements ClientRequestO
 			return KeyValue.of(LowCardinalityKeyNames.URI, extractPath(context.getUriTemplate()));
 		}
 		ClientRequest request = context.getRequest();
-		if (request != null && ROOT_PATH.equals(request.url().getPath())) {
+		if (request != null) {
+			String path = request.url().getPath();
+			if (StringUtils.hasText(path)) {
+				return KeyValue.of(LowCardinalityKeyNames.URI, path);
+			}
 			return URI_ROOT;
 		}
 		return URI_NONE;

--- a/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/DefaultClientRequestObservationConventionTests.java
+++ b/spring-webflux/src/test/java/org/springframework/web/reactive/function/client/DefaultClientRequestObservationConventionTests.java
@@ -60,7 +60,7 @@ class DefaultClientRequestObservationConventionTests {
 		ClientRequestObservationContext context = new ClientRequestObservationContext(request);
 		context.setError(new IllegalStateException("Could not create client request"));
 		assertThat(this.observationConvention.getLowCardinalityKeyValues(context)).hasSize(6)
-				.contains(KeyValue.of("method", "GET"), KeyValue.of("uri", "none"), KeyValue.of("status", "CLIENT_ERROR"),
+				.contains(KeyValue.of("method", "GET"), KeyValue.of("uri", "/test"), KeyValue.of("status", "CLIENT_ERROR"),
 						KeyValue.of("client.name", "none"), KeyValue.of("exception", "IllegalStateException"), KeyValue.of("outcome", "UNKNOWN"));
 		assertThat(this.observationConvention.getHighCardinalityKeyValues(context)).hasSize(1)
 				.contains(KeyValue.of("http.url", "/test"));
@@ -96,8 +96,17 @@ class DefaultClientRequestObservationConventionTests {
 	void shouldAddKeyValuesForRequestWithoutUriTemplate() {
 		ClientRequestObservationContext context = createContext(ClientRequest.create(HttpMethod.GET, URI.create("/resource/42")));
 		assertThat(this.observationConvention.getLowCardinalityKeyValues(context))
-				.contains(KeyValue.of("method", "GET"), KeyValue.of("uri", "none"));
+				.contains(KeyValue.of("method", "GET"), KeyValue.of("uri", "/resource/42"));
 		assertThat(this.observationConvention.getHighCardinalityKeyValues(context)).hasSize(1).contains(KeyValue.of("http.url", "/resource/42"));
+	}
+
+	@Test
+	// gh-36547
+	void fallBackToPathWhenUriTemplateIsMissing() {
+		ClientRequestObservationContext context = createContext(ClientRequest.create(HttpMethod.GET, URI.create("https://example.org/resource/42?query=123")));
+		assertThat(this.observationConvention.getLowCardinalityKeyValues(context))
+				.contains(KeyValue.of("method", "GET"), KeyValue.of("client.name", "example.org"), KeyValue.of("uri", "/resource/42"));
+		assertThat(this.observationConvention.getHighCardinalityKeyValues(context)).hasSize(1).contains(KeyValue.of("http.url", "https://example.org/resource/42?query=123"));
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #36547 by falling back to the URL path for the uri observation tag when the URI template is missing, preventing unbounded cardinality when URLs are passed without templates.