### PR TITLE
Support CompletableFuture<Optional<?>> cache values

### DIFF
--- a/spring-context/src/main/java/org/springframework/cache/interceptor/CacheAspectSupport.java
+++ b/spring-context/src/main/java/org/springframework/cache/interceptor/CacheAspectSupport.java
@@ -55,6 +55,7 @@ import org.springframework.core.BridgeMethodResolver;
 import org.springframework.core.KotlinDetector;
 import org.springframework.core.ReactiveAdapter;
 import org.springframework.core.ReactiveAdapterRegistry;
+import org.springframework.core.ResolvableType;
 import org.springframework.core.SpringProperties;
 import org.springframework.expression.EvaluationContext;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
@@ -437,7 +438,8 @@ public abstract class CacheAspectSupport extends AbstractCacheInvoker
 				AtomicBoolean invokeFailure = new AtomicBoolean(false);
 				CompletableFuture<?> result = doRetrieve(cache, key,
 						() -> {
-							CompletableFuture<?> invokeResult = ((CompletableFuture<?>) invokeOperation(invoker));
+							CompletableFuture<?> invokeResult = ((CompletableFuture<?>) unwrapReturnValue(
+									invokeOperation(invoker), method));
 							if (invokeResult == null) {
 								throw new IllegalStateException("Returned CompletableFuture must not be null: " + method);
 							}
@@ -446,7 +448,7 @@ public abstract class CacheAspectSupport extends AbstractCacheInvoker
 								return CompletableFuture.failedFuture(ex);
 							});
 						});
-				return result.exceptionallyCompose(ex -> {
+				CompletableFuture<?> resultWithErrorHandling = result.exceptionallyCompose(ex -> {
 					if (!(ex instanceof RuntimeException rex)) {
 						return CompletableFuture.failedFuture(ex);
 					}
@@ -455,12 +457,13 @@ public abstract class CacheAspectSupport extends AbstractCacheInvoker
 						if (invokeFailure.get()) {
 							return CompletableFuture.failedFuture(ex);
 						}
-						return (CompletableFuture) invokeOperation(invoker);
+						return (CompletableFuture) unwrapReturnValue(invokeOperation(invoker), method);
 					}
 					catch (Throwable ex2) {
 						return CompletableFuture.failedFuture(ex2);
 					}
 				});
+				return wrapCacheValue(method, resultWithErrorHandling);
 			}
 			if (this.reactiveCachingHandler != null) {
 				Object returnValue = this.reactiveCachingHandler.executeSynchronized(invoker, method, cache, key);
@@ -469,7 +472,7 @@ public abstract class CacheAspectSupport extends AbstractCacheInvoker
 				}
 			}
 			try {
-				return wrapCacheValue(method, doGet(cache, key, () -> unwrapReturnValue(invokeOperation(invoker))));
+				return wrapCacheValue(method, doGet(cache, key, () -> unwrapReturnValue(invokeOperation(invoker), method)));
 			}
 			catch (Cache.ValueRetrievalException ex) {
 				// Directly propagate ThrowableWrapper from the invoker,
@@ -572,7 +575,7 @@ public abstract class CacheAspectSupport extends AbstractCacheInvoker
 		else {
 			// Invoke the method if we don't have a cache hit
 			returnValue = invokeOperation(invoker);
-			cacheValue = unwrapReturnValue(returnValue);
+			cacheValue = unwrapReturnValue(returnValue, method);
 		}
 
 		// Collect puts from any @Cacheable miss, if no cached value is found
@@ -588,7 +591,8 @@ public abstract class CacheAspectSupport extends AbstractCacheInvoker
 		for (CachePutRequest cachePutRequest : cachePutRequests) {
 			Object returnOverride = cachePutRequest.apply(cacheValue);
 			if (returnOverride != null) {
-				returnValue = returnOverride;
+				returnValue = (isCompletableFutureWithOptionalReturnType(method) ?
+						wrapCacheValue(method, returnOverride) : returnOverride);
 			}
 		}
 
@@ -614,11 +618,22 @@ public abstract class CacheAspectSupport extends AbstractCacheInvoker
 				(cacheValue == null || cacheValue.getClass() != Optional.class)) {
 			return Optional.ofNullable(cacheValue);
 		}
+		if (isCompletableFutureWithOptionalReturnType(method) && cacheValue instanceof CompletableFuture<?> future) {
+			return future.thenApply(value -> Optional.ofNullable(ObjectUtils.unwrapOptional(value)));
+		}
 		return cacheValue;
 	}
 
