### PR TITLE
Avoid int overflow in expiration time calculations in MockMvc and FlashMap

### DIFF
--- a/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnection.java
+++ b/spring-test/src/main/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebConnection.java
@@ -183,7 +183,7 @@ public final class MockMvcWebConnection implements WebConnection {
 	private static Cookie createCookie(jakarta.servlet.http.Cookie cookie) {
 		Date expires = null;
 		if (cookie.getMaxAge() > -1) {
-			expires = new Date(System.currentTimeMillis() + cookie.getMaxAge() * 1000);
+			expires = new Date(System.currentTimeMillis() + cookie.getMaxAge() * 1000L);
 		}
 		BasicClientCookie result = new BasicClientCookie(cookie.getName(), cookie.getValue());
 		result.setDomain(cookie.getDomain());

--- a/spring-test/src/test/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebClientBuilderTests.java
+++ b/spring-test/src/test/java/org/springframework/test/web/servlet/htmlunit/MockMvcWebClientBuilderTests.java
@@ -109,6 +109,17 @@ class MockMvcWebClientBuilderTests {
 		assertThat(getResponse(client, "http://localhost/").getContentAsString()).isEqualTo("NA");
 	}
 
+	@Test
+	void cookieWithLargeMaxAgeIsStored() throws Exception {
+		this.mockMvc = MockMvcBuilders.standaloneSetup(new CookieController()).build();
+		WebClient client = MockMvcWebClientBuilder.mockMvcSetup(this.mockMvc).build();
+
+		assertThat(getResponse(client, "http://localhost/").getContentAsString()).isEqualTo("NA");
+		assertThat(postResponse(client, "http://localhost/long-lived", "cookie=foo")
+				.getContentAsString()).isEqualTo("Set");
+		assertThat(getResponse(client, "http://localhost/").getContentAsString()).isEqualTo("foo");
+	}
+
 	private void assertMockMvcUsed(WebClient client, String url) throws Exception {
 		assertThat(getResponse(client, url).getContentAsString()).isEqualTo("mvc");
 	}
@@ -159,6 +170,15 @@ class MockMvcWebClientBuilderTests {
 		@PostMapping(path = "/", produces = "text/plain")
 		String setCookie(@RequestParam String cookie, HttpServletResponse response) {
 			response.addCookie(new jakarta.servlet.http.Cookie(COOKIE_NAME, cookie));
+			return "Set";
+		}
+
+		@PostMapping(path = "/long-lived", produces = "text/plain")
+		String setLongLivedCookie(@RequestParam String cookie, HttpServletResponse response) {
+			jakarta.servlet.http.Cookie longLived = new jakarta.servlet.http.Cookie(COOKIE_NAME, cookie);
+			longLived.setMaxAge(Integer.MAX_VALUE);
+			longLived.setPath("/");
+			response.addCookie(longLived);
 			return "Set";
 		}
 

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/FlashMap.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/FlashMap.java
@@ -112,7 +112,7 @@ public final class FlashMap extends HashMap<String, Object> implements Comparabl
 	 * @param timeToLive the number of seconds before expiration
 	 */
 	public void startExpirationPeriod(int timeToLive) {
-		this.expirationTime = System.currentTimeMillis() + timeToLive * 1000;
+		this.expirationTime = System.currentTimeMillis() + timeToLive * 1000L;
 	}
 
 	/**

--- a/spring-webmvc/src/test/java/org/springframework/web/servlet/FlashMapTests.java
+++ b/spring-webmvc/src/test/java/org/springframework/web/servlet/FlashMapTests.java
@@ -51,6 +51,15 @@ class FlashMapTests {
 	}
 
 	@Test
+	void notExpiredWithLargeTimeToLive() {
+		FlashMap flashMap = new FlashMap();
+		flashMap.startExpirationPeriod(Integer.MAX_VALUE);
+
+		assertThat(flashMap.getExpirationTime()).isGreaterThan(System.currentTimeMillis());
+		assertThat(flashMap.isExpired()).isFalse();
+	}
+
+	@Test
 	void compareTo() {
 		FlashMap flashMap1 = new FlashMap();
 		FlashMap flashMap2 = new FlashMap();


### PR DESCRIPTION
Two places still compute an expiration time by multiplying an `int`
number of seconds by `1000` without widening to `long`:

- `FlashMap.startExpirationPeriod(int)` (spring-webmvc)
- `MockMvcWebConnection.createCookie(...)` (spring-test)

Above `2_147_483` seconds (~24.9 days) the multiplication overflows and
yields a negative offset, so the expiration time lands in the **past**.
With `Integer.MAX_VALUE`, `timeToLive * 1000` evaluates to `-1000`, i.e.
one second ago.

**Impact**

- `FlashMap`: a timeout set via the public
  `AbstractFlashMapManager.setFlashMapTimeout(int)` is treated as
  already expired, so flash attributes are silently dropped.
- `MockMvcWebConnection`: because `storeCookies` compares the computed
  expiry against now, a cookie with a large `max-age` is passed to
  `cookieManager.removeCookie(...)` instead of `addCookie(...)` — the
  cookie is discarded rather than stored.

**Fix**

Widen the literal to `1000L` in both places. This is the same change
already applied to this exact pattern in gh-25613
(`ExecutorConfigurationSupport.setAwaitTerminationSeconds(int)` and
`AbstractResourceBasedMessageSource.setCacheSeconds(int)`), and matches
how those methods read today.

**Tests**

Two regression tests are included, both of which fail before the change:

- `FlashMapTests.notExpiredWithLargeTimeToLive()` — fails with
  `Expecting actual: <now-1000> to be greater than: <now>`.
- `MockMvcWebClientBuilderTests.cookieWithLargeMaxAgeIsStored()` — fails
  with `expected: "foo" but was: "NA"`, showing the cookie was dropped.

A scan of `src/main/java` found no other live instances of this pattern:
`AbstractSockJsService.ONE_YEAR` and `DurationFormatterUtils.micros` are
already declared `long`.
