### PR TITLE
Improve EncodedResourceResolver encoding selection

### DIFF
--- a/spring-webflux/src/main/java/org/springframework/web/reactive/resource/EncodedResourceResolver.java
+++ b/spring-webflux/src/main/java/org/springframework/web/reactive/resource/EncodedResourceResolver.java
@@ -147,18 +147,18 @@ public class EncodedResourceResolver extends AbstractResourceResolver {
 				return resource;
 			}
 
-			for (String acceptedCoding : acceptedCodings) {
-				if (this.contentCodings.contains(acceptedCoding)) {
+			for (String contentCoding : this.contentCodings) {
+				if (acceptedCodings.contains(contentCoding)) {
 					try {
-						String extension = getExtension(acceptedCoding);
-						Resource encoded = new EncodedResource(resource, acceptedCoding, extension);
+						String extension = getExtension(contentCoding);
+						Resource encoded = new EncodedResource(resource, contentCoding, extension);
 						if (encoded.exists()) {
 							return encoded;
 						}
 					}
 					catch (IOException ex) {
 						logger.trace(exchange.getLogPrefix() +
-								"No " + acceptedCoding + " resource for [" + resource.getFilename() + "]", ex);
+								"No " + contentCoding + " resource for [" + resource.getFilename() + "]", ex);
 					}
 				}
 			}

--- a/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/EncodedResourceResolver.java
+++ b/spring-webmvc/src/main/java/org/springframework/web/servlet/resource/EncodedResourceResolver.java
@@ -145,18 +145,18 @@ public class EncodedResourceResolver extends AbstractResourceResolver {
 			return resource;
 		}
 
-		for (String acceptedCoding : acceptedCodings) {
-			if (this.contentCodings.contains(acceptedCoding)) {
+		for (String contentCoding : this.contentCodings) {
+			if (acceptedCodings.contains(contentCoding)) {
 				try {
-					String extension = getExtension(acceptedCoding);
-					Resource encoded = new EncodedResource(resource, acceptedCoding, extension);
+					String extension = getExtension(contentCoding);
+					Resource encoded = new EncodedResource(resource, contentCoding, extension);
 					if (encoded.exists()) {
 						return encoded;
 					}
 				}
 				catch (IOException ex) {
 					if (logger.isTraceEnabled()) {
-						logger.trace("No " + acceptedCoding + " resource for [" + resource.getFilename() + "]", ex);
+						logger.trace("No " + contentCoding + " resource for [" + resource.getFilename() + "]", ex);
 					}
 				}
 			}


### PR DESCRIPTION
This addresses #37210 by making EncodedResourceResolver honor the server-side encoding preference rather than relying on the order of encodings in the client's Accept-Encoding header.