### PR TITLE
Emit multipart parts with empty bodies in PartGenerator

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/converter/multipart/PartGenerator.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/multipart/PartGenerator.java
@@ -86,6 +86,7 @@ final class PartGenerator implements MultipartParser.PartListener {
 
 	@Override
 	public void onHeaders(HttpHeaders headers) {
+		this.state.onComplete();
 		if (isFormField(headers)) {
 			this.state = new FormFieldState(headers);
 		}
@@ -127,6 +128,7 @@ final class PartGenerator implements MultipartParser.PartListener {
 
 	@Override
 	public void onComplete() {
+		this.state.onComplete();
 		if (logger.isTraceEnabled()) {
 			logger.trace("Finished reading " + this.partCount + " part(s)");
 		}
@@ -172,6 +174,14 @@ final class PartGenerator implements MultipartParser.PartListener {
 		void onBody(DataBuffer dataBuffer, boolean last);
 
 		/**
+		 * Invoked when no further {@link #onBody(DataBuffer, boolean) body} is
+		 * expected for the current part, that is when a new part begins, or when
+		 * parsing completed. This emits the part, also when it has an empty body.
+		 */
+		default void onComplete() {
+		}
+
+		/**
 		 * Clean up resources.
 		 */
 		default void dispose() {
@@ -210,6 +220,8 @@ final class PartGenerator implements MultipartParser.PartListener {
 
 		private final HttpHeaders headers;
 
+		private boolean emitted;
+
 		public FormFieldState(HttpHeaders headers) {
 			this.headers = headers;
 		}
@@ -227,6 +239,14 @@ final class PartGenerator implements MultipartParser.PartListener {
 						PartGenerator.this.maxInMemorySize + " bytes");
 			}
 			if (last) {
+				onComplete();
+			}
+		}
+
+		@Override
+		public void onComplete() {
+			if (!this.emitted) {
+				this.emitted = true;
 				byte[] bytes = this.value.toByteArrayUnsafe();
 				String value = new String(bytes, MultipartUtils.charset(this.headers));
 				FormFieldPart formFieldPart = DefaultParts.formFieldPart(this.headers, value);
@@ -268,6 +288,7 @@ final class PartGenerator implements MultipartParser.PartListener {
 
 		private final HttpHeaders headers;
 
+		private boolean emitted;
 
 		public InMemoryState(HttpHeaders headers) {
 			this.headers = headers;
@@ -282,6 +303,14 @@ final class PartGenerator implements MultipartParser.PartListener {
 			}
 			this.content.add(dataBuffer);
 			if (last) {
+				onComplete();
+			}
+		}
+
+		@Override
+		public void onComplete() {
+			if (!this.emitted) {
+				this.emitted = true;
 				emitMemoryPart();
 			}
 		}
@@ -339,6 +368,8 @@ final class PartGenerator implements MultipartParser.PartListener {
 
 		private long byteCount;
 
+		private boolean emitted;
+
 		public FileState(HttpHeaders headers, Path folder) {
 			this.headers = headers;
 			this.file = createFile(folder);
@@ -377,6 +408,14 @@ final class PartGenerator implements MultipartParser.PartListener {
 			}
 			writeBuffer(dataBuffer);
 			if (last) {
+				onComplete();
+			}
+		}
+
+		@Override
+		public void onComplete() {
+			if (!this.emitted) {
+				this.emitted = true;
 				Part part = DefaultParts.part(this.headers, this.file);
 				PartGenerator.this.addPart(part);
 				closeOutputStream();

--- a/spring-web/src/main/java/org/springframework/http/converter/multipart/PartGenerator.java
+++ b/spring-web/src/main/java/org/springframework/http/converter/multipart/PartGenerator.java
@@ -86,6 +86,7 @@ final class PartGenerator implements MultipartParser.PartListener {
 
 	@Override
 	public void onHeaders(HttpHeaders headers) {
+		// no-op on the first part, since InitialState does not override onComplete()
 		this.state.onComplete();
 		if (isFormField(headers)) {
 			this.state = new FormFieldState(headers);

--- a/spring-web/src/test/java/org/springframework/http/converter/multipart/MultipartHttpMessageConverterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/converter/multipart/MultipartHttpMessageConverterTests.java
@@ -197,6 +197,26 @@ class MultipartHttpMessageConverterTests {
 		}
 
 		@Test
+		void readMultipartEmptyPart() throws Exception {
+			MockHttpInputMessage response = createMultipartResponse("servlet-empty-part.multipart", "boundary");
+			MultiValueMap<String, Part> result = converter.read(ResolvableType.forClassWithGenerics(MultiValueMap.class, String.class, Part.class), response, null);
+
+			assertThat(result).containsOnlyKeys("text1", "text2");
+			assertThat(result.get("text1")).anyMatch(isFormData("text1", ""));
+			assertThat(result.get("text2")).anyMatch(isFormData("text2", "a"));
+		}
+
+		@Test
+		void readMultipartEmptyLastPart() throws Exception {
+			MockHttpInputMessage response = createMultipartResponse("servlet-empty-last-part.multipart", "boundary");
+			MultiValueMap<String, Part> result = converter.read(ResolvableType.forClassWithGenerics(MultiValueMap.class, String.class, Part.class), response, null);
+
+			assertThat(result).containsOnlyKeys("text1", "text2");
+			assertThat(result.get("text1")).anyMatch(isFormData("text1", "a"));
+			assertThat(result.get("text2")).anyMatch(isFormData("text2", ""));
+		}
+
+		@Test
 		void readMultipartInvalid() throws Exception {
 			MockHttpInputMessage response = createMultipartResponse("garbage-1.multipart", "boundary");
 			assertThatThrownBy(() -> converter.read(ResolvableType.forClassWithGenerics(MultiValueMap.class, String.class, Part.class), response, null))

--- a/spring-web/src/test/resources/org/springframework/http/multipart/servlet-empty-last-part.multipart
+++ b/spring-web/src/test/resources/org/springframework/http/multipart/servlet-empty-last-part.multipart
@@ -1,0 +1,9 @@
+--boundary
+Content-Disposition: form-data; name="text1"
+
+a
+--boundary
+Content-Disposition: form-data; name="text2"
+
+
+--boundary--

--- a/spring-web/src/test/resources/org/springframework/http/multipart/servlet-empty-part.multipart
+++ b/spring-web/src/test/resources/org/springframework/http/multipart/servlet-empty-part.multipart
@@ -1,0 +1,9 @@
+--boundary
+Content-Disposition: form-data; name="text1"
+
+
+--boundary
+Content-Disposition: form-data; name="text2"
+
+a
+--boundary--


### PR DESCRIPTION
Fixes #37200

## Description
Parts were emitted only from `PartListener.onBody(buffer, last=true)`, so a part with an empty body (for example a blank form field, or a trailing empty part) was silently dropped from the resulting `MultiValueMap`, and was indistinguishable from an absent field.

This carries over the fix from the reactive `DefaultPartHttpMessageReader` (#30953): `State` gains an `onComplete()` callback that emits the part — also when it has an empty body. It is invoked when a new part begins (previous part completes without a final body chunk) and when parsing completes (final part).

Emission is guarded per state so a part completed via `onBody(last=true)` is not emitted twice.

## Test coverage
- `readMultipartEmptyPart()` — empty form field followed by a non-empty one
- `readMultipartEmptyLastPart()` — non-empty field followed by a trailing empty part
- Both fail on `main` (part missing from the result) and pass with this change; the full `:spring-web:test` suite (3,919 tests) passes