### PR TITLE
Avoid invoking Task.project at execution time in ShadowSource

### DIFF
--- a/buildSrc/src/main/java/org/springframework/build/shadow/ShadowSource.java
+++ b/buildSrc/src/main/java/org/springframework/build/shadow/ShadowSource.java
@@ -18,30 +18,31 @@ package org.springframework.build.shadow;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Set;
+
+import javax.inject.Inject;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.component.ModuleComponentSelector;
-import org.gradle.api.artifacts.query.ArtifactResolutionQuery;
-import org.gradle.api.artifacts.result.ArtifactResolutionResult;
-import org.gradle.api.artifacts.result.ComponentArtifactsResult;
-import org.gradle.api.artifacts.result.DependencyResult;
-import org.gradle.api.artifacts.result.ResolutionResult;
-import org.gradle.api.artifacts.result.ResolvedArtifactResult;
+import org.gradle.api.attributes.Bundling;
+import org.gradle.api.attributes.Category;
+import org.gradle.api.attributes.DocsType;
+import org.gradle.api.attributes.Usage;
+import org.gradle.api.file.ArchiveOperations;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileCopyDetails;
+import org.gradle.api.file.FileSystemOperations;
 import org.gradle.api.file.FileTree;
-import org.gradle.api.tasks.Classpath;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Nested;
-import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.jvm.JvmLibrary;
-import org.gradle.language.base.artifact.SourcesArtifact;
 
 /**
  * Gradle task to add source from shadowed jars into our own source jars.
@@ -49,23 +50,44 @@ import org.gradle.language.base.artifact.SourcesArtifact;
  * @author Phillip Webb
  * @author Andy Wilkinson
  */
-public class ShadowSource extends DefaultTask {
-
-	private final DirectoryProperty outputDirectory = getProject().getObjects().directoryProperty();
-
-	private List<Configuration> configurations = new ArrayList<>();
+public abstract class ShadowSource extends DefaultTask {
 
 	private final List<Relocation> relocations = new ArrayList<>();
 
 
-	@Classpath
-	@Optional
-	public List<Configuration> getConfigurations() {
-		return this.configurations;
-	}
+	@InputFiles
+	@PathSensitive(PathSensitivity.NONE)
+	public abstract ConfigurableFileCollection getSourceJars();
+
+	@OutputDirectory
+	public abstract DirectoryProperty getOutputDirectory();
+
+	@Inject
+	protected abstract FileSystemOperations getFileSystemOperations();
+
+	@Inject
+	protected abstract ArchiveOperations getArchiveOperations();
+
+	@Inject
+	protected abstract ObjectFactory getObjectFactory();
 
 	public void setConfigurations(List<Configuration> configurations) {
-		this.configurations = configurations;
+		for (Configuration configuration : configurations) {
+			getSourceJars().from(resolveSourceArtifacts(configuration));
+		}
+	}
+
+	private FileCollection resolveSourceArtifacts(Configuration configuration) {
+		ObjectFactory objects = getObjectFactory();
+		return configuration.getIncoming().artifactView(view -> {
+			view.withVariantReselection();
+			view.attributes(attributes -> {
+				attributes.attribute(Usage.USAGE_ATTRIBUTE, objects.named(Usage.class, Usage.JAVA_RUNTIME));
+				attributes.attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.class, Category.DOCUMENTATION));
+				attributes.attribute(Bundling.BUNDLING_ATTRIBUTE, objects.named(Bundling.class, Bundling.EXTERNAL));
+				attributes.attribute(DocsType.DOCS_TYPE_ATTRIBUTE, objects.named(DocsType.class, DocsType.SOURCES));
+			});
+		}).getFiles();
 	}
 
 	@Nested
@@ -77,52 +99,15 @@ public class ShadowSource extends DefaultTask {
 		this.relocations.add(new Relocation(pattern, destination));
 	}
 
