### PR TITLE
Prefer reason messages over response status fallback

### DIFF
--- a/spring-web/src/main/java/org/springframework/web/server/ResponseStatusException.java
+++ b/spring-web/src/main/java/org/springframework/web/server/ResponseStatusException.java
@@ -24,6 +24,7 @@ import org.springframework.context.MessageSource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ProblemDetail;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.ErrorResponseException;
 
 /**
@@ -94,9 +95,9 @@ public class ResponseStatusException extends ErrorResponseException {
 			HttpStatusCode status, @Nullable String reason, @Nullable Throwable cause,
 			@Nullable String messageDetailCode, Object @Nullable [] messageDetailArguments) {
 
-		super(status, ProblemDetail.forStatus(status), cause, messageDetailCode, messageDetailArguments);
+		super(status, new ResponseStatusProblemDetail(status, reason, messageDetailCode == null), cause,
+				messageDetailCode, messageDetailArguments);
 		this.reason = reason;
-		setDetail(reason);
 	}
 
 
@@ -117,25 +118,69 @@ public class ResponseStatusException extends ErrorResponseException {
 
 	@Override
 	public ProblemDetail updateAndGetBody(@Nullable MessageSource messageSource, Locale locale) {
-		String detail = getBody().getDetail();
+		ResponseStatusProblemDetail body = (ResponseStatusProblemDetail) getBody();
+		boolean reasonLocalizationAllowed = body.isReasonLocalizationAllowed();
 		super.updateAndGetBody(messageSource, locale);
 
 		// The reason may be a code (consistent with ResponseStatusExceptionResolver)
 
-		if (messageSource != null && getReason() != null && getReason().equals(detail)) {
+		String reason = getReason();
+		if (reasonLocalizationAllowed && messageSource != null && reason != null &&
+				isDefaultDetailMessageCode()) {
 			Object[] arguments = getDetailMessageArguments(messageSource, locale);
-			String resolved = messageSource.getMessage(getReason(), arguments, null, locale);
+			String resolved = messageSource.getMessage(reason, arguments, null, locale);
 			if (resolved != null) {
-				getBody().setDetail(resolved);
+				body.setDetailFromReason(resolved);
 			}
 		}
+		body.setReasonLocalizationAllowed(reasonLocalizationAllowed);
 
 		return getBody();
+	}
+
+	private boolean isDefaultDetailMessageCode() {
+		return getDetailMessageCode().equals(ErrorResponse.getDefaultDetailMessageCode(getClass(), null));
 	}
 
 	@Override
 	public String getMessage() {
 		return getStatusCode() + (this.reason != null ? " \"" + this.reason + "\"" : "");
+	}
+
+
+	private static final class ResponseStatusProblemDetail extends ProblemDetail {
+
+		private static final long serialVersionUID = 1L;
+
+		private boolean reasonLocalizationAllowed;
+
+
+		ResponseStatusProblemDetail(
+				HttpStatusCode status, @Nullable String reason, boolean reasonLocalizationAllowed) {
+
+			super(ProblemDetail.forStatus(status));
+			this.reasonLocalizationAllowed = reasonLocalizationAllowed;
+			super.setDetail(reason);
+		}
+
+		@Override
+		public void setDetail(@Nullable String detail) {
+			super.setDetail(detail);
+			this.reasonLocalizationAllowed = false;
+		}
+
+		boolean isReasonLocalizationAllowed() {
+			return this.reasonLocalizationAllowed;
+		}
+
+		void setDetailFromReason(String detail) {
+			super.setDetail(detail);
+		}
+
+		void setReasonLocalizationAllowed(boolean allowed) {
+			this.reasonLocalizationAllowed = allowed;
+		}
+
 	}
 
 }

--- a/spring-web/src/main/java/org/springframework/web/server/ResponseStatusException.java
+++ b/spring-web/src/main/java/org/springframework/web/server/ResponseStatusException.java
@@ -117,11 +117,12 @@ public class ResponseStatusException extends ErrorResponseException {
 
 	@Override
 	public ProblemDetail updateAndGetBody(@Nullable MessageSource messageSource, Locale locale) {
+		String detail = getBody().getDetail();
 		super.updateAndGetBody(messageSource, locale);
 
 		// The reason may be a code (consistent with ResponseStatusExceptionResolver)
 
-		if (messageSource != null && getReason() != null && getReason().equals(getBody().getDetail())) {
+		if (messageSource != null && getReason() != null && getReason().equals(detail)) {
 			Object[] arguments = getDetailMessageArguments(messageSource, locale);
 			String resolved = messageSource.getMessage(getReason(), arguments, null, locale);
 			if (resolved != null) {

--- a/spring-web/src/test/java/org/springframework/web/ErrorResponseExceptionTests.java
+++ b/spring-web/src/test/java/org/springframework/web/ErrorResponseExceptionTests.java
@@ -416,11 +416,21 @@ class ErrorResponseExceptionTests {
 			messageSource.addMessage(
 					ErrorResponse.getDefaultDetailMessageCode(ResponseStatusException.class, null),
 					locale, "Default response status exception message");
+			messageSource.addMessage(reason, Locale.US, "Bad Request");
+			messageSource.addMessage(
+					ErrorResponse.getDefaultDetailMessageCode(ResponseStatusException.class, null),
+					Locale.US, "Default response status exception message");
 
 			ResponseStatusException ex = new ResponseStatusException(HttpStatus.BAD_REQUEST, reason);
 
 			ProblemDetail problemDetail = ex.updateAndGetBody(messageSource, locale);
 			assertThat(problemDetail.getDetail()).isEqualTo(message);
+
+			problemDetail = ex.updateAndGetBody(messageSource, locale);
+			assertThat(problemDetail.getDetail()).isEqualTo(message);
+
+			problemDetail = ex.updateAndGetBody(messageSource, Locale.US);
+			assertThat(problemDetail.getDetail()).isEqualTo("Bad Request");
 		}
 		finally {
 			LocaleContextHolder.resetLocaleContext();
@@ -439,6 +449,36 @@ class ErrorResponseExceptionTests {
 
 		ProblemDetail problemDetail = ex.updateAndGetBody(messageSource, locale);
 		assertThat(problemDetail.getDetail()).isEqualTo("Default response status exception message");
+	}
+
+	@Test  // gh-36984
+	void responseStatusExceptionSubclassWithCustomDetail() {
+		Locale locale = Locale.UK;
+		StaticMessageSource messageSource = new StaticMessageSource();
+		messageSource.addMessage("Request method 'PUT' is not supported.", locale, "Localized reason");
+
+		MethodNotAllowedException ex = new MethodNotAllowedException(
+				HttpMethod.PUT, Arrays.asList(HttpMethod.GET, HttpMethod.POST));
+
+		ProblemDetail problemDetail = ex.updateAndGetBody(messageSource, locale);
+		assertThat(problemDetail.getDetail()).isEqualTo("Supported methods: [GET, POST]");
+	}
+
+	@Test  // gh-36984
+	void responseStatusExceptionWithExplicitDetailMessageCode() {
+		Locale locale = Locale.UK;
+		StaticMessageSource messageSource = new StaticMessageSource();
+		messageSource.addMessage("custom.detail", locale, "Explicit detail message");
+		messageSource.addMessage("custom.detail", Locale.US, "Explicit US detail message");
+		messageSource.addMessage("bad.request", locale, "Breaking Bad Request");
+
+		CustomResponseStatusException ex = new CustomResponseStatusException("bad.request");
+
+		ProblemDetail problemDetail = ex.updateAndGetBody(messageSource, locale);
+		assertThat(problemDetail.getDetail()).isEqualTo("Explicit detail message");
+
+		problemDetail = ex.updateAndGetBody(messageSource, Locale.US);
+		assertThat(problemDetail.getDetail()).isEqualTo("Explicit US detail message");
 	}
 
 	private void assertStatus(ErrorResponse ex, HttpStatus status) {
@@ -521,6 +561,17 @@ class ErrorResponseExceptionTests {
 			assertThat(BindErrorUtils.resolve(errors, this.messageSource, Locale.UK)).hasSize(4)
 					.containsValues("Bean A message", "Bean B message", "name is required", "age is below minimum");
 		}
+	}
+
+
+	private static class CustomResponseStatusException extends ResponseStatusException {
+
+		private static final long serialVersionUID = 1L;
+
+		CustomResponseStatusException(String reason) {
+			super(HttpStatus.BAD_REQUEST, reason, null, "custom.detail", null);
+		}
+
 	}
 
 }

--- a/spring-web/src/test/java/org/springframework/web/ErrorResponseExceptionTests.java
+++ b/spring-web/src/test/java/org/springframework/web/ErrorResponseExceptionTests.java
@@ -403,7 +403,7 @@ class ErrorResponseExceptionTests {
 		assertThat(ex.getHeaders().isEmpty()).isTrue();
 	}
 
-	@Test  // gh-30300
+	@Test  // gh-30300, gh-36984
 	void responseStatusException() {
 		Locale locale = Locale.UK;
 		LocaleContextHolder.setLocale(locale);
@@ -413,6 +413,9 @@ class ErrorResponseExceptionTests {
 			String message = "Breaking Bad Request";
 			StaticMessageSource messageSource = new StaticMessageSource();
 			messageSource.addMessage(reason, locale, message);
+			messageSource.addMessage(
+					ErrorResponse.getDefaultDetailMessageCode(ResponseStatusException.class, null),
+					locale, "Default response status exception message");
 
 			ResponseStatusException ex = new ResponseStatusException(HttpStatus.BAD_REQUEST, reason);
 
@@ -422,6 +425,20 @@ class ErrorResponseExceptionTests {
 		finally {
 			LocaleContextHolder.resetLocaleContext();
 		}
+	}
+
+	@Test  // gh-36984
+	void responseStatusExceptionWithDefaultMessage() {
+		Locale locale = Locale.UK;
+		StaticMessageSource messageSource = new StaticMessageSource();
+		messageSource.addMessage(
+				ErrorResponse.getDefaultDetailMessageCode(ResponseStatusException.class, null),
+				locale, "Default response status exception message");
+
+		ResponseStatusException ex = new ResponseStatusException(HttpStatus.BAD_REQUEST, "bad.request");
+
+		ProblemDetail problemDetail = ex.updateAndGetBody(messageSource, locale);
+		assertThat(problemDetail.getDetail()).isEqualTo("Default response status exception message");
 	}
 
 	private void assertStatus(ErrorResponse ex, HttpStatus status) {


### PR DESCRIPTION
Fixes #36984

## Problem

When a `ResponseStatusException` has a reason that can be resolved through a `MessageSource`, that localized reason should be used as the `ProblemDetail` detail.

This can be surprising when the message source also contains the default detail message for `ResponseStatusException`. The general `ErrorResponse` localization step may replace the original reason first, so the exception no longer recognizes that it should resolve the reason message. In that case, the default detail is returned even though a localized reason is available.

## What this change does

- Keeps the reason as the initial `ProblemDetail` detail for `ResponseStatusException`.
- Resolves the reason after the common `ErrorResponse` localization has completed when the default detail message code is being used.
- Preserves an explicitly configured detail message code as the source of truth.
- Preserves details supplied by specialized `ResponseStatusException` subclasses, such as `MethodNotAllowedException`.
- Keeps repeated updates and locale changes consistent.

In short, a localized reason is preferred when the exception is using the default response-status detail, while explicit or specialized details remain authoritative.

## Tests

The regression coverage verifies:

- localized reason messages take precedence over the default detail;
- repeated updates do not lose the reason localization;
- changing the locale re-resolves the reason;
- the default detail remains the fallback when the reason cannot be resolved;
- custom detail message codes are not overridden by the reason;
- subclass-specific details remain unchanged.

## Verification

- `JAVA_HOME=/opt/homebrew/opt/openjdk@25 ./gradlew :spring-web:test --tests org.springframework.web.ErrorResponseExceptionTests`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@25 ./gradlew :spring-webflux:test --tests org.springframework.web.reactive.result.method.annotation.ResponseEntityExceptionHandlerTests`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@25 ./gradlew :spring-web:check`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@25 ./gradlew build`