### PR TITLE
Complete empty Uni instances from the Mutiny reactive adapter

### DIFF
--- a/spring-core/src/main/java/org/springframework/core/ReactiveAdapterRegistry.java
+++ b/spring-core/src/main/java/org/springframework/core/ReactiveAdapterRegistry.java
@@ -375,7 +375,7 @@ public class ReactiveAdapterRegistry {
 		void registerAdapters(ReactiveAdapterRegistry registry) {
 			ReactiveTypeDescriptor uniDesc = ReactiveTypeDescriptor.singleOptionalValue(
 					io.smallrye.mutiny.Uni.class,
-					() -> io.smallrye.mutiny.Uni.createFrom().nothing());
+					() -> io.smallrye.mutiny.Uni.createFrom().nullItem());
 			ReactiveTypeDescriptor multiDesc = ReactiveTypeDescriptor.multiValue(
 					io.smallrye.mutiny.Multi.class,
 					() -> io.smallrye.mutiny.Multi.createFrom().empty());

--- a/spring-core/src/test/java/org/springframework/core/ReactiveAdapterRegistryTests.java
+++ b/spring-core/src/test/java/org/springframework/core/ReactiveAdapterRegistryTests.java
@@ -301,6 +301,20 @@ class ReactiveAdapterRegistryTests {
 		}
 
 		@Test
+		void fromNullValue() {
+			Object target = getAdapter(Uni.class).toPublisher(null);
+			assertThat(target).isInstanceOf(Mono.class);
+			assertThat(((Mono<Integer>) target).block(FIVE_SECONDS)).isNull();
+		}
+
+		@Test
+		void toUniFromEmptyPublisher() {
+			Object target = getAdapter(Uni.class).fromPublisher(Mono.empty());
+			assertThat(target).isInstanceOf(Uni.class);
+			assertThat(((Uni<Integer>) target).await().atMost(FIVE_SECONDS)).isNull();
+		}
+
+		@Test
 		void toMulti() {
 			List<Integer> sequence = Arrays.asList(1, 2, 3);
 			Publisher<Integer> source = Flux.fromIterable(sequence);


### PR DESCRIPTION
## Overview

The Mutiny `Uni` adapter in `ReactiveAdapterRegistry` supplies `Uni.createFrom().nothing()` as its empty value. That `Uni` never signals, so everywhere the framework adapts a `null` source - most visibly a WebFlux handler method declared to return `Uni<T>` that returns `null` - the resulting `Publisher` never completes and the request hangs, while the same handler declared with `Mono<T>` completes empty. This PR changes the supplier to `Uni.createFrom().nullItem()`.

## Problem

`ReactiveAdapter.toPublisher(Object)` substitutes `getDescriptor().getEmptyValue()` when the source is `null`. The `Uni` descriptor is registered with `ReactiveTypeDescriptor.singleOptionalValue`, which declares that the type supports an empty value, but the supplied empty value is `Uni.createFrom().nothing()` - a `Uni` that never emits an item, a failure, or completion. Adapting it produces a `Publisher` that never signals, so a blocking or subscribing consumer waits until its own timeout.

All sibling registrations supply an empty value that completes immediately: `Mono::empty`, `Maybe::empty`, `Completable::complete`, `CompletableDeferred(null)`, and the `Multi` registration itself uses `Multi.createFrom().empty()`. The `Uni` registration is also asymmetric with its own `fromPublisher` function: adapting an empty `Publisher` produces a `Uni` that completes with a `null` item, but the registered empty value cannot make the trip back.

## Fix

The empty-value supplier now uses `Uni.createFrom().nullItem()`. Mutiny converts a `Uni` with a `null` item to a `Publisher` that completes without emitting an item (Reactive Streams forbids `onNext(null)`), which matches the sibling adapters and makes the round trip through `fromPublisher` symmetric. The descriptor instance is shared by the Mutiny 1 and Mutiny 2 registrations, so both are covered.

Two tests are added: adapting a `null` source completes empty within a timeout (previously it hung), and adapting an empty `Publisher` to `Uni` yields a `null` item, pinning the round-trip contract. The full `spring-core` test suite passes.
