### PR TITLE
Revise null-safety within `DateTimeFormatterRegistrar`

### DIFF
--- a/spring-context/src/main/java/org/springframework/format/datetime/standard/DateTimeFormatterRegistrar.java
+++ b/spring-context/src/main/java/org/springframework/format/datetime/standard/DateTimeFormatterRegistrar.java
@@ -43,6 +43,7 @@ import org.springframework.format.annotation.DateTimeFormat.ISO;
  *
  * @author Juergen Hoeller
  * @author Phillip Webb
+ * @author Junhwan Choi
  * @since 4.0
  * @see #setDateStyle
  * @see #setTimeStyle
@@ -51,7 +52,6 @@ import org.springframework.format.annotation.DateTimeFormat.ISO;
  * @see org.springframework.format.FormatterRegistrar#registerFormatters
  * @see org.springframework.format.datetime.DateFormatterRegistrar
  */
-@SuppressWarnings("NullAway") // Well-known map keys
 public class DateTimeFormatterRegistrar implements FormatterRegistrar {
 
 	private enum Type {DATE, TIME, DATE_TIME}
@@ -82,9 +82,9 @@ public class DateTimeFormatterRegistrar implements FormatterRegistrar {
 	 * properties are effectively ignored.
 	 */
 	public void setUseIsoFormat(boolean useIsoFormat) {
-		this.factories.get(Type.DATE).setIso(useIsoFormat ? ISO.DATE : ISO.NONE);
-		this.factories.get(Type.TIME).setIso(useIsoFormat ? ISO.TIME : ISO.NONE);
-		this.factories.get(Type.DATE_TIME).setIso(useIsoFormat ? ISO.DATE_TIME : ISO.NONE);
+		getFactory(Type.DATE).setIso(useIsoFormat ? ISO.DATE : ISO.NONE);
+		getFactory(Type.TIME).setIso(useIsoFormat ? ISO.TIME : ISO.NONE);
+		getFactory(Type.DATE_TIME).setIso(useIsoFormat ? ISO.DATE_TIME : ISO.NONE);
 	}
 
 	/**
@@ -92,7 +92,7 @@ public class DateTimeFormatterRegistrar implements FormatterRegistrar {
 	 * <p>Default is {@link java.time.format.FormatStyle#SHORT}.
 	 */
 	public void setDateStyle(FormatStyle dateStyle) {
-		this.factories.get(Type.DATE).setDateStyle(dateStyle);
+		getFactory(Type.DATE).setDateStyle(dateStyle);
 	}
 
 	/**
@@ -100,7 +100,7 @@ public class DateTimeFormatterRegistrar implements FormatterRegistrar {
 	 * <p>Default is {@link java.time.format.FormatStyle#SHORT}.
 	 */
 	public void setTimeStyle(FormatStyle timeStyle) {
-		this.factories.get(Type.TIME).setTimeStyle(timeStyle);
+		getFactory(Type.TIME).setTimeStyle(timeStyle);
 	}
 
 	/**
@@ -108,7 +108,7 @@ public class DateTimeFormatterRegistrar implements FormatterRegistrar {
 	 * <p>Default is {@link java.time.format.FormatStyle#SHORT}.
 	 */
 	public void setDateTimeStyle(FormatStyle dateTimeStyle) {
-		this.factories.get(Type.DATE_TIME).setDateTimeStyle(dateTimeStyle);
+		getFactory(Type.DATE_TIME).setDateTimeStyle(dateTimeStyle);
 	}
 
 	/**
@@ -207,7 +207,12 @@ public class DateTimeFormatterRegistrar implements FormatterRegistrar {
 			return formatter;
 		}
 		DateTimeFormatter fallbackFormatter = getFallbackFormatter(type);
-		return this.factories.get(type).createDateTimeFormatter(fallbackFormatter);
+		return getFactory(type).createDateTimeFormatter(fallbackFormatter);
+	}
+
+	@SuppressWarnings("NullAway") // Well-known map keys
+	private DateTimeFormatterFactory getFactory(Type type) {
+		return this.factories.get(type);
 	}
 
 	private DateTimeFormatter getFallbackFormatter(Type type) {


### PR DESCRIPTION
## Overview

Narrow the scope of the `@SuppressWarnings("NullAway")` annotation in `DateTimeFormatterRegistrar` from the class level to a single `getFactory(Type)` accessor.

The `factories` map is a private, final `EnumMap` that is fully populated for every `Type` in the constructor and never mutated afterward, so the suppression only needs to cover that one lookup instead of masking unrelated issues across the whole class.

## Related Issues

- #37219
- #36921