### PR TITLE
Use `ArrayList` instead of `LinkedList` in `CompositeRetryListener`

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/retry/support/CompositeRetryListener.java
+++ b/spring-core/src/main/java/org/springframework/core/retry/support/CompositeRetryListener.java
@@ -16,7 +16,7 @@
 
 package org.springframework.core.retry.support;
 
-import java.util.LinkedList;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.jspecify.annotations.Nullable;
@@ -42,7 +42,7 @@ import org.springframework.util.Assert;
  */
 public class CompositeRetryListener implements RetryListener {
 
-	private final List<RetryListener> listeners = new LinkedList<>();
+	private final List<RetryListener> listeners = new ArrayList<>();
 
 
 	/**


### PR DESCRIPTION
`CompositeRetryListener` currently uses `LinkedList` to store registered listeners. The primary operation on this list is iteration (traversing all listeners on every retry lifecycle event).

`ArrayList` provides better iteration performance due to better cache locality and lower memory overhead.