### PR TITLE
Fix out-of-bounds read for truncated percent-escape in opaque host

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/util/WhatWgUrlParser.java
+++ b/spring-web/src/main/java/org/springframework/web/util/WhatWgUrlParser.java
@@ -2241,8 +2241,8 @@ final class WhatWgUrlParser {
 				// If input contains a U+0025 (%) and the two code points following it
 				// are not ASCII hex digits, invalid-URL-unit validation error.
 				if (p.validate() && ch == '%' &&
-						(input.length() - i < 2 || !isAsciiDigit(input.codePointAt(i + 1)) ||
-								!isAsciiDigit(input.codePointAt(i + 2)))) {
+						(input.length() - i < 3 || !isAsciiHexDigit(input.codePointAt(i + 1)) ||
+								!isAsciiHexDigit(input.codePointAt(i + 2)))) {
 					p.validationError("Code point \"" + ch + "\" is not a URL unit.");
 				}
 			}

--- a/spring-web/src/test/java/org/springframework/web/util/WhatWgUrlParserTests.java
+++ b/spring-web/src/test/java/org/springframework/web/util/WhatWgUrlParserTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.web.util;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 
@@ -61,6 +64,21 @@ class WhatWgUrlParserTests {
 		testParse("https://XN--pokxncvks.example", "https", "xn--pokxncvks.example", null, "", null, null);
 		testParse("https://xn--/", "https", "xn--", null, "/", null, null);
 		testParse("file://xn--/p", "file", "xn--", null, "/p", null, null);
+	}
+
+	@Test
+	void parseOpaqueHostTruncatedPercentEscape() {
+		// A truncated or non-hex percent-escape in an opaque host is a validation error,
+		// not a failure, and must not read past the end of the input
+		// (see https://url.spec.whatwg.org/#concept-opaque-host-parser).
+		List<String> errors = new ArrayList<>();
+		WhatWgUrlParser.UrlRecord record = WhatWgUrlParser.parse("foo://%4", EMPTY_URL_RECORD, null, errors::add);
+		assertThat(record.host().toString()).isEqualTo("%4");
+
+		record = WhatWgUrlParser.parse("foo://%4x", EMPTY_URL_RECORD, null, errors::add);
+		assertThat(record.host().toString()).isEqualTo("%4x");
+
+		assertThat(errors).isNotEmpty();
 	}
 
 	private void testParse(String input, String scheme, @Nullable String host, @Nullable String port, String path, @Nullable String query, @Nullable String fragment) {


### PR DESCRIPTION
Fixes #37201

## Description
The opaque-host percent-escape validation guard reads `input.codePointAt(i + 2)` after only checking `input.length() - i < 2`, so an input such as `foo://%4` throws `StringIndexOutOfBoundsException` instead of reporting a validation error.

The guard now requires two code points after `%` and checks ASCII hex digits rather than ASCII digits, matching the [URL spec](https://url.spec.whatwg.org/#concept-opaque-host-parser) and the existing code comment: invalid percent-escapes in opaque hosts are validation errors, not failures — the host `%4` is accepted.

## Test coverage
- `parseOpaqueHostTruncatedPercentEscape()` — parses `foo://%4` / `foo://%4x` with validation enabled, asserts the resulting host and that validation errors were reported
- Fails on `main` with `StringIndexOutOfBoundsException` and passes with this change; the full `:spring-web:test` suite (3,919 tests) passes