-	@OutputDirectory
-	public DirectoryProperty getOutputDirectory() {
-		return this.outputDirectory;
-	}
-
 	@TaskAction
 	void syncSourceJarFiles() {
-		sync(getSourceJarFiles());
-	}
-
-	private List<File> getSourceJarFiles() {
-		List<File> sourceJarFiles = new ArrayList<>();
-		for (Configuration configuration : this.configurations) {
-			ResolutionResult resolutionResult = configuration.getIncoming().getResolutionResult();
-			resolutionResult.getRootComponent().get().getDependencies().forEach(dependency -> {
-				Set<ComponentArtifactsResult> artifactsResults = resolveSourceArtifacts(dependency);
-				for (ComponentArtifactsResult artifactResult : artifactsResults) {
-					artifactResult.getArtifacts(SourcesArtifact.class).forEach(sourceArtifact -> {
-						sourceJarFiles.add(((ResolvedArtifactResult) sourceArtifact).getFile());
-					});
-				}
-			});
-		}
-		return Collections.unmodifiableList(sourceJarFiles);
-	}
-
-	private Set<ComponentArtifactsResult> resolveSourceArtifacts(DependencyResult dependency) {
-		ModuleComponentSelector componentSelector = (ModuleComponentSelector) dependency.getRequested();
-		ArtifactResolutionQuery query = getProject().getDependencies().createArtifactResolutionQuery()
-				.forModule(componentSelector.getGroup(), componentSelector.getModule(), componentSelector.getVersion());
-		return executeQuery(query).getResolvedComponents();
-	}
-
-	@SuppressWarnings("unchecked")
-	private ArtifactResolutionResult executeQuery(ArtifactResolutionQuery query) {
-		return query.withArtifacts(JvmLibrary.class, SourcesArtifact.class).execute();
-	}
-
-	private void sync(List<File> sourceJarFiles) {
-		getProject().sync(spec -> {
-			spec.into(this.outputDirectory);
+		getFileSystemOperations().sync(spec -> {
+			spec.into(getOutputDirectory());
 			spec.eachFile(this::relocateFile);
 			spec.filter(this::transformContent);
 			spec.exclude("META-INF/**");
 			spec.setIncludeEmptyDirs(false);
-			sourceJarFiles.forEach(sourceJar -> spec.from(zipTree(sourceJar)));
+			getSourceJars().forEach(sourceJar -> spec.from(zipTree(sourceJar)));
 		});
 	}
 
@@ -142,7 +127,7 @@ public class ShadowSource extends DefaultTask {
 	}
 
 	private FileTree zipTree(File sourceJar) {
-		return getProject().zipTree(sourceJar);
+		return getArchiveOperations().zipTree(sourceJar);
 	}
 
 

--- a/spring-core/spring-core.gradle
+++ b/spring-core/spring-core.gradle
@@ -71,8 +71,8 @@ tasks.register('objenesisSourceJar', Jar) {
 }
 
 dependencies {
-	javapoet("com.palantir.javapoet:javapoet:${javapoetVersion}@jar")
-	objenesis("org.objenesis:objenesis:${objenesisVersion}@jar")
+	javapoet("com.palantir.javapoet:javapoet:${javapoetVersion}") { transitive = false }
+	objenesis("org.objenesis:objenesis:${objenesisVersion}") { transitive = false }
 	api(files(javapoetRepackJar))
 	api(files(objenesisRepackJar))
 	api("commons-logging:commons-logging")


### PR DESCRIPTION
Currently, running the build with `--warning-mode=all` reports the following deprecation warning:
```
$ ./gradlew clean build --warning-mode all

> Task :spring-core:javapoetSource
Invocation of Task.project at execution time has been deprecated. This will fail with an error in Gradle 10. This API is incompatible with the configuration cache, which will become the only mode supported by Gradle in a future release. Consult the upgrading guide for further information: https://docs.gradle.org/9.7.1/userguide/upgrading_version_7.html#task_project
```

`ShadowSource` currently invokes `Task.project` at execution time — to run an `ArtifactResolutionQuery` for source artifacts, and to call `Project.sync()` and `Project.zipTree()`. Gradle deprecates this and will reject it in Gradle 10.

This PR injects `FileSystemOperations` and `ArchiveOperations` in place of `Project`, and replaces the `List<Configuration>` input with a `ConfigurableFileCollection` populated at configuration time from an `ArtifactView` that reselects the `sources` variant. That also removes the last task state that could not be serialized into the configuration cache.

Reselecting the variant requires module metadata, so `javapoet` and `objenesis` in spring-core now use `transitive = false` instead of the `@jar` artifact-only notation, which skips metadata entirely. The artifacts resolved for the repack jars are unchanged.

However, `ArtifactView.ViewConfiguration#withVariantReselection()` is still `@Incubating` in Gradle 9.7.1 and has no stable equivalent.

Reference: https://docs.gradle.org/9.7.1/userguide/upgrading_version_7.html#task_project