### PR TITLE
 Release the body of an unconsumed `ReactorClientHttpResponse` once it becomes unreachable

### DIFF
--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpConnector.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpConnector.java
@@ -48,6 +48,7 @@ import org.springframework.util.Assert;
  * @author Rossen Stoyanchev
  * @author Sebastien Deleuze
  * @author Juergen Hoeller
+ * @author Seungbin Ko
  * @since 5.0
  * @see reactor.netty.http.client.HttpClient
  */
@@ -175,7 +176,7 @@ public class ReactorClientHttpConnector implements ClientHttpConnector, SmartLif
 				.doOnCancel(() -> {
 					ReactorClientHttpResponse response = responseRef.get();
 					if (response != null) {
-						response.releaseAfterCancel(method);
+						response.releaseAfterCancel();
 					}
 				});
 	}

--- a/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpResponse.java
+++ b/spring-web/src/main/java/org/springframework/http/client/reactive/ReactorClientHttpResponse.java
@@ -16,6 +16,7 @@
 
 package org.springframework.http.client.reactive;
 
+import java.lang.ref.Cleaner;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
@@ -48,12 +49,15 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Brian Clozel
  * @author Rossen Stoyanchev
+ * @author Seungbin Ko
  * @since 5.0
  * @see reactor.netty.http.client.HttpClient
  */
 class ReactorClientHttpResponse implements ClientHttpResponse {
 
 	private static final Log logger = LogFactory.getLog(ReactorClientHttpResponse.class);
+
+	private static final Cleaner cleaner = Cleaner.create();
 
 	private final HttpClientResponse response;
 
@@ -63,8 +67,10 @@ class ReactorClientHttpResponse implements ClientHttpResponse {
 
 	private final NettyDataBufferFactory bufferFactory;
 
-	// 0 - not subscribed, 1 - subscribed, 2 - cancelled via connector (before subscribe)
+	// 0 - not subscribed, 1 - subscribed, 2 - released before subscribe (cancelled or unreachable)
 	private final AtomicInteger state = new AtomicInteger();
+
+	private final Cleaner.@Nullable Cleanable cleanable;
 
 
 	/**
@@ -78,6 +84,8 @@ class ReactorClientHttpResponse implements ClientHttpResponse {
 		this.headers = HttpHeaders.readOnlyHttpHeaders(adapter);
 		this.inbound = connection.inbound();
 		this.bufferFactory = new NettyDataBufferFactory(connection.outbound().alloc());
+		this.cleanable = (mayHaveBody() ?
+				cleaner.register(this, new BodyReleaser(connection, this.state)) : null);
 	}
 
 
@@ -98,6 +106,9 @@ class ReactorClientHttpResponse implements ClientHttpResponse {
 		return this.inbound.receive()
 				.doOnSubscribe(s -> {
 					if (this.state.compareAndSet(0, 1)) {
+						if (this.cleanable != null) {
+							this.cleanable.clean();
+						}
 						return;
 					}
 					if (this.state.get() == 2) {
@@ -160,19 +171,24 @@ class ReactorClientHttpResponse implements ClientHttpResponse {
 	 * materialize if the cancellation happened very early, or the response
 	 * reading was delayed for some reason.
 	 */
-	void releaseAfterCancel(HttpMethod method) {
-		if (mayHaveBody(method) && this.state.compareAndSet(0, 2)) {
+	void releaseAfterCancel() {
+		if (mayHaveBody() && this.state.compareAndSet(0, 2)) {
 			if (logger.isDebugEnabled()) {
 				logger.debug("[" + getId() + "]" + "Releasing body, not yet subscribed.");
 			}
-			this.inbound.receive().doOnNext(byteBuf -> {}).subscribe(byteBuf -> {}, ex -> {});
+			drain(this.inbound);
 		}
 	}
 
-	private boolean mayHaveBody(HttpMethod method) {
+	private boolean mayHaveBody() {
 		int code = getStatusCode().value();
 		return !((code >= 100 && code < 200) || code == 204 || code == 205 ||
-				method.equals(HttpMethod.HEAD) || getHeaders().getContentLength() == 0);
+				HttpMethod.HEAD.name().equals(this.response.method().name()) ||
+				getHeaders().getContentLength() == 0);
+	}
+
+	private static void drain(NettyInbound inbound) {
+		inbound.receive().doOnNext(byteBuf -> {}).subscribe(byteBuf -> {}, ex -> {});
 	}
 
 	@Override
@@ -180,6 +196,39 @@ class ReactorClientHttpResponse implements ClientHttpResponse {
 		return "ReactorClientHttpResponse{" +
 				"request=[" + this.response.method().name() + " " + this.response.uri() + "]," +
 				"status=" + getStatusCode() + '}';
+	}
+
+
+	/**
+	 * Registered with a {@link Cleaner} for the case where the response is
+	 * dropped after it was emitted, without the content having been subscribed
+	 * to, e.g. by {@code Mono.zip} when it is cancelled after one of its sources
+	 * has emitted. There is no cancel signal to react to in that case, and
+	 * Reactor Netty does not drain the content when the connection is closed,
+	 * so the content is drained once the response becomes unreachable.
+	 * Must not reference the response.
+	 */
+	private static final class BodyReleaser implements Runnable {
+
+		private final Connection connection;
+
+		private final AtomicInteger state;
+
+		BodyReleaser(Connection connection, AtomicInteger state) {
+			this.connection = connection;
+			this.state = state;
+		}
+
+		@Override
+		public void run() {
+			if (this.state.compareAndSet(0, 2)) {
+				if (logger.isDebugEnabled()) {
+					logger.debug("[" + this.connection.channel().id().asShortText() + "]" +
+							"Releasing body, never subscribed.");
+				}
+				drain(this.connection.inbound());
+			}
+		}
 	}
 
 }

--- a/spring-web/src/test/java/org/springframework/http/client/reactive/ReactorClientHttpResponseReleaseTests.java
+++ b/spring-web/src/test/java/org/springframework/http/client/reactive/ReactorClientHttpResponseReleaseTests.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2002-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.http.client.reactive;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.function.LongSupplier;
+import java.util.stream.Stream;
+
+import io.netty.buffer.PoolArenaMetric;
+import io.netty.buffer.PooledByteBufAllocator;
+import io.netty.buffer.PooledByteBufAllocatorMetric;
+import io.netty.channel.ChannelOption;
+import mockwebserver3.MockResponse;
+import mockwebserver3.MockWebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import reactor.core.publisher.Mono;
+import reactor.core.publisher.Sinks;
+import reactor.test.StepVerifier;
+
+import org.springframework.core.io.buffer.DataBufferUtils;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ReactiveHttpOutputMessage;
+import org.springframework.http.client.ReactorResourceFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+/**
+ * Tests for the release of unconsumed content by {@link ReactorClientHttpResponse}.
+ *
+ * @author Seungbin Ko
+ * @since 7.1
+ */
+@TestInstance(PER_CLASS)
+class ReactorClientHttpResponseReleaseTests {
+
+	private static final Duration TIMEOUT = Duration.ofSeconds(3);
+
+	private final ReactorResourceFactory factory = new ReactorResourceFactory();
+
+	private MockWebServer server;
+
+	private PooledByteBufAllocator allocator;
+
+	private ReactorClientHttpConnector connector;
+
+
+	@BeforeAll
+	void setUpReactorResourceFactory() {
+		this.factory.setShutdownQuietPeriod(Duration.ofMillis(100));
+		this.factory.afterPropertiesSet();
+	}
+
+	@AfterAll
+	void destroyReactorResourceFactory() {
+		this.factory.destroy();
+	}
+
+	@AfterEach
+	void stopServer() {
+		if (this.server != null) {
+			this.server.close();
+		}
+	}
+
+	private void setUp(boolean preferDirect, boolean followRedirect) throws IOException {
+		this.server = new MockWebServer();
+		this.server.start();
+		this.allocator = new PooledByteBufAllocator(preferDirect, 1, 1, 4096, 4, 0, 0, true);
+		this.connector = new ReactorClientHttpConnector(this.factory, client ->
+				client.option(ChannelOption.ALLOCATOR, this.allocator).followRedirect(followRedirect));
+	}
+
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void bodyConsumed(boolean preferDirect) throws Exception {
+		setUp(preferDirect, false);
+		this.server.enqueue(new MockResponse.Builder().code(200).body("{\"foo\":\"bar\"}").build());
+
+		StepVerifier.create(connect(HttpMethod.GET)
+						.flatMapMany(ClientHttpResponse::getBody)
+						.map(DataBufferUtils::release))
+				.expectNextCount(1)
+				.expectComplete()
+				.verify(TIMEOUT);
+
+		awaitBodyRelease();
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void cancelBeforeBodySubscribed(boolean preferDirect) throws Exception {
+		setUp(preferDirect, false);
+		this.server.enqueue(new MockResponse.Builder().code(200).body("{\"foo\":\"bar\"}").build());
+
+		Sinks.Empty<Void> responseReceived = Sinks.empty();
+		StepVerifier.create(connect(HttpMethod.GET)
+						.doFinally(signal -> responseReceived.tryEmitEmpty())
+						.flatMap(response -> Mono.never())
+						.takeUntilOther(responseReceived.asMono()))
+				.expectComplete()
+				.verify(TIMEOUT);
+
+		awaitBodyRelease();
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void responseDroppedWithoutSubscribingBody(boolean preferDirect) throws Exception {
+		setUp(preferDirect, false);
+		this.server.enqueue(new MockResponse.Builder().code(200).body("{\"foo\":\"bar\"}").build());
+
+		StepVerifier.create(connect(HttpMethod.GET).map(ClientHttpResponse::getStatusCode))
+				.expectNextCount(1)
+				.expectComplete()
+				.verify(TIMEOUT);
+
+		awaitBodyRelease();
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void responseDiscardedByCancelAfterEmission(boolean preferDirect) throws Exception {
+		setUp(preferDirect, false);
+		this.server.enqueue(new MockResponse.Builder().code(200).body("{\"foo\":\"bar\"}").build());
+
+		Sinks.Empty<Void> responseEmitted = Sinks.empty();
+		StepVerifier.create(Mono.zip(
+								connect(HttpMethod.GET)
+										.doFinally(signal -> responseEmitted.tryEmitEmpty()),
+								Mono.never())
+						.takeUntilOther(responseEmitted.asMono()))
+				.expectComplete()
+				.verify(TIMEOUT);
+
+		awaitBodyRelease();
+	}
+
+	@ParameterizedTest
+	@ValueSource(booleans = {true, false})
+	void headRedirectedToGetResponseDroppedWithoutSubscribingBody(boolean preferDirect) throws Exception {
+		setUp(preferDirect, true);
+		this.server.enqueue(new MockResponse.Builder().code(303)
+				.setHeader("Location", this.server.url("/target").toString()).build());
+		this.server.enqueue(new MockResponse.Builder().code(200).body("{\"foo\":\"bar\"}").build());
+
+		StepVerifier.create(connect(HttpMethod.HEAD).map(ClientHttpResponse::getStatusCode))
+				.expectNextCount(1)
+				.expectComplete()
+				.verify(TIMEOUT);
+
+		awaitBodyRelease();
+	}
+
+
+	private Mono<ClientHttpResponse> connect(HttpMethod method) {
+		return this.connector.connect(method, this.server.url("/").uri(),
+				ReactiveHttpOutputMessage::setComplete);
+	}
+
+	private void awaitBodyRelease() throws InterruptedException {
+		PooledByteBufAllocatorMetric metric = this.allocator.metric();
+		LongSupplier activeAllocations = () ->
+				Stream.concat(metric.directArenas().stream(), metric.heapArenas().stream())
+						.mapToLong(PoolArenaMetric::numActiveAllocations).sum();
+		Instant deadline = Instant.now().plus(TIMEOUT);
+		while (activeAllocations.getAsLong() > 0 && Instant.now().isBefore(deadline)) {
+			System.gc();
+			Thread.sleep(50);
+		}
+		assertThat(activeAllocations.getAsLong()).as("ByteBuf Leak: unreleased allocations").isZero();
+	}
+
+}


### PR DESCRIPTION
## Motivation

`ReactorClientHttpConnector.connect()` emits a `ClientHttpResponse` before the body is read.
If the response is dropped without subscribing to `getBody()`, the buffered content stays in the Reactor Netty inbound queue.
The connector releases the body only on `doOnCancel`, but a cancel signal does not always arrive.
For example `Mono.zip` marks a source as cancelled once it has emitted, so a later cancel is not propagated upstream and the emitted response is discarded instead.
Reactor Netty does not release the queued content when the connection is closed either.

We receives many client cancellations (HTTP 499). When a request is cancelled after the upstream response was already emitted but before its body was read, the leak reproduces. In production it appears as:

```
LEAK: ByteBuf.release() was not called before it's garbage-collected.
  Hint: [..., R:upstream:80] Buffered ByteBufHolder in the inbound buffer queue
  reactor.netty.channel.FluxReceive.onInboundNext(FluxReceive.java:397)
```

Reproduce: call `connector.connect(...)` against a local server, then drop the response without reading the body, or cancel a `Mono.zip` after the response was emitted. `PooledByteBufAllocator` metrics show one allocation that stays active.

> The body cannot be released on a timer or on connection close because a late subscriber is still valid at that point.
> It can only be released once nobody can subscribe anymore, that is when the response object is unreachable.

## Key changed

* Register `ReactorClientHttpResponse` with a `java.lang.ref.Cleaner` when the response may have a body.
* When the response becomes unreachable with the body still not subscribed, drain the inbound and release the buffers.
* Deregister as soon as `getBody()` is subscribed, so normal responses add no work for the GC.
* `mayHaveBody()` now uses the request method from the Reactor Netty response, so a `HEAD` redirected to `GET` is handled by the final method.
* Add `ReactorClientHttpResponseReleaseTests` (consumed, cancelled before subscribe, dropped, cancelled after emission, HEAD redirected to GET).

No behavior change for responses whose body is subscribed or cancelled before emission.