-	private @Nullable Object unwrapReturnValue(@Nullable Object returnValue) {
+	private @Nullable Object unwrapReturnValue(@Nullable Object returnValue, Method method) {
+		if (isCompletableFutureWithOptionalReturnType(method) && returnValue instanceof CompletableFuture<?> future) {
+			return future.thenApply(ObjectUtils::unwrapOptional);
+		}
 		return ObjectUtils.unwrapOptional(returnValue);
+	}
+
+	private boolean isCompletableFutureWithOptionalReturnType(Method method) {
+		return (CompletableFuture.class.isAssignableFrom(method.getReturnType()) &&
+				ResolvableType.forMethodReturnType(method).getGeneric().resolve() == Optional.class);
 	}
 
 	private boolean hasCachePut(CacheOperationContexts contexts) {

--- a/spring-context/src/test/java/org/springframework/cache/CacheReproTests.java
+++ b/spring-context/src/test/java/org/springframework/cache/CacheReproTests.java
@@ -210,6 +210,50 @@ class CacheReproTests {
 	}
 
 	@Test
+	void spr37162AdaptsToCompletableFutureWithOptional() {
+		AnnotationConfigApplicationContext context =
+				new AnnotationConfigApplicationContext(Spr14235Config.class, Spr37162FutureOptionalService.class);
+		Spr37162FutureOptionalService bean = context.getBean(Spr37162FutureOptionalService.class);
+		Cache cache = context.getBean(CacheManager.class).getCache("itemCache");
+
+		assertThat(bean.findById("tb1").join()).contains("PREFIX-tb1");
+		assertThat(bean.getInvocationCount()).isOne();
+		assertThat(cache.get("tb1").get()).isEqualTo("PREFIX-tb1");
+		assertThat(bean.findById("tb1").join()).contains("PREFIX-tb1");
+		assertThat(bean.getInvocationCount()).isOne();
+
+		assertThat(bean.findById("").join()).isEmpty();
+		assertThat(bean.getInvocationCount()).isEqualTo(2);
+		assertThat(cache.get("").get()).isNull();
+		assertThat(bean.findById("").join()).isEmpty();
+		assertThat(bean.getInvocationCount()).isEqualTo(2);
+
+		context.close();
+	}
+
+	@Test
+	void spr37162AdaptsToCompletableFutureWithOptionalAndSync() {
+		AnnotationConfigApplicationContext context =
+				new AnnotationConfigApplicationContext(Spr14235Config.class, Spr37162FutureOptionalServiceSync.class);
+		Spr37162FutureOptionalServiceSync bean = context.getBean(Spr37162FutureOptionalServiceSync.class);
+		Cache cache = context.getBean(CacheManager.class).getCache("itemCache");
+
+		assertThat(bean.findById("tb1").join()).contains("PREFIX-tb1");
+		assertThat(bean.getInvocationCount()).isOne();
+		assertThat(cache.get("tb1").get()).isEqualTo("PREFIX-tb1");
+		assertThat(bean.findById("tb1").join()).contains("PREFIX-tb1");
+		assertThat(bean.getInvocationCount()).isOne();
+
+		assertThat(bean.findById("").join()).isEmpty();
+		assertThat(bean.getInvocationCount()).isEqualTo(2);
+		assertThat(cache.get("").get()).isNull();
+		assertThat(bean.findById("").join()).isEmpty();
+		assertThat(bean.getInvocationCount()).isEqualTo(2);
+
+		context.close();
+	}
+
+	@Test
 	void spr14235AdaptsToCompletableFutureWithSync() throws Exception {
 		AnnotationConfigApplicationContext context =
 				new AnnotationConfigApplicationContext(Spr14235Config.class, Spr14235FutureServiceSync.class);
@@ -608,6 +652,40 @@ class CacheReproTests {
 		@CacheEvict(cacheNames = "itemCache", allEntries = true, condition = "#result > 0")
 		public CompletableFuture<Integer> clear() {
 			return CompletableFuture.completedFuture(1);
+		}
+	}
+
+
+	public static class Spr37162FutureOptionalService {
+
+		private int invocationCount;
+
+		@Cacheable("itemCache")
+		public CompletableFuture<Optional<String>> findById(String id) {
+			this.invocationCount++;
+			return CompletableFuture.completedFuture(
+					(id.isEmpty() ? Optional.empty() : Optional.of("PREFIX-" + id)));
+		}
+
+		int getInvocationCount() {
+			return this.invocationCount;
+		}
+	}
+
+
+	public static class Spr37162FutureOptionalServiceSync {
+
+		private int invocationCount;
+
+		@Cacheable(value = "itemCache", sync = true)
+		public CompletableFuture<Optional<String>> findById(String id) {
+			this.invocationCount++;
+			return CompletableFuture.completedFuture(
+					(id.isEmpty() ? Optional.empty() : Optional.of("PREFIX-" + id)));
+		}
+
+		int getInvocationCount() {
+			return this.invocationCount;
 		}
 	}
 


### PR DESCRIPTION
Fixes #37162

## What does this PR do?

This change adds support for `@Cacheable` methods that return `CompletableFuture<Optional<T>>`.

The cache now stores the value inside the `Optional` (or the cache-compatible null representation for `Optional.empty()`), while callers continue to receive the declared `CompletableFuture<Optional<T>>` result on both cache misses and cache hits. The same adaptation is applied to the existing `sync = true` path.

The cache-put completion stage remains part of the returned future, so cache put failures and completion ordering retain the existing `CompletableFuture` behavior.

## Why is this change needed?

Before this change, a cached result could be returned with the wrong inner type, causing a `ClassCastException` when a `CompletableFuture<Optional<T>>` method was called again.

## How is this tested?

- Added regression coverage for present and empty `Optional` values.
- Covered regular asynchronous caching and `sync = true` caching.
- Asserted that the second call is served from the cache.
- Ran `JAVA_HOME=/opt/homebrew/opt/openjdk@25 ./gradlew :spring-context:check`.