### PR TITLE
Resolve Gradle deprecation warnings for Project object as a dependency notation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 	// kotlinVersion is managed in gradle.properties
 	id 'org.jetbrains.kotlin.plugin.serialization' version "${kotlinVersion}" apply false
 	id 'org.jetbrains.dokka'
-	id 'com.github.bjornvester.xjc' version '1.8.2' apply false
+	id 'com.github.bjornvester.xjc' version '1.9.1' apply false
 	id 'com.gradleup.shadow' version "9.2.2" apply false
 	id 'me.champeau.jmh' version '0.7.2' apply false
 	id 'io.spring.nullability' version '0.0.15' apply false

--- a/buildSrc/src/main/java/org/springframework/build/KotlinConventions.java
+++ b/buildSrc/src/main/java/org/springframework/build/KotlinConventions.java
@@ -37,7 +37,8 @@ public class KotlinConventions {
 			if (project.getLayout().getProjectDirectory().dir("src/main/kotlin").getAsFile().exists()) {
 				project.getPlugins().apply(DokkaPlugin.class);
 				project.getExtensions().configure(DokkaExtension.class, dokka -> configure(project, dokka));
-				project.project(":framework-api").getDependencies().add("dokka", project);
+				project.project(":framework-api").getDependencies()
+						.add("dokka", project.getDependencyFactory().createProjectDependency());
 			}
 		});
 	}

--- a/buildSrc/src/main/java/org/springframework/build/hint/RuntimeHintsAgentPlugin.java
+++ b/buildSrc/src/main/java/org/springframework/build/hint/RuntimeHintsAgentPlugin.java
@@ -65,7 +65,8 @@ public class RuntimeHintsAgentPlugin implements Plugin<Project> {
 				test.getJvmArgumentProviders().add(createRuntimeHintsAgentArgumentProvider(project, agentExtension));
 			});
 			project.getTasks().named("check", task -> task.dependsOn(agentTest));
-			project.getDependencies().add(CONFIGURATION_NAME, project.project(":spring-core-test"));
+			project.getDependencies().add(CONFIGURATION_NAME,
+					project.getDependencyFactory().createProjectDependency(":spring-core-test"));
 		});
 	}
 

--- a/spring-oxm/spring-oxm.gradle
+++ b/spring-oxm/spring-oxm.gradle
@@ -29,9 +29,10 @@ dependencies {
 }
 
 // The XJC plugin adds generated code to the main source set, but we need it only for tests.
-// 1) Reset main source sets to the standard directories only.
-sourceSets.main.java.setSrcDirs(["src/main/java"])
-sourceSets.main.resources.setSrcDirs(["src/main/resources"])
+tasks.named("xjc", XjcTask).configure {
+	sourceSets.main.java.setSrcDirs(["src/main/java"])
+	sourceSets.main.resources.setSrcDirs(["src/main/resources"])
+}
 // 2) Attach XJC output only to the test source sets via lazy providers.
 sourceSets.test.java.srcDir(tasks.named("xjc", XjcTask).flatMap { it.outputJavaDir })
 sourceSets.test.resources.srcDir(tasks.named("xjc", XjcTask).flatMap { it.outputResourcesDir })


### PR DESCRIPTION
Currently, running the build with `--warning-mode=all` reports the following deprecation warning:

```text
> Configure project :integration-tests
Using a Project object as a dependency notation has been deprecated. This will fail with an error in Gradle 10. Please use the project(String) method on DependencyHandler or the createProjectDependency(String) method on DependencyFactory instead. Consult the upgrading guide for further information: https://docs.gradle.org/9.7.1/userguide/upgrading_version_9.html#dependency_project_notation
```

This PR updates `KotlinConventions` and `RuntimeHintsAgentPlugin` to create explicit project dependencies with `DependencyFactory#createProjectDependency(...)`.

Reference: https://docs.gradle.org/9.7.1/userguide/upgrading_version_9.html#dependency_project_notation