### PR TITLE
Fix thrown exception setup in ExceptionHandlingWebHandlerTests

### DIFF
--- a/spring-web/src/test/java/org/springframework/web/server/handler/ExceptionHandlingWebHandlerTests.java
+++ b/spring-web/src/test/java/org/springframework/web/server/handler/ExceptionHandlingWebHandlerTests.java
@@ -17,6 +17,7 @@
 package org.springframework.web.server.handler;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
@@ -79,7 +80,10 @@ class ExceptionHandlingWebHandlerTests {
 
 	@Test
 	void thrownExceptionBecomesErrorSignal() {
-		createWebHandler(new BadRequestExceptionHandler()).handle(this.exchange).block();
+		new ExceptionHandlingWebHandler(
+				new StubWebHandler(new IllegalStateException("boo"), true),
+				List.of(new BadRequestExceptionHandler())).handle(this.exchange).block();
+
 		assertThat(this.exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
 	}
 


### PR DESCRIPTION
`handleErrorSignal()` and `thrownExceptionBecomesErrorSignal()` previously had identical bodies, so both exercised the `Mono.error()` path in `StubWebHandler`.

`StubWebHandler` already had a `raise` flag to simulate a synchronously thrown exception, but no test enabled it.

Enable the flag in `thrownExceptionBecomesErrorSignal()` to cover the [catch (Throwable) block](https://github.com/spring-projects/spring-framework/blob/16edf9867a143f95cefadb7b2115dcbbf624e176/spring-web/src/main/java/org/springframework/web/server/handler/ExceptionHandlingWebHandler.java#L79-L81) in `ExceptionHandlingWebHandler`.