### PR TITLE
Apply charset preprocessing to Mono JSON decoding

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/codec/json/AbstractJackson2Decoder.java
+++ b/spring-web/src/main/java/org/springframework/http/codec/json/AbstractJackson2Decoder.java
@@ -193,12 +193,13 @@ public abstract class AbstractJackson2Decoder extends Jackson2CodecSupport imple
 	public Mono<Object> decodeToMono(Publisher<DataBuffer> input, ResolvableType elementType,
 			@Nullable MimeType mimeType, @Nullable Map<String, Object> hints) {
 
+		Flux<DataBuffer> processed = processInput(input, elementType, mimeType, hints);
 		return Mono.deferContextual(contextView -> {
 
 			Map<String, Object> hintsToUse = contextView.isEmpty() ? hints :
 					Hints.merge(hints, ContextView.class.getName(), contextView);
 
-			return DataBufferUtils.join(input, this.maxInMemorySize).flatMap(dataBuffer ->
+			return DataBufferUtils.join(processed, this.maxInMemorySize).flatMap(dataBuffer ->
 					Mono.justOrEmpty(decode(dataBuffer, elementType, mimeType, hintsToUse)));
 		});
 	}

--- a/spring-web/src/test/java/org/springframework/http/codec/json/Jackson2JsonDecoderTests.java
+++ b/spring-web/src/test/java/org/springframework/http/codec/json/Jackson2JsonDecoderTests.java
@@ -312,16 +312,18 @@ class Jackson2JsonDecoderTests extends AbstractDecoderTests<Jackson2JsonDecoder>
 				null);
 	}
 
-	@Test
+	@Test  // gh-37195
 	@SuppressWarnings("unchecked")
 	void decodeMonoNonUtf8Encoding() {
-		Mono<DataBuffer> input = stringBuffer("{\"foo\":\"bar\"}", StandardCharsets.UTF_16);
+		Flux<DataBuffer> input = Flux.concat(
+				stringBuffer("{\"føø\":\"", StandardCharsets.ISO_8859_1),
+				stringBuffer("bår\"}", StandardCharsets.ISO_8859_1));
 		ResolvableType type = ResolvableType.forType(new ParameterizedTypeReference<Map<String, String>>() {});
 
 		testDecodeToMono(input, type, step -> step
-						.assertNext(value -> assertThat((Map<String, String>) value).containsEntry("foo", "bar"))
+						.assertNext(value -> assertThat((Map<String, String>) value).containsEntry("føø", "bår"))
 						.verifyComplete(),
-				MediaType.parseMediaType("application/json; charset=utf-16"),
+				MediaType.parseMediaType("application/json; charset=iso-8859-1"),
 				null);
 	}
 


### PR DESCRIPTION
Fixes #37195

## Problem

`Jackson2JsonDecoder` already preprocesses non-UTF-8 input for streaming decoding because Jackson's asynchronous parser only accepts UTF-8 (or ASCII). However, `decodeToMono` joined the original `DataBuffer` input and passed it directly to Jackson, bypassing that preprocessing.

As a result, a BOM-free ISO-8859-1 JSON payload could be decoded successfully through the streaming path but fail through the `Mono` path.

## Solution

- Apply the existing `processInput` hook before `DataBufferUtils.join` in `decodeToMono`.
- Keep the existing aggregation limit, context handling, and `decode(DataBuffer, ...)` behavior unchanged.

This makes the `Mono` and streaming paths use the same charset handling.

## Tests

The regression test uses BOM-free ISO-8859-1 JSON split across two data buffers and verifies that `decodeToMono` returns the expected values.

Verified with:

- `JAVA_HOME=/opt/homebrew/opt/openjdk@25 ./gradlew :spring-web:test --tests org.springframework.http.codec.json.Jackson2JsonDecoderTests`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@25 ./gradlew :spring-web:check`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@25 ./gradlew build`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@25 ./gradlew :spring-webflux:test --tests org.springframework.web.reactive.result.method.annotation.RequestMappingMessageConversionIntegrationTests.personResponseBodyWithObservable`