### PR TITLE
Sort duplicate key codes in `SQLErrorCodes`

### DIFF
--- a/spring-jdbc/src/main/java/org/springframework/jdbc/support/SQLErrorCodes.java
+++ b/spring-jdbc/src/main/java/org/springframework/jdbc/support/SQLErrorCodes.java
@@ -123,7 +123,7 @@ public class SQLErrorCodes {
 	}
 
 	public void setDuplicateKeyCodes(String... duplicateKeyCodes) {
-		this.duplicateKeyCodes = duplicateKeyCodes;
+		this.duplicateKeyCodes = StringUtils.sortStringArray(duplicateKeyCodes);
 	}
 
 	public void setDataIntegrityViolationCodes(String... dataIntegrityViolationCodes) {

--- a/spring-jdbc/src/test/java/org/springframework/jdbc/support/SQLErrorCodeSQLExceptionTranslatorTests.java
+++ b/spring-jdbc/src/test/java/org/springframework/jdbc/support/SQLErrorCodeSQLExceptionTranslatorTests.java
@@ -108,6 +108,20 @@ class SQLErrorCodeSQLExceptionTranslatorTests {
 	}
 
 	@Test
+	void duplicateKeyCodesDeclaredInUnsortedOrder() {
+		SQLErrorCodes errorCodes = new SQLErrorCodes();
+		errorCodes.setDuplicateKeyCodes("90002", "1586", "1062");
+		SQLErrorCodeSQLExceptionTranslator unsortedCodesTranslator = new SQLErrorCodeSQLExceptionTranslator(errorCodes);
+
+		for (int errorCode : new int[] {90002, 1586, 1062}) {
+			SQLException sqlException = new SQLException("", "", errorCode);
+			assertThat(unsortedCodesTranslator.translate("task", "SQL", sqlException))
+					.isInstanceOf(DuplicateKeyException.class)
+					.hasCause(sqlException);
+		}
+	}
+
+	@Test
 	void batchExceptionTranslation() {
 		SQLException badSqlEx = new SQLException("", "", 1);
 		BatchUpdateException batchUpdateEx = new BatchUpdateException();


### PR DESCRIPTION
## Overview

`SQLErrorCodes.setDuplicateKeyCodes` is the only error code setter that does not sort the supplied array, while `SQLErrorCodeSQLExceptionTranslator` looks all code arrays up with `Arrays.binarySearch`. With an unsorted custom list of duplicate key codes, translation silently succeeds or fails depending on where each value happens to sit in the array. This PR makes the setter sort the array like its nine sibling setters.

## Problem

All other code array setters in `SQLErrorCodes` store `StringUtils.sortStringArray(...)`, and `CustomSQLErrorCodesTranslation.setErrorCodes` does the same, establishing the invariant that `Arrays.binarySearch` relies on. `setDuplicateKeyCodes` stores the array as-is.

Binary search on an unsorted array is data-dependent: with `setDuplicateKeyCodes("90002", "1586", "1062")`, error code 1586 happens to be found (it sits at the first probed middle position), while 90002 and 1062 are missed because the comparison at the middle element steers the search into the wrong half. For a missed code the translator falls through: with a generic 23xxx SQLState the fallback reports a `DataIntegrityViolationException`, and without a usable SQLState the translation returns no result at all, instead of the configured `DuplicateKeyException`.

The default `sql-error-codes.xml` is unaffected because its `duplicateKeyCodes` lists are already lexicographically sorted. The mismatch surfaces for custom configurations, which nothing instructs to pre-sort - most naturally when codes of different digit lengths are listed in numeric order (for example `548, 2601, 2627`, which is unsorted as strings), or when application-specific codes are appended to a vendor list.

## Fix

`setDuplicateKeyCodes` now applies `StringUtils.sortStringArray` like all sibling setters, so lookups no longer depend on the declaration order. The new test configures a translator with an unsorted custom list and verifies that all three codes translate to `DuplicateKeyException`; before the change, two of the three lookups missed. The full `spring-jdbc` test suite passes.
