### PR TITLE
Normalize function return parameter lookup in `CallMetaDataContext`

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/core/metadata/CallMetaDataContext.java
@@ -374,9 +374,14 @@ public class CallMetaDataContext {
 			if (declaredParams.containsKey(paramNameToCheck) || (meta.isReturnParameter() && returnDeclared)) {
 				SqlParameter param;
 				if (meta.isReturnParameter()) {
-					param = declaredParams.get(getFunctionReturnName());
+					// Same normalization as the declaredParams keys above; the function
+					// return name may have been adopted from a declared out parameter
+					param = declaredParams.get(paramNameToCheck);
+					if (param == null) {
+						param = declaredParams.get(lowerCase(provider.parameterNameToUse(getFunctionReturnName())));
+					}
 					if (param == null && !getOutParameterNames().isEmpty()) {
-						param = declaredParams.get(getOutParameterNames().get(0).toLowerCase(Locale.ROOT));
+						param = declaredParams.get(lowerCase(provider.parameterNameToUse(getOutParameterNames().get(0))));
 					}
 					if (param == null) {
 						throw new InvalidDataAccessApiUsageException(

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/core/simple/SimpleJdbcCallTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/core/simple/SimpleJdbcCallTests.java
@@ -267,6 +267,62 @@ class SimpleJdbcCallTests {
 	}
 
 
+	@Test
+	void functionWithAdditionalOutParameterDeclaredBeforeReturn() throws Exception {
+		initializeGetTotalFunctionWithMetaData();
+		SimpleJdbcCall function = new SimpleJdbcCall(dataSource).withFunctionName("get_total");
+		function.declareParameters(
+				new SqlOutParameter("out_status", Types.INTEGER),
+				new SqlOutParameter("RESULT", Types.INTEGER));
+		function.compile();
+		assertThat(function.getCallParameters()).extracting(SqlParameter::getName)
+				.containsExactly("RESULT", "AMOUNT", "out_status");
+		verifyStatement(function, "{? = call GET_TOTAL(?, ?)}");
+		Integer total = function.executeFunction(Integer.class, 5);
+		assertThat(total).isEqualTo(42);
+	}
+
+	@Test
+	void functionWithAdditionalOutParameterDeclaredAfterReturn() throws Exception {
+		initializeGetTotalFunctionWithMetaData();
+		SimpleJdbcCall function = new SimpleJdbcCall(dataSource).withFunctionName("get_total");
+		function.declareParameters(
+				new SqlOutParameter("RESULT", Types.INTEGER),
+				new SqlOutParameter("out_status", Types.INTEGER));
+		function.compile();
+		assertThat(function.getCallParameters()).extracting(SqlParameter::getName)
+				.containsExactly("RESULT", "AMOUNT", "out_status");
+		Integer total = function.executeFunction(Integer.class, 5);
+		assertThat(total).isEqualTo(42);
+	}
+
+	@Test
+	void sqlServerProcedureWithReturnValueDeclaredAfterOutParameter() throws Exception {
+		initializeSqlServerProcedureWithReturnValue();
+		SimpleJdbcCall procedure = new SimpleJdbcCall(dataSource).withProcedureName("my_proc").withReturnValue();
+		procedure.declareParameters(
+				new SqlOutParameter("@out_total", Types.INTEGER),
+				new SqlOutParameter("RETURN_VALUE", Types.INTEGER));
+		procedure.compile();
+		assertThat(procedure.getCallParameters()).extracting(SqlParameter::getName)
+				.containsExactly("RETURN_VALUE", "amount", "@out_total");
+		verifyStatement(procedure, "{? = call my_proc(?, ?)}");
+	}
+
+	@Test
+	void sqlServerProcedureWithReturnValueDeclaredFirst() throws Exception {
+		initializeSqlServerProcedureWithReturnValue();
+		SimpleJdbcCall procedure = new SimpleJdbcCall(dataSource).withProcedureName("my_proc").withReturnValue();
+		procedure.declareParameters(
+				new SqlOutParameter("RETURN_VALUE", Types.INTEGER),
+				new SqlOutParameter("@out_total", Types.INTEGER));
+		procedure.compile();
+		assertThat(procedure.getCallParameters()).extracting(SqlParameter::getName)
+				.containsExactly("RETURN_VALUE", "amount", "@out_total");
+		verifyStatement(procedure, "{? = call my_proc(?, ?)}");
+	}
+
+
 	private void verifyStatement(SimpleJdbcCall adder, String expected) {
 		assertThat(adder.getCallString()).as("Incorrect call statement").isEqualTo(expected);
 	}
@@ -348,6 +404,41 @@ class SimpleJdbcCallTests {
 		verify(callableStatement).close();
 		verify(proceduresResultSet).close();
 		verify(procedureColumnsResultSet).close();
+	}
+
+	private void initializeGetTotalFunctionWithMetaData() throws SQLException {
+		ResultSet proceduresResultSet = mock();
+		ResultSet procedureColumnsResultSet = mock();
+		given(databaseMetaData.getDatabaseProductName()).willReturn("Oracle");
+		given(databaseMetaData.getUserName()).willReturn("ME");
+		given(databaseMetaData.storesUpperCaseIdentifiers()).willReturn(true);
+		given(databaseMetaData.getProcedures("", "ME", "GET_TOTAL")).willReturn(proceduresResultSet);
+		given(databaseMetaData.getProcedureColumns("", "ME", "GET_TOTAL", null)).willReturn(procedureColumnsResultSet);
+		given(proceduresResultSet.next()).willReturn(true, false);
+		given(proceduresResultSet.getString("PROCEDURE_NAME")).willReturn("get_total");
+		given(procedureColumnsResultSet.next()).willReturn(true, true, true, false);
+		given(procedureColumnsResultSet.getInt("DATA_TYPE")).willReturn(4);
+		given(procedureColumnsResultSet.getString("COLUMN_NAME")).willReturn(null, "amount", "out_status");
+		given(procedureColumnsResultSet.getInt("COLUMN_TYPE")).willReturn(5, 1, 4);
+		given(connection.prepareCall("{? = call GET_TOTAL(?, ?)}")).willReturn(callableStatement);
+		given(callableStatement.execute()).willReturn(false);
+		given(callableStatement.getUpdateCount()).willReturn(-1);
+		given(callableStatement.getObject(1)).willReturn(42);
+		given(callableStatement.getObject(3)).willReturn(7);
+	}
+
+	private void initializeSqlServerProcedureWithReturnValue() throws SQLException {
+		ResultSet proceduresResultSet = mock();
+		ResultSet procedureColumnsResultSet = mock();
+		given(databaseMetaData.getDatabaseProductName()).willReturn("Microsoft SQL Server");
+		given(databaseMetaData.getProcedures(null, null, "my_proc")).willReturn(proceduresResultSet);
+		given(databaseMetaData.getProcedureColumns(null, null, "my_proc", null)).willReturn(procedureColumnsResultSet);
+		given(proceduresResultSet.next()).willReturn(true, false);
+		given(proceduresResultSet.getString("PROCEDURE_NAME")).willReturn("my_proc");
+		given(procedureColumnsResultSet.next()).willReturn(true, true, true, false);
+		given(procedureColumnsResultSet.getInt("DATA_TYPE")).willReturn(4);
+		given(procedureColumnsResultSet.getString("COLUMN_NAME")).willReturn("@RETURN_VALUE", "@amount", "@out_total");
+		given(procedureColumnsResultSet.getInt("COLUMN_TYPE")).willReturn(5, 1, 4);
 	}
 
 	@Test


### PR DESCRIPTION
## Overview

`CallMetaDataContext.reconcileParameters` matches the return parameter reported by the database metadata against the declared parameters with lookup keys that do not follow the map's own key rule. When a function has an additional out parameter declared before the return parameter, the return slot is silently bound to the wrong parameter and `executeFunction` returns the wrong value; on SQL Server the same declaration order with `withReturnValue()` fails with `InvalidDataAccessApiUsageException`. This PR normalizes the lookups with the same rule used to build the map.

## Problem

The declared parameter map is keyed by `lowerCase(provider.parameterNameToUse(name))`, so a declared `RESULT` is stored under `result` and a SQL Server `@out_total` under `out_total`. The return parameter branch, however, looked up `getFunctionReturnName()` as declared (original case, so it never matched on Oracle) and then fell back to `getOutParameterNames().get(0).toLowerCase()`, i.e. the first declared out parameter without the provider transformation.

Because the first lookup always missed, the fallback decided the result, and it only happens to be right when the return parameter is the first declared out parameter:

| Declaration (Oracle function `GET_TOTAL`) | Before | After |
|---|---|---|
| `SqlOutParameter("RESULT")`, `SqlOutParameter("out_status")` | `[RESULT, AMOUNT, out_status]` | unchanged |
| `SqlOutParameter("out_status")`, `SqlOutParameter("RESULT")` | `[out_status, AMOUNT, out_status]`, `executeFunction` returns the `out_status` value | `[RESULT, AMOUNT, out_status]` |

On SQL Server, `withProcedureName(...).withReturnValue()` with `SqlOutParameter("@out_total")` declared before `SqlOutParameter("RETURN_VALUE")` threw `Unable to locate declared parameter for function return value - add an SqlOutParameter with name 'return'`, since `"@out_total".toLowerCase()` does not match the stored key `out_total`.

The first-out-parameter fallback itself dates back to the 4.x behavior restored in #25707 and is kept as is; only the lookup keys change.

## Fix

The return parameter branch now looks up the metadata-derived name (`paramNameToCheck`) first, then the function return name, then the first declared out parameter, with all three keys normalized by `lowerCase(provider.parameterNameToUse(...))` exactly like the map keys. Parameter names themselves are not modified, so existing call parameter names and call strings are unchanged. Applications that declared an additional out parameter before the return parameter of a function now receive the actual return value under the declared return parameter name instead of the value of that other out parameter. As before, this lookup only decides which declared parameter represents the return slot; whether a return slot is bound at all is still governed by `withFunctionName()` and `withReturnValue()`.

`SimpleJdbcCallTests` gains four tests: an Oracle function and a SQL Server procedure with return value, each with the additional out parameter declared before and after the return parameter. The two "before" cases failed prior to this change; the two "after" cases guard the previously working declaration order. The full `spring-jdbc` test suite passes.
