### PR TITLE
Use a LinkedHashSet when merging parent bean names

### DIFF
--- a/spring-beans/src/main/java/org/springframework/beans/factory/BeanFactoryUtils.java
+++ b/spring-beans/src/main/java/org/springframework/beans/factory/BeanFactoryUtils.java
@@ -17,11 +17,10 @@
 package org.springframework.beans.factory;
 
 import java.lang.annotation.Annotation;
-import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.jspecify.annotations.Nullable;
@@ -29,6 +28,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.beans.BeansException;
 import org.springframework.core.ResolvableType;
 import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
@@ -522,8 +522,8 @@ public abstract class BeanFactoryUtils {
 		if (parentResult.length == 0) {
 			return result;
 		}
-		List<String> merged = new ArrayList<>(result.length + parentResult.length);
-		merged.addAll(Arrays.asList(result));
+		Set<String> merged = CollectionUtils.newLinkedHashSet(result.length + parentResult.length);
+		Collections.addAll(merged, result);
 		for (String beanName : parentResult) {
 			if (!merged.contains(beanName) && !hbf.containsLocalBean(beanName)) {
 				merged.add(beanName);


### PR DESCRIPTION
`BeanFactoryUtils.mergeNamesWithParent` builds its result in an `ArrayList` and calls `contains` on it for every name returned by the parent factory. A call that finds no match walks the whole list, so merging m parent names into n local names is `O(n*m + m^2)` string comparisons.

The list is only ever used as an ordered set: names are appended, never read by index, and `contains` only rejects duplicates. `beansOfTypeIncludingAncestors` in the same class already applies the same shadowing rule with a `LinkedHashMap`. Declaring `merged` as a `LinkedHashSet` does the same thing here and makes the membership check a hash lookup.

Only the declaration and the copy that follows it change; `StringUtils.toStringArray` already has a `Collection<String>` overload. It has to be a `LinkedHashSet` rather than a plain `HashSet`: with a `HashSet`, `AutowiredAnnotationBeanPostProcessorTests.objectProviderInjectionWithNonCandidatesInStream` fails.

One behavior change is worth flagging. If a `ListableBeanFactory` returns the same name twice, the old code keeps both entries and the new code keeps only the first. `DefaultListableBeanFactory` cannot return a duplicate — `beanDefinitionNames` and `manualSingletonNames` are kept disjoint, aliases are skipped, and the `FactoryBean` branch rewrites a name rather than adding one — and `StaticListableBeanFactory` iterates a `LinkedHashMap`. If duplicates from a custom implementation should be preserved, I can leave the `ArrayList` in place and add a `HashSet` alongside it for the membership check. The method is only called when the factory has a parent `ListableBeanFactory`, so nothing changes for a context without one.

I ran the same harness against `main` and this branch, covering aliases, `FactoryBean` `&` names, manually registered singletons and shadowed names. Every returned array matched, in the same order. `spring-beans`, `spring-context` and `spring-aop` all pass `check` on JDK 25.
