### PR TITLE
Expose documentation variants in module metadata

### DIFF
--- a/gradle/spring-module.gradle
+++ b/gradle/spring-module.gradle
@@ -1,3 +1,8 @@
+import org.gradle.api.attributes.Bundling
+import org.gradle.api.attributes.Category
+import org.gradle.api.attributes.DocsType
+import org.gradle.api.attributes.Usage
+
 apply plugin: 'java-library'
 apply plugin: 'org.springframework.build.conventions'
 apply plugin: 'org.springframework.build.optional-dependencies'
@@ -7,6 +12,10 @@ apply plugin: 'org.springframework.build.optional-dependencies'
 apply plugin: 'me.champeau.jmh'
 apply from: "$rootDir/gradle/publications.gradle"
 apply plugin: "io.spring.nullability"
+
+java {
+	withJavadocJar()
+}
 
 dependencies {
 	jmh 'org.openjdk.jmh:jmh-core:1.37'
@@ -102,17 +111,29 @@ tasks.register('sourcesJar', Jar) {
 	// Don't include or exclude anything explicitly by default. See SPR-12085.
 }
 
-tasks.register('javadocJar', Jar) {
-	archiveClassifier.set("javadoc")
-	from javadoc
+configurations {
+	sourcesElements {
+		canBeConsumed = true
+		canBeResolved = false
+		attributes {
+			attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category, Category.DOCUMENTATION))
+			attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling, Bundling.EXTERNAL))
+			attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, DocsType.SOURCES))
+			attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage, Usage.JAVA_RUNTIME))
+		}
+	}
+}
+
+afterEvaluate {
+	configurations.sourcesElements.outgoing.artifacts.clear()
+	configurations.sourcesElements.outgoing.artifact(sourcesJar)
+	components.java.addVariantsFromConfiguration(configurations.sourcesElements) { }
 }
 
 publishing {
 	publications {
 		mavenJava(MavenPublication) {
 			from components.java
-			artifact sourcesJar
-			artifact javadocJar
 		}
 	}
 }


### PR DESCRIPTION
## What is the problem?

Spring Framework publishes `-sources.jar` and `-javadoc.jar`, but the build currently attaches those artifacts directly to the Maven publication. Gradle Module Metadata is generated from the published component variants, so the `.module` files do not describe `sourcesElements` or `javadocElements`. This makes source and Javadoc artifacts harder for Gradle-aware tooling to discover.

## What does this change do?

- Registers the existing aggregate `sourcesJar` as the `sourcesElements` variant of the Java component.
- Enables Gradle's standard `javadocJar` and `javadocElements` variant.
- Removes the direct Maven artifact declarations now that the Java component publishes the variants.
- Replaces the Kotlin-generated source artifact with Spring's aggregate source jar after project evaluation, avoiding duplicate source entries while retaining Java and Kotlin sources together.

Gradle publishes component variants to Gradle Module Metadata; the standard Javadoc variant behavior is described in the [JavaPluginExtension documentation](https://docs.gradle.org/current/dsl/org.gradle.api.plugins.JavaPluginExtension.html).

## Why is only one file changed?

`gradle/spring-module.gradle` is the shared publication convention applied to all 22 Spring Framework modules. A single change here updates every published module consistently; per-module edits would duplicate the same configuration. This change is limited to build and publication metadata and does not alter Java APIs or runtime behavior.

## Design note

Kotlin modules already contribute a `sourcesElements` configuration. Calling Gradle's `withSourcesJar()` in addition to that configuration would publish duplicate source artifacts, so this change deliberately keeps Spring's existing aggregate `sourcesJar` and installs it after all project plugins have configured their outgoing artifacts. This preserves the current Java-plus-Kotlin source archive while exposing it as a proper component variant.

## Verification

- Generated publication metadata for all 22 Spring modules.
- Confirmed every `.module` file contains exactly one `sourcesElements` artifact and one `javadocElements` artifact.
- Published `spring-core` to a temporary Maven repository and verified an external Gradle consumer resolves exactly one sources JAR and one Javadoc JAR through the corresponding variants.
- Full `build` passed across the repository (`348 actionable tasks`).
- `:spring-core:check` (Kotlin module)
- `:spring-jms:check` (Java-only module)
- `git diff --check`
- Hosted `Build Pull Request`, `DCO`, and backport checks pass.

Closes gh-37209
