### PR TITLE
Optimize get for single-value headers in ServletResponseHeadersAdapter

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/server/ServletResponseHeadersAdapter.java
+++ b/spring-web/src/main/java/org/springframework/http/server/ServletResponseHeadersAdapter.java
@@ -131,6 +131,9 @@ class ServletResponseHeadersAdapter implements MultiValueMap<String, String> {
 				return (contentType != null ? Collections.singletonList(contentType) : null);
 			}
 			if (!values.isEmpty()) {
+				if (values.size() == 1) {
+					return Collections.singletonList(values.iterator().next());
+				}
 				return new ArrayList<>(values);
 			}
 		}

--- a/spring-web/src/test/java/org/springframework/http/server/ServletResponseHeadersAdapterTests.java
+++ b/spring-web/src/test/java/org/springframework/http/server/ServletResponseHeadersAdapterTests.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.server;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.web.testfixture.servlet.MockHttpServletResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ServletResponseHeadersAdapter}.
+ */
+class ServletResponseHeadersAdapterTests {
+
+	private final MockHttpServletResponse response = new MockHttpServletResponse();
+
+	private final ServletResponseHeadersAdapter headersAdapter = new ServletResponseHeadersAdapter(response);
+
+
+	@Test // gh-37080
+	void getWithSingleValue() {
+		response.addHeader("MyHeader", "value");
+
+		assertThat(headersAdapter.get("MyHeader")).containsExactly("value");
+	}
+
+	@Test
+	void getWithMultipleValues() {
+		response.addHeader("MyHeader", "value1");
+		response.addHeader("MyHeader", "value2");
+
+		assertThat(headersAdapter.get("MyHeader")).containsExactly("value1", "value2");
+	}
+
+	@Test
+	void getWithNonExistentHeader() {
+		assertThat(headersAdapter.get("NonExistent")).isNull();
+	}
+
+	@Test
+	void getWithContentTypeSpecialCase() {
+		response.setContentType("text/plain");
+
+		assertThat(headersAdapter.get("Content-Type")).containsExactly("text/plain");
+	}
+
+}


### PR DESCRIPTION
This change optimizes ServletResponseHeadersAdapter#get(Object) for headers with a single value.

Previously, a new ArrayList was created for every non-empty response header, including headers containing only a single value.

For single-value headers, the implementation now returns a singleton list, avoiding the unnecessary ArrayList allocation. Multi-value headers retain the existing behavior.

Tests are added for:
- single-value headers
- multiple-value headers
- non-existent headers
- Content-Type handling

Closes #